### PR TITLE
Port release.py to use github repository as source code

### DIFF
--- a/release.py
+++ b/release.py
@@ -395,7 +395,7 @@ def generate_upload_tarball(args):
     cmd = ['git', 'diff-index', 'HEAD']
     out, err = check_call(cmd)
     if out:
-        print('%s says that you have uncommitted changes git')
+        print('git says that you have uncommitted changes')
         print('Please clean up your working copy so that "%s" outputs nothing' % (' '.join(cmd)))
         print('stdout: %s' % (out))
         sys.exit(1)

--- a/release.py
+++ b/release.py
@@ -38,9 +38,6 @@ IGN_REPO = False
 
 IGNORE_DRY_RUN = True
 
-class ErrorGitRepo(Exception):
-    pass
-
 class ErrorNoPermsRepo(Exception):
     pass
 
@@ -315,7 +312,6 @@ def discover_distros(repo_dir):
     root, subdirs, files = os.walk(repo_dir).next()
     repo_arch_exclusion = get_exclusion_arches(files)
 
-    if '.hg' in subdirs: subdirs.remove('.hg')
     if '.git' in subdirs: subdirs.remove('.git')
     # remove ubuntu (common stuff) and debian (new supported distro at top level)
     if 'ubuntu' in subdirs: subdirs.remove('ubuntu')
@@ -359,14 +355,6 @@ def check_call(cmd, ignore_dry_run = False):
                 raise ErrorNoPermsRepo()
             if "abort: no username supplied" in err:
                 raise ErrorNoUsernameSupplied()
-            if "hg" in cmd:
-                try:
-                    r = subprocess.Popen(["git", "status"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                except OSError as e:
-                    print("Unable to run 'git status'. Is git installed?")
-                    raise
-                if r.returncode != 0:
-                    raise ErrorGitRepo()
             # Unkown exception
             print('Error running command (%s).'%(' '.join(cmd)))
             print('stdout: %s'%(out))
@@ -401,31 +389,26 @@ def generate_upload_tarball(args):
     sourcedir = os.getcwd()
     tmpdir    = tempfile.mkdtemp()
     builddir  = os.path.join(tmpdir, 'build')
-    use_git   = os.path.isdir(os.path.join(sourcedir, '.git'))
 
-    # Put the hg-specific stuff in a try block, to allow for a git repo
-    try:
-        # Check for uncommitted changes; abort if present
+    # Check for uncommitted changes; abort if present
 
-        cmd = ['git', 'diff-index', 'HEAD'] if use_git else ['hg', 'status', '-q']
-        out, err = check_call(cmd)
-        if out:
-            print('%s says that you have uncommitted changes' % ('git' if use_git else 'Mercurial'))
-            print('Please clean up your working copy so that "%s" outputs nothing' % (' '.join(cmd)))
-            print('stdout: %s' % (out))
-            sys.exit(1)
+    cmd = ['git', 'diff-index', 'HEAD']
+    out, err = check_call(cmd)
+    if out:
+        print('%s says that you have uncommitted changes git')
+        print('Please clean up your working copy so that "%s" outputs nothing' % (' '.join(cmd)))
+        print('stdout: %s' % (out))
+        sys.exit(1)
 
-        # Make a clean copy, to avoid pulling in other stuff that the user has
-        # sitting in the working copy
-        srcdir = os.path.join(tmpdir, 'src')
-        if use_git:
-            os.mkdir(srcdir)
-            tmp_tar = os.path.join(tmpdir, 'orig.tar')
-            check_call(['git', 'archive', '--format=tar', 'HEAD', '-o', tmp_tar])
-            check_call(['tar', 'xf', tmp_tar, '-C', srcdir])
-            os.remove(tmp_tar)
-        else:
-            check_call(['hg', 'archive', srcdir])
+    # Make a clean copy, to avoid pulling in other stuff that the user has
+    # sitting in the working copy
+    srcdir = os.path.join(tmpdir, 'src')
+    os.mkdir(srcdir)
+    tmp_tar = os.path.join(tmpdir, 'orig.tar')
+    check_call(['git', 'archive', '--format=tar', 'HEAD', '-o', tmp_tar])
+    check_call(['tar', 'xf', tmp_tar, '-C', srcdir])
+    if not args.dry_run:
+        os.remove(tmp_tar)
 
     # use cmake to generate package_source
     generate_package_source(srcdir, builddir)
@@ -462,20 +445,16 @@ def generate_upload_tarball(args):
 
     try:
         tag = '%s_%s'%(args.package_alias, args.version)
-        if use_git:
-            check_call(['git', 'tag', '-f', tag])
-            check_call(['git', 'push', '--tags'])
-        else:
-            check_call(['hg', 'tag', '-f', tag])
-            check_call(['hg', 'push', '-b', '.'])
+        check_call(['git', 'tag', '-f', tag])
+        check_call(['git', 'push', '--tags'])
     except ErrorNoPermsRepo as e:
-        print('The bitbucket server reports problems with permissions')
+        print('The Git server reports problems with permissions')
         print('The branch could be blocked by configuration if you do not have')
         print('rights to push code in default branch.')
         sys.exit(1)
     except ErrorNoUsernameSupplied as e:
-        print('The hg tag could not be committed because you have not configured')
-        print('your username. Use "hg config --edit" to set your username.')
+        print('git tag could not be committed because you have not configured')
+        print('your username. Use "git config --username" to set your username.')
         sys.exit(1)
     except Exception as e:
         print('There was a problem with pushing tags to the git repository')


### PR DESCRIPTION
Port our release tool to be able to work with new github repositories. Code is a bit old and would need a good cleanup but the patch seems to work for me while releasing `ignition-rendering2`.

The use is as usual. Remember to include the `-a ignition-foo2 --ignition-repo` arguments.

Tested:
 * [builds are in Jenkins](https://build.osrfoundation.org/job/ign-rendering2-debbuilder/43)
 * [S3 tarball is in place](https://osrf-distributions.s3.amazonaws.com/ign-rendering/releases/ignition-rendering2-2.4.0.tar.bz2)
 * [tag is ok](https://github.com/ignitionrobotics/ign-rendering/releases/tag/ignition-rendering2_2.4.0)