### PR TITLE
Remove Bitbucket release from debbuild scripts

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -69,11 +69,7 @@ fi
 
 # Step 4: add debian/ subdirectory with necessary metadata files to unpacked source tarball
 rm -rf /tmp/$PACKAGE-release
-if ${GITHUB_RELEASE}; then
-  git clone https://github.com/ignition-release/$PACKAGE-release -b $RELEASE_REPO_BRANCH /tmp/$PACKAGE-release
-else
-  hg clone https://bitbucket.org/${BITBUCKET_REPO}/$PACKAGE-release -b $RELEASE_REPO_BRANCH /tmp/$PACKAGE-release
-fi
+git clone https://github.com/ignition-release/$PACKAGE-release -b $RELEASE_REPO_BRANCH /tmp/$PACKAGE-release
 cd /tmp/$PACKAGE-release
 # In nightly get the default latest version from default changelog
 if $NIGHTLY_MODE; then
@@ -99,13 +95,8 @@ fi
 case \${BUILD_METHOD} in
     "OVERWRITE_BASE")
 	# 1. Clone the base branch
-        if ${GITHUB_RELEASE}; then
-          checkout_cmd="git clone https://github.com/ignition-release/$PACKAGE-release"
-        else
-          checkout_cmd="hg clone https://bitbucket.org/${BITBUCKET_REPO}/$PACKAGE-release"
-        fi
-        \$checkout_cmd \\
-	    -b \${RELEASE_BASE_BRANCH} \\
+        git clone https://github.com/ignition-release/$PACKAGE-release \\
+           -b \${RELEASE_BASE_BRANCH} \\
 	    /tmp/base_$PACKAGE-release
 	# 2. Overwrite the information
 	if [[ -d ${DISTRO} ]]; then

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -95,8 +95,8 @@ fi
 case \${BUILD_METHOD} in
     "OVERWRITE_BASE")
 	# 1. Clone the base branch
-        git clone https://github.com/ignition-release/$PACKAGE-release \\
-           -b \${RELEASE_BASE_BRANCH} \\
+        git clone https://github.com/ignition-release/\${PACKAGE}-release \\
+            -b \${RELEASE_BASE_BRANCH} \\
 	    /tmp/base_$PACKAGE-release
 	# 2. Overwrite the information
 	if [[ -d ${DISTRO} ]]; then

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
@@ -69,9 +69,6 @@ class OSRFLinuxBuildPkg
         stringParam("OSRF_REPOS_TO_USE",
                     default_params.find{ it.key == "OSRF_REPOS_TO_USE"}?.value,
                     "OSRF repos name to use when building the package")
