### PR TITLE
Add Ruby dependency to ign-math

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -458,6 +458,8 @@ fi
 #
 
 IGN_MATH_DEPENDENCIES="libeigen3-dev \\
+                       ruby-dev \\
+                       swig \\
                        libignition-cmake-dev \\
                        libignition-cmake1-dev"
 if [[ ${DISTRO} != 'xenial' ]]; then


### PR DESCRIPTION
On BitBucket pipelines, we installed ruby and swig as `ign-math` dependencies to make sure ruby tests were running. It may take a while until we have GitHub actions, so I propose we run these tests on Jenkins.

Test build: [![Build Status](https://build.osrfoundation.org/job/ignition_math-ci-pr_any-ubuntu_auto-amd64/243/badge/icon)](https://build.osrfoundation.org/job/ignition_math-ci-pr_any-ubuntu_auto-amd64/243/)