### PR TITLE
Move Github integration DSL code to configure block

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -64,7 +64,7 @@ class GenericAnyJobGitHub
             cron()
             whiteListTargetBranches {
               'org.jenkinsci.plugins.ghprb.GhprbBranch' {
-                 branch supported_ros_branches.join(" ")
+                 branch supported_branches.join(" ")
               }
             }
             triggerPhrase '.*(re)?run test(s).*'

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -61,27 +61,29 @@ class GenericAnyJobGitHub
         }
       }
 
-      triggers {
-        githubPullRequest {
-            admins(['osrf-jenkins', 'j-rivero'])
-            useGitHubHooks()
-            cron('')
-            triggerPhrase('.*(re)?run test(s).*')
-            allowMembersOfWhitelistedOrgsAsAdmin()
-            if (supported_ros_branches) {
-              // Only will be triggered in supported_ros_branches
-              whiteListTargetBranches(supported_ros_branches)
-            }
+      configure { project ->
+        project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
+            adminList 'osrf-jenkins j-rivero'
+            useGitHubHooks(true)
+            allowMembersOfWhitelistedOrgsAsAdmin(true)
+            useGitHubHooks(true)
+            onlyTriggerPhrase(false)
             permitAll(true)
-            extensions {
-                commitStatus {
-                    context('${JOB_NAME}')
-                    triggeredStatus('starting deployment to build.osrfoundation.org')
-                    startedStatus('deploying to build.osrfoundation.org')
-                }
+            whiteListTargetBranches {
+              'org.jenkinsci.plugins.ghprb.GhprbBranch' {
+                 branch supported_ros_branches.join(" ")
+              }
             }
-        }
-      } // end of triggers
+            triggerPhrase '*(re)?run test(s).*'
+            extensions {
+                'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus' {
+                  commitStatusContext '${JOB_NAME}'
+                  triggeredStatus 'starting deployment to build.osrfoundation.org'
+                  startedStatus 'deploying to build.osrfoundation.org'
+                }
+              }
+            }
+          }
     } // end of with
   } // end of create method
 }

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -69,12 +69,13 @@ class GenericAnyJobGitHub
             useGitHubHooks(true)
             onlyTriggerPhrase(false)
             permitAll(true)
+            cron()
             whiteListTargetBranches {
               'org.jenkinsci.plugins.ghprb.GhprbBranch' {
                  branch supported_ros_branches.join(" ")
               }
             }
-            triggerPhrase '*(re)?run test(s).*'
+            triggerPhrase '.*(re)?run test(s).*'
             extensions {
                 'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus' {
                   commitStatusContext '${JOB_NAME}'

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -12,6 +12,6 @@ OSRFWinBase.create(ignition_ci_job_win)
 def ignition_ci_pr_job = job("_test_pr_job_from_dsl")
 OSRFLinuxCompilationAnyGitHub.create(ignition_ci_pr_job,
                                      'ignitionrobotics/testing',
-                                     true,
+                                     false,
                                      false,
                                      ['master'])

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -9,3 +9,9 @@ def ignition_ci_job_mac = job("_test_job_from_dsl_mac")
 OSRFOsXBase.create(ignition_ci_job_mac)
 def ignition_ci_job_win = job("_test_job_from_dsl_win")
 OSRFWinBase.create(ignition_ci_job_win)
+def ignition_ci_pr_job = job("_test_pr_job_from_dsl")
+OSRFLinuxCompilationAnyGitHub.create(ignition_ci_pr_job,
+                                     'ignitionrobotics/testing',
+                                     true,
+                                     false,
+                                     ['master'])


### PR DESCRIPTION
One of the problems to develop DSL code that we have now is that [the trick to generate jobs](https://github.com/jenkinsci/job-dsl-plugin/wiki/User-Power-Moves) (check syntax and results) does not work with the github PR plugin DSL code.

This PR changes the DSL to use configure block. Although we are losing a layer of indirection and almost inject code directly in the XML I think it worth to back to be able to generate code locally to speed up development.

I still need to configure test.dsl and a test repo to do the checks on Jenkins itself.