### PR TITLE
Pass supported_ros_distros parameter

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilationAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilationAnyGitHub.groovy
@@ -24,6 +24,6 @@ class OSRFLinuxCompilationAnyGitHub
     OSRFLinuxCompilation.create(job, enable_testing, enable_cppcheck)
     Globals.rtools_description = true
 
-    GenericAnyJobGitHub.create(job, github_repo)
+    GenericAnyJobGitHub.create(job, github_repo, supported_ros_distros)
   }
 } // end of class


### PR DESCRIPTION
This was broken by #168 and caused gazebo_ros_pkgs
jobs to create builds for every ROS distro.