### PR TITLE
Workaround to avoid make_jobs to be unset

### DIFF
--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -18,8 +18,6 @@ fi
 [[ -z $GENERIC_ENABLE_CPPCHECK ]] && GENERIC_ENABLE_CPPCHECK=true
 [[ -z $GENERIC_ENABLE_TESTS ]] && GENERIC_ENABLE_TESTS=true
 
-echo "${MAKE_JOBS}" > "${WORKSPACE}/make_jobs"
-
 cat > build.sh << DELIM_HEADER
 #!/bin/bash
 set -ex

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -18,6 +18,8 @@ fi
 [[ -z $GENERIC_ENABLE_CPPCHECK ]] && GENERIC_ENABLE_CPPCHECK=true
 [[ -z $GENERIC_ENABLE_TESTS ]] && GENERIC_ENABLE_TESTS=true
 
+echo "${MAKE_JOBS}" > "${WORKSPACE}/make_jobs"
+
 cat > build.sh << DELIM_HEADER
 #!/bin/bash
 set -ex
@@ -83,7 +85,7 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: compiling'
 init_stopwatch COMPILATION
-make -j${MAKE_JOBS}
+make -j\$(cat $WORKSPACE/make_jobs)
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: installing'

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -250,4 +250,8 @@ fi
 rm -fr Dockerfile
 rm -fr ${WORKSPACE}/build.sh
 
+# Workaround to fix several nested levels of calls to the same script that seems
+# to kill global bash variables
+echo "${MAKE_JOBS}" > "${WORKSPACE}/make_jobs"
+
 cd ${WORKSPACE}


### PR DESCRIPTION
There were some problems related to the use of `make -j` with no specific job count. That triggered automatically many jobs that were killing the drogon node in some occasions due to the lack of memory available.

We are calling recursively the generic compilation script in order to get dependencies compiled. Somehow in those calls the MAKE_JOBS variable is missing. I tried to reproduce the problem locally using a minimal script but I was unable to get the same result.

This PR is no more than a workaround in order to avoid that effect by using a file in the WORKSPACE and inject the content of the file in the script.

Tested: https://build.osrfoundation.org/job/_test_maxjobs_ignition_gazebo-ci-default-bionic-amd64/2/consoleFull . (grep for `make -j`).