-        booleanParam('GITHUB_RELEASE',
-                    false,
-                    '-release repo is in github instead of bitbucket')
         labelParam('JENKINS_NODE_TAG') {
           description('Jenkins node or group to run build')
           defaultValue('docker')

--- a/jenkins-scripts/dsl/ros1_ign_bridge.dsl
+++ b/jenkins-scripts/dsl/ros1_ign_bridge.dsl
@@ -34,7 +34,7 @@ bridge_packages.each { pkg ->
         stringParam("ARCH", "amd64", "Architecture to build packages for")
         stringParam('ROS_DISTRO', 'kinetic','ROS DISTRO to build pakcages for')
         stringParam("UPLOAD_TO_REPO", 'stable', "OSRF repo name to upload the package to")
-        stringParam('UPSTREAM_RELEASE_REPO', 'https://bitbucket.org/osrf/bridge-release', 'Release repository url')
+        stringParam('UPSTREAM_RELEASE_REPO', 'https://github.com/ignition-release/ros1_ign_bridge-release', 'Release repository url')
     }
 
     steps {

--- a/jenkins-scripts/lib/debbuild-base.bash
+++ b/jenkins-scripts/lib/debbuild-base.bash
@@ -43,7 +43,7 @@ sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu $DISTRO main" >
 wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 apt-get update
 
-# Hack to avoid problem with non updated 
+# Hack to avoid problem with non updated
 if [ $DISTRO = 'precise' ]; then
   echo "Skipping pbuilder check for outdated info"
   sed -i -e 's:UbuntuDistroInfo().devel():self.target_distro:g' /usr/bin/pbuilder-dist
@@ -92,7 +92,7 @@ fi
 
 # Step 4: add debian/ subdirectory with necessary metadata files to unpacked source tarball
 rm -rf /tmp/$PACKAGE-release
-hg clone https://bitbucket.org/${BITBUCKET_REPO}/$PACKAGE-release /tmp/$PACKAGE-release 
+git clone https://github.com/ignition-release/$PACKAGE-release /tmp/$PACKAGE-release
 cd /tmp/$PACKAGE-release
 # In nightly get the default latest version from default changelog
 if $NIGHTLY_MODE; then
@@ -123,7 +123,7 @@ if $NIGHTLY_MODE; then
   # TODO: Fix CMakeLists.txt ?
 fi
 
-# Get into the unpacked source directory, without explicit knowledge of that 
+# Get into the unpacked source directory, without explicit knowledge of that
 # directory's name
 cd \`find $WORKSPACE/build -mindepth 1 -type d |head -n 1\`
 # If use the quilt 3.0 format for debian (drcsim) it needs a tar.gz with sources
@@ -132,8 +132,8 @@ if $NIGHTLY_MODE; then
   echo | dh_make -s --createorig -p ${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}~hg\${TIMESTAMP}r\${REV} > /dev/null
 fi
 
-# Adding extra directories to code. debian has no problem but some extra directories 
-# handled by symlinks (like cmake) in the repository can not be copied directly. 
+# Adding extra directories to code. debian has no problem but some extra directories
+# handled by symlinks (like cmake) in the repository can not be copied directly.
 # Need special care to copy, using first a --dereference
 cp -a --dereference /tmp/$PACKAGE-release/${RELEASE_REPO_DIRECTORY}/* .
 
@@ -148,7 +148,7 @@ cat > \$PBUILD_DIR/A10_run_rosdep << DELIM_ROS_DEP
 #!/bin/sh
 if [ -f /usr/bin/rosdep ]; then
   # root share the same /tmp/buildd HOME than pbuilder user. Need to specify the root
-  # HOME=/root otherwise it will make cache created during ros call forbidden to 
+  # HOME=/root otherwise it will make cache created during ros call forbidden to
   # access to pbuilder user.
   HOME=/root rosdep init
 fi
@@ -207,7 +207,7 @@ FOUND_PKG=0
 for pkg in \${PKGS}; do
     echo "found \$pkg"
     # Check for correctly generated packages size > 3Kb
-    test -z \$(find \$pkg -size +3k) && echo "WARNING: empty package?" 
+    test -z \$(find \$pkg -size +3k) && echo "WARNING: empty package?"
     # && exit 1
     cp \${pkg} $WORKSPACE/pkgs
     FOUND_PKG=1

--- a/jenkins-scripts/lib/libbullet-release-base.bash
+++ b/jenkins-scripts/lib/libbullet-release-base.bash
@@ -56,7 +56,7 @@ cd $WORKSPACE/bullet
 # Debian information
 rm -fr $WORKSPACE/debian
 mkdir $WORKSPACE/debian
-hg clone https://bitbucket.org/osrf/bullet-2.82-debian-release $WORKSPACE/debian
+git clone https://github.com/ignition-release/bullet-2.82-debian-release $WORKSPACE/debian
 cp -a --dereference $WORKSPACE/debian/old/debian $WORKSPACE/bullet
 
 cd $WORKSPACE/bullet


### PR DESCRIPTION
The old chroot scripts need a clean up (those living in jenkins/lib/ instead of jenkins/docker/lib) but I'm changing here all the ocurrences I found.

Testing:
 * DSL  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition&build=949)](https://build.osrfoundation.org/view/All/job/_dsl_ignition/949/)
 * debbuild: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-launch2-debbuilder&build=23)](https://build.osrfoundation.org/job/ign-launch2-debbuilder/23/)
