### PR TITLE
Sdformat disable old jobs

### DIFF
--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -378,14 +378,11 @@ all_branches.each { branch ->
       }
 
       if (branch == 'sdformat4')
-        ign_math_v="2"
-      else
-        ign_math_v="3"
+        disabled()
 
       steps {
         batchFile("""\
               set USE_IGNITION_ZIP=FALSE
-              set IGNMATH_BRANCH=ign-math${ign_math_v}
               call "./scripts/jenkins-scripts/sdformat-default-devel-windows-amd64.bat"
               """.stripIndent())
       }

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -1,10 +1,10 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
-def sdformat_supported_branches = [ 'sdformat4', 'sdformat5', 'sdformat6', 'sdformat8' , 'sdformat9' ]
+def sdformat_supported_branches = [ 'sdformat4', 'sdformat6', 'sdformat8' , 'sdformat9' ]
 def sdformat_gz11_branches = [ 'sdformat8', 'sdformat9', 'master' ]
 // nightly and prereleases
-def extra_sdformat_debbuilder = [ 'sdformat7', 'sdformat9' ]
+def extra_sdformat_debbuilder = [ 'sdformat7' ]
 
 // Main platform using for quick CI
 def ci_distro               = Globals.get_ci_distro()


### PR DESCRIPTION
I noticed some old sdformat branches have failing windows builds:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat5-windows7-amd64&build=47)](https://build.osrfoundation.org/job/sdformat-ci-sdformat5-windows7-amd64/47/) https://build.osrfoundation.org/job/sdformat-ci-sdformat5-windows7-amd64/47/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat4-windows7-amd64&build=74)](https://build.osrfoundation.org/job/sdformat-ci-sdformat4-windows7-amd64/74/) https://build.osrfoundation.org/job/sdformat-ci-sdformat4-windows7-amd64/74/

I disabled the jobs for now, but we need to disable them in dsl for the next time they get regenerated. This PR disables all sdformat5 CI builds since that version is no longer supported. sdformat4 is still in use by gazebo7, and it's windows build is failing since we are not providing a suitable version of boost, so this PR disables the windows build for that branch.