### PR TITLE
Windows scripts: default -> master

### DIFF
--- a/jenkins-scripts/lib/sdformat-base-windows.bat
+++ b/jenkins-scripts/lib/sdformat-base-windows.bat
@@ -4,8 +4,6 @@
 ::  - USE_IGNITION_ZIP : (default true) [true | false]. Use zip to install ignition
 ::                       instead of compile
 ::  - BUILD_TYPE       : (default Release) [ Release | Debug ] Build type to use
-::  - IGNMATH_BRANCH   : (default default) [optional]. Ignition math branch to
-::                       compile. If in use, USE_IGNITION_ZIP will be false
 ::
 
 @if "%BUILD_TYPE%" == "" set BUILD_TYPE=Release
@@ -15,17 +13,8 @@ findstr /r /b "find_package(ignition-math" %WORKSPACE%\sdformat\cmake\SearchForS
 set /p IGN_MATH_REQUIRED_VERSION=<version.txt
 set IGN_MATH_REQUIRED_VERSION=%IGN_MATH_REQUIRED_VERSION:~26,1%
 set IGNMATH_BRANCH="ign-math%IGN_MATH_REQUIRED_VERSION%"
-:: hard-code ign-math3 for now until we fix configure scripts
-@if %IGN_MATH_REQUIRED_VERSION% EQU 4 set IGNMATH_BRANCH="ign-math3"
 @if "%USE_IGNITION_ZIP%" == "" set USE_IGNITION_ZIP=FALSE
 set IGNMATH_ZIP=%IGNMATH_BRANCH% :: should not be needed
-
-:: When CI is run on the default branch use the .zip. Otherwise compile ign-math
-@if "%SRC_BRANCH%" == "default" (
-  set IGNMATH_BRANCH="default"
-  set IGNMATH_ZIP="ign-math3"
-  @if "%USE_IGNITION_ZIP%" == "" set USE_IGNITION_ZIP=TRUE
-)
 
 set win_lib=%SCRIPT_DIR%\lib\windows_library.bat
 set TEST_RESULT_PATH="%WORKSPACE%\test_results"

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -122,8 +122,8 @@ goto :EOF
 set IGN_PROJECT_DEPENDENCY_DIR=%LOCAL_WS%\%1
 if exist %IGN_PROJECT_DEPENDENCY_DIR% ( rmdir /s /q %IGN_PROJECT_DEPENDENCY_DIR% )
 if "%2"=="" (
-  echo Installing default branch of %1
-  git clone https://github.com/ignitionrobotics/%1 %IGN_PROJECT_DEPENDENCY_DIR% -b default
+  echo Installing master branch of %1
+  git clone https://github.com/ignitionrobotics/%1 %IGN_PROJECT_DEPENDENCY_DIR% -b master
 ) else (
   echo Installing branch %2 of %1
   git clone https://github.com/ignitionrobotics/%1 %IGN_PROJECT_DEPENDENCY_DIR% -b %2


### PR DESCRIPTION
This updates `windows_library.bat` to clone the `master` branch by default instead of `default` as a follow-up to #181.

It also cleans up some logic from sdformat-base-windows.bat since that scripts is only used for sdformat5 and earlier (see https://github.com/ignition-tooling/release-tools/blob/master/jenkins-scripts/sdformat-default-devel-windows-amd64.bat#L10-L14 ).