### PR TITLE
Don't install Ruby for ign-msgs on Xenial

### DIFF
--- a/jenkins-scripts/docker/ign_msgs-compilation.bash
+++ b/jenkins-scripts/docker/ign_msgs-compilation.bash
@@ -17,7 +17,7 @@ fi
 export BUILDING_SOFTWARE_DIRECTORY="ign-msgs"
 export BUILDING_PKG_DEPENDENCIES_VAR_NAME="IGN_MSGS_DEPENDENCIES"
 # skip ruby on Xenial, because protobuf requires Ruby version >= 2.4.4
-export DOCKER_POSTINSTALL_HOOK="gem install protobuf || if [ `lsb_release -sr` == "16.04" ]; then true; else false; fi"
+export DOCKER_POSTINSTALL_HOOK="gem install protobuf || if [ `lsb_release -sr` = "16.04" ]; then true; else false; fi"
 
 # Identify IGN_MSGS_MAJOR_VERSION to help with dependency resolution
 IGN_MSGS_MAJOR_VERSION=$(\

--- a/jenkins-scripts/docker/ign_msgs-compilation.bash
+++ b/jenkins-scripts/docker/ign_msgs-compilation.bash
@@ -16,7 +16,8 @@ fi
 
 export BUILDING_SOFTWARE_DIRECTORY="ign-msgs"
 export BUILDING_PKG_DEPENDENCIES_VAR_NAME="IGN_MSGS_DEPENDENCIES"
-export DOCKER_POSTINSTALL_HOOK="gem install protobuf"
+# skip ruby on Xenial, because protobuf requires Ruby version >= 2.4.4
+export DOCKER_POSTINSTALL_HOOK="gem install protobuf || if [ `lsb_release -sr` == "16.04" ]; then true; else false; fi"
 
 # Identify IGN_MSGS_MAJOR_VERSION to help with dependency resolution
 IGN_MSGS_MAJOR_VERSION=$(\


### PR DESCRIPTION
`ign-msgs1` CI is [failing](https://build.osrfoundation.org/job/ignition_msgs-ci-pr_any-ubuntu_auto-amd64/317/consoleFull) on Xenial with this message:

```
Step 23/34 : RUN gem install protobuf
 ---> Running in 8e959b4281df
ERROR:  Error installing protobuf:
	zeitwerk requires Ruby version >= 2.4.4.
```

A quick solution is to just skip Ruby for Xenial.

Queued a test build: [![Build Status](https://build.osrfoundation.org/job/ignition_msgs-ci-pr_any-ubuntu_auto-amd64/325/badge/icon)](https://build.osrfoundation.org/job/ignition_msgs-ci-pr_any-ubuntu_auto-amd64/325/)