### PR TITLE
ID closed branches to delete with 'hg heads -c'

### DIFF
--- a/jenkins-scripts/tools/git_delete_closed_hg_branches.bash
+++ b/jenkins-scripts/tools/git_delete_closed_hg_branches.bash
@@ -9,7 +9,7 @@ echo =========== Done Cloning HG Repository
 echo
 echo =========== Identify Closed HG Branches
 CLOSED_BRANCHES=$(\
-  hg branches -c | grep '(closed)$' | sed -e 's@ *[0-9]*[0-9]:.*@@')
+  hg branches -c | grep '(closed)$' | awk '{ print $1 }')
 # the following doesn't work because 'hg log -r "closed()"' lists branches
 # that were closed and then re-opened:
 #  hg -R $HG_TMP log -r "closed()" --template '{branch}\n' | sort)
@@ -23,5 +23,4 @@ do
   echo remote git branch found: $b
   git push --delete origin $b
 done
-
 

--- a/jenkins-scripts/tools/git_delete_closed_hg_branches.bash
+++ b/jenkins-scripts/tools/git_delete_closed_hg_branches.bash
@@ -9,7 +9,13 @@ echo =========== Done Cloning HG Repository
 echo
 echo =========== Identify Closed HG Branches
 CLOSED_BRANCHES=$(\
-  hg -R $HG_TMP log -r "closed()" --template '{branch}\n' | sort)
+  hg branches -c | grep '(closed)$' | sed -e 's@ *[0-9]*[0-9]:.*@@')
+# the following doesn't work because 'hg log -r "closed()"' lists branches
+# that were closed and then re-opened:
+#  hg -R $HG_TMP log -r "closed()" --template '{branch}\n' | sort)
+# 'hg log -r "closed() and head()"' doesn't quite work either because a
+# branch could have 1 closed head and 1 open head, and it should still
+# be characterized as open
 for b in $CLOSED_BRANCHES
 do
   git show remotes/origin/$b &> /dev/null || \


### PR DESCRIPTION
Using 'hg log -r 'closed()' was inaccurate, as it includes
branches that were closed and then re-opened, causing the
git_delete_closed_hg_branches.bash script to delete open branches.
This improves the logic using 'hg heads -c'.

For gazebo:

~~~
# includes branches thet were closed and re-opened
$ hg log -r 'closed()' --template "{branch}\n" | sort | uniq | wc -l
    3144
~~~

~~~
# includes branches with a closed head and an open head
$ hg log -r 'closed() and head()' --template "{branch}\n" | sort | uniq | wc -l
    3124
~~~

~~~
# includes non-open branches only
$ hg branches -c | grep '(closed)$' | sed -e 's@ *[0-9]*[0-9]:.*@@' | sort | uniq | wc -l
    3121
~~~

the last one is the most accurate for this purpose