### PR TITLE
Jenkins dsl: use GitHub for sdformat non-any builds

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
@@ -6,8 +6,7 @@ class OSRFGitHub
 {
   static void create(Job job, String repo,
                               String rev    = 'master',
-                              String subdir = 'NOT-DEFINED-USE-DEFAULT',
-                              String installName = 'Default')
+                              String subdir = 'NOT-DEFINED-USE-DEFAULT')
   {
     String software_name = repo.tokenize('/').last()
 
@@ -17,10 +16,14 @@ class OSRFGitHub
     job.with
     {
       scm {
-        github(repo) {
+        git {
+          remote {
+            github(repo)
+          }
           branch(rev)
-          installation(installName)
-          subdirectory(subdir)
+          extensions {
+            relativeTargetDirectory(subdir)
+          }
         }
       }
     }

--- a/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
@@ -1,0 +1,28 @@
+package _configs_
+
+import javaposse.jobdsl.dsl.Job
+
+class OSRFGitHub
+{
+  static void create(Job job, String repo,
+                              String rev    = 'master',
+                              String subdir = 'NOT-DEFINED-USE-DEFAULT',
+                              String installName = 'Default')
+  {
+    String software_name = repo.tokenize('/').last()
+
+    if (subdir == 'NOT-DEFINED-USE-DEFAULT')
+      subdir = software_name
+
+    job.with
+    {
+      scm {
+        github(repo) {
+          branch(rev)
+          installation(installName)
+          subdirectory(subdir)
+        }
+      }
+    }
+  }
+}

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -2,7 +2,7 @@ import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
 def sdformat_supported_branches = [ 'sdformat4', 'sdformat5', 'sdformat6', 'sdformat8' , 'sdformat9' ]
-def sdformat_gz11_branches = [ 'sdformat8', 'sdformat9', 'default' ]
+def sdformat_gz11_branches = [ 'sdformat8', 'sdformat9', 'master' ]
 // nightly and prereleases
 def extra_sdformat_debbuilder = [ 'sdformat7', 'sdformat9' ]
 
@@ -70,10 +70,10 @@ abi_distro.each { distro ->
 [ Globals.get_gz11_ubuntu_distro() ].each { distro ->
   supported_arches.each { arch ->
     // --------------------------------------------------------------
-    // 1. Create the default ci jobs
-    def sdformat_ci_job = job("sdformat-ci-default-${distro}-${arch}")
+    // 1. Create the master ci jobs
+    def sdformat_ci_job = job("sdformat-ci-master-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFBitbucketHg.create(sdformat_ci_job, "https://bitbucket.org/osrf/sdformat")
+    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat")
 
     sdformat_ci_job.with
     {
@@ -144,17 +144,17 @@ abi_distro.each { distro ->
   } // end of arch
 } // end of distro
 
-// OTHER CI SUPPORTED JOBS (default branch) @ SCM/DAILY
+// OTHER CI SUPPORTED JOBS (master branch) @ SCM/DAILY
 other_supported_distros.each { distro ->
-  // default doesn't support xenial anymore
+  // master doesn't support xenial anymore
   if ("${distro}" == "xenial")
     return
 
   supported_arches.each { arch ->
-    // ci_default job for the rest of arches / scm@daily
-    def sdformat_ci_job = job("sdformat-ci-default-${distro}-${arch}")
+    // ci_master job for the rest of arches / scm@daily
+    def sdformat_ci_job = job("sdformat-ci-master-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFBitbucketHg.create(sdformat_ci_job, "https://bitbucket.org/osrf/sdformat")
+    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat")
 
     sdformat_ci_job.with
     {
@@ -183,12 +183,11 @@ sdformat_supported_branches.each { branch ->
       distro = Globals.get_gz11_ubuntu_distro()
 
     supported_arches.each { arch ->
-      // ci_default job for the rest of arches / scm@daily
+      // ci_master job for the rest of arches / scm@daily
       def sdformat_ci_job = job("sdformat-ci-${branch}-${distro}-${arch}")
       OSRFLinuxCompilation.create(sdformat_ci_job)
-      OSRFBitbucketHg.create(sdformat_ci_job,
-                             "https://bitbucket.org/osrf/sdformat",
-                             get_sdformat_branch_name(branch))
+      OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat",
+                        get_sdformat_branch_name(branch))
       sdformat_ci_job.with
       {
         triggers {
@@ -213,9 +212,9 @@ sdformat_supported_branches.each { branch ->
 // EXPERIMENTAL ARCHES @ SCM/WEEKLY
 [ Globals.get_gz11_ubuntu_distro() ].each { distro ->
   experimental_arches.each { arch ->
-    def sdformat_ci_job = job("sdformat-ci-default-${distro}-${arch}")
+    def sdformat_ci_job = job("sdformat-ci-master-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFBitbucketHg.create(sdformat_ci_job, "https://bitbucket.org/osrf/sdformat")
+    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat")
 
     sdformat_ci_job.with
     {
@@ -318,15 +317,13 @@ sdformat_brew_ci_any_job.with
     }
 }
 
-// 2. default in all branches @SCM/daily
-all_branches = sdformat_supported_branches + 'default'
+// 2. master in all branches @SCM/daily
+all_branches = sdformat_supported_branches + 'master'
 all_branches.each { branch ->
   def sdformat_brew_ci_job = job("sdformat-ci-${branch}-homebrew-amd64")
   OSRFBrewCompilation.create(sdformat_brew_ci_job)
-  OSRFBitbucketHg.create(sdformat_brew_ci_job,
-                         "https://bitbucket.org/osrf/sdformat",
-                         get_sdformat_branch_name(branch),
-                         "sdformat", "HomeBrew")
+  OSRFGitHub.create(sdformat_brew_ci_job, "osrf/sdformat",
+                         get_sdformat_branch_name(branch))
 
   sdformat_brew_ci_job.with
   {
@@ -365,14 +362,13 @@ all_branches.each { branch ->
       }
   }
 
-// 2. default / @ SCM/Daily
-all_branches = sdformat_supported_branches + 'default'
+// 2. master / @ SCM/Daily
+all_branches = sdformat_supported_branches + 'master'
 all_branches.each { branch ->
   def sdformat_win_ci_job = job("sdformat-ci-${branch}-windows7-amd64")
   OSRFWinCompilation.create(sdformat_win_ci_job)
-  OSRFBitbucketHg.create(sdformat_win_ci_job,
-                         "https://bitbucket.org/osrf/sdformat",
-                         get_sdformat_branch_name(branch))
+  OSRFGitHub.create(sdformat_win_ci_job, "osrf/sdformat",
+                    get_sdformat_branch_name(branch))
   sdformat_win_ci_job.with
   {
       triggers {


### PR DESCRIPTION
Create a `OSRFGitHub` helper class similar to `OSRFBitbucketHg` and change sdformat release branch builds to use it (save the `-ci-pr_any-` branches for later). Also rename the `-ci-default` builds to `-ci-master`.

* https://build.osrfoundation.org/job/_dsl_sdformat/838/

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-master-bionic-i386&build=1)](https://build.osrfoundation.org/job/sdformat-ci-master-bionic-i386/1/) https://build.osrfoundation.org/job/sdformat-ci-master-bionic-i386/1/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-master-homebrew-amd64&build=1)](https://build.osrfoundation.org/job/sdformat-ci-master-homebrew-amd64/1/) https://build.osrfoundation.org/job/sdformat-ci-master-homebrew-amd64/1/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-master-windows7-amd64&build=1)](https://build.osrfoundation.org/job/sdformat-ci-master-windows7-amd64/1/) https://build.osrfoundation.org/job/sdformat-ci-master-windows7-amd64/1/