### PR TITLE
GithubAny emails: use $GIT_BRANCH in subject line

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -18,7 +18,7 @@ class GenericAnyJobGitHub
    {
      // setup special mail subject
      GenericMail.update_field(job, 'defaultSubject',
-                    '$PROJECT_NAME - Branch: $SRC_BRANCH (#$BUILD_NUMBER) - $BUILD_STATUS!')
+                    '$PROJECT_NAME - Branch: $GIT_BRANCH (#$BUILD_NUMBER) - $BUILD_STATUS!')
      GenericMail.update_field(job, 'defaultContent',
                     '$JOB_DESCRIPTION \n' + GenericCompilation.get_compilation_mail_content())
 


### PR DESCRIPTION
$SRC_BRANCH is not a parameter created by the
github pull reuqest builder plugin, but $GIT_BRANCH seems to be.

* https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-homebrew-amd64/292/parameters/

Testing with sdformat:

* https://build.osrfoundation.org/job/_dsl_sdformat/853/
* the sdf4 windows jenkins builds don't work, so I was able to see an email with a useful branch name in the subject line from https://github.com/osrf/sdformat/pull/248: "sdformat-ci-pr_any-windows7-amd64 - Branch: github_changelog_sdf4 (#1313) - Failure!"