### PR TITLE
Docker scripts: bitbucket -> GitHub

### DIFF
--- a/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
+++ b/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
@@ -32,7 +32,7 @@ fi
 if [[ ${IGN_FUEL_TOOLS_MAJOR_VERSION} -ge 5 ]]; then
   export BUILD_IGN_MSGS=true
   export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=default
+  export IGN_MSGS_BRANCH=master
 fi
 
 export GZDEV_PROJECT_NAME="ignition-fuel-tools${IGN_FUEL_TOOLS_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_gazebo-compilation.bash
+++ b/jenkins-scripts/docker/ign_gazebo-compilation.bash
@@ -31,13 +31,13 @@ fi
 if [[ ${IGN_GAZEBO_MAJOR_VERSION} -ge 4 ]]; then
   export BUILD_IGN_SENSORS=true
   export IGN_SENSORS_MAJOR_VERSION=4
-  export IGN_SENSORS_BRANCH=default
+  export IGN_SENSORS_BRANCH=master
   export BUILD_IGN_GUI=true
   export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=default
+  export IGN_GUI_BRANCH=master
   export BUILD_IGN_RENDERING=true
   export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=default
+  export IGN_RENDERING_BRANCH=master
   export BUILD_IGN_COMMON=true
   export IGN_COMMON_MAJOR_VERSION=3
   export IGN_COMMON_BRANCH=ign-common3

--- a/jenkins-scripts/docker/ign_gui-compilation.bash
+++ b/jenkins-scripts/docker/ign_gui-compilation.bash
@@ -31,7 +31,7 @@ fi
 if [[ ${IGN_GUI_MAJOR_VERSION} -ge 4 ]]; then
   export BUILD_IGN_RENDERING=true
   export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=default
+  export IGN_RENDERING_BRANCH=master
   export BUILD_IGN_COMMON=true
   export IGN_COMMON_MAJOR_VERSION=3
   export IGN_COMMON_BRANCH=ign-common3

--- a/jenkins-scripts/docker/ign_launch-compilation.bash
+++ b/jenkins-scripts/docker/ign_launch-compilation.bash
@@ -35,19 +35,19 @@ if [[ ${IGN_LAUNCH_MAJOR_VERSION} -ge 3 ]]; then
 
   export BUILD_IGN_SENSORS=true
   export IGN_SENSORS_MAJOR_VERSION=4
-  export IGN_SENSORS_BRANCH=default
+  export IGN_SENSORS_BRANCH=master
 
   export BUILD_IGN_GUI=true
   export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=default
+  export IGN_GUI_BRANCH=master
 
   export BUILD_IGN_RENDERING=true
   export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=default
+  export IGN_RENDERING_BRANCH=master
 
   export BUILD_IGN_GAZEBO=true
   export IGN_GAZEBO_MAJOR_VERSION=4
-  export IGN_GAZEBO_BRANCH=default
+  export IGN_GAZEBO_BRANCH=master
 fi
 
 export USE_GCC8=true

--- a/jenkins-scripts/docker/ign_sensors-compilation.bash
+++ b/jenkins-scripts/docker/ign_sensors-compilation.bash
@@ -31,7 +31,7 @@ fi
 if [[ ${IGN_SENSORS_MAJOR_VERSION} -ge 4 ]]; then
   export BUILD_IGN_RENDERING=true
   export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=default
+  export IGN_RENDERING_BRANCH=master
   export BUILD_IGN_COMMON=true
   export IGN_COMMON_MAJOR_VERSION=3
   export IGN_COMMON_BRANCH=ign-common3

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -7,7 +7,7 @@
 #  - GENERIC_ENABLE_TESTS (optional) [default true] run tests
 #  - BUILDING_EXTRA_CMAKE_PARAMS (optional) extra cmake params
 #  - BUILD_<lib name> (optional) build dependency from source, for example, BUILD_IGN_MATH
-#    - <lib name>_BRANCH (optional [default: default]) branch for BUILD_<lib_name>
+#    - <lib name>_BRANCH (optional [default: master]) branch for BUILD_<lib_name>
 
 if [[ -z ${SOFTWARE_DIR} ]]; then
     echo "SOFTWARE_DIR variable is unset. Please fix the code"
@@ -44,7 +44,7 @@ for dep_uppercase in $OSRF_DEPS; do
   if [[ -n ${dependecy_installation} ]] && ${dependecy_installation}; then
       # Handle the depedency BRANCH
       eval dep_branch=\$$dep_uppercase\_BRANCH
-      [[ -z ${dep_branch} ]] && dep_branch='default'
+      [[ -z ${dep_branch} ]] && dep_branch='master'
 cat >> build.sh << DELIM_BUILD_DEPS
     echo "# BEGIN SECTION: building dependency: ${dep} (${dep_branch})"
     echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -51,13 +51,13 @@ cat >> build.sh << DELIM_BUILD_DEPS
     rm -fr $WORKSPACE/$dep
 
     if [[ ${dep/ign} == ${dep} ]]; then
-      bitbucket_repo="osrf/${dep}"
+      dependency_repo="osrf/${dep}"
     else
       # need to replace _ by -
-      bitbucket_repo="ignitionrobotics/${dep//_/-}"
+      dependency_repo="ignitionrobotics/${dep//_/-}"
     fi
 
-    hg clone http://bitbucket.org/\$bitbucket_repo -b ${dep_branch} \
+    git clone http://github.com/\$dependency_repo -b ${dep_branch} \
 	$WORKSPACE/$dep
 
     GENERIC_ENABLE_TIMING=false

--- a/jenkins-scripts/docker/lib/gazebo-base-default.bash
+++ b/jenkins-scripts/docker/lib/gazebo-base-default.bash
@@ -124,7 +124,7 @@ for dep_uppercase in $GAZEBO_OSRF_DEPS; do
   if [[ -n ${dependecy_installation} ]] && ${dependecy_installation}; then
       # Handle the depedency BRANCH
       eval dep_branch=\$$dep_uppercase\_BRANCH
-      [[ -z ${dep_branch} ]] && dep_branch='default'
+      [[ -z ${dep_branch} ]] && dep_branch='master'
 cat >> build.sh << DELIM_BUILD_DEPS
     echo "# BEGIN SECTION: building dependency: ${dep} (${dep_branch})"
     echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/gazebo-base-default.bash
+++ b/jenkins-scripts/docker/lib/gazebo-base-default.bash
@@ -131,13 +131,13 @@ cat >> build.sh << DELIM_BUILD_DEPS
     rm -fr $WORKSPACE/$dep
 
     if [[ ${dep/ign} == ${dep} ]]; then
-      bitbucket_repo="osrf/${dep}"
+      dependency_repo="osrf/${dep}"
     else
       # need to replace _ by -
-      bitbucket_repo="ignitionrobotics/${dep/_/-}"
+      dependency_repo="ignitionrobotics/${dep/_/-}"
     fi
 
-    hg clone http://bitbucket.org/\$bitbucket_repo -b ${dep_branch} \
+    git clone http://github.com/\$dependency_repo -b ${dep_branch} \
 	$WORKSPACE/$dep
 
     GENERIC_ENABLE_TIMING=false

--- a/jenkins-scripts/docker/sdformat-compilation.bash
+++ b/jenkins-scripts/docker/sdformat-compilation.bash
@@ -28,7 +28,7 @@ fi
 
 export GZDEV_PROJECT_NAME="sdformat${SDFORMAT_MAJOR_VERSION}"
 
-# default and major branches compilations
+# master and major branches compilations
 export BUILDING_PKG_DEPENDENCIES_VAR_NAME="SDFORMAT_BASE_DEPENDENCIES"
 
 . "${SCRIPT_DIR}/lib/generic-building-base.bash"


### PR DESCRIPTION
When building dependencies from source in the docker scripts, clone from GitHub rather than bitbucket. Also change some `default` branch names to `master`.