### PR TITLE
Remove gazebo_ros_pkgs branch logic out of generic DSL classes

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -56,7 +56,7 @@ class GenericAnyJobGitHub
             allowMembersOfWhitelistedOrgsAsAdmin()
             // Only will be triggered in supported_branches
             if (supported_branches) {
-              whiteListTargetBranches(supported_branches.join(" "))
+              whiteListTargetBranches(supported_branches)
             }
             permitAll(true)
             extensions {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -28,7 +28,7 @@ class GenericAnyJobGitHub
     // Transform GStringImp into real string
     ArrayList supported_branches_str = []
     supported_branches.each { branch ->
-      supported_branches_str.add(branch)
+      supported_branches_str.add(branch.toString())
     }
 
     job.with

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -25,6 +25,12 @@ class GenericAnyJobGitHub
     // Get repo name for relativeTargetDirectory
     String github_repo_name = github_repo.substring(github_repo.lastIndexOf("/") + 1)
 
+    // Transform GStringImp into real string
+    ArrayList supported_branches_str = []
+    supported_branches.each { branch ->
+      supported_branches_str.add(branch)
+    }
+
     job.with
     {
       parameters
@@ -55,8 +61,8 @@ class GenericAnyJobGitHub
             triggerPhrase('.*(re)?run test(s).*')
             allowMembersOfWhitelistedOrgsAsAdmin()
             // Only will be triggered in supported_branches
-            if (supported_branches) {
-              whiteListTargetBranches(supported_branches)
+            if (supported_branches_str) {
+              whiteListTargetBranches(supported_branches_str)
             }
             permitAll(true)
             extensions {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -56,7 +56,7 @@ class GenericAnyJobGitHub
             allowMembersOfWhitelistedOrgsAsAdmin()
             // Only will be triggered in supported_branches
             if (supported_branches) {
-              whiteListTargetBranches(supported_branches)
+              whiteListTargetBranches(supported_branches.join(" "))
             }
             permitAll(true)
             extensions {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -14,7 +14,7 @@ class GenericAnyJobGitHub
 {
    static void create(Job job,
                      String github_repo,
-                     ArrayList supported_ros_distros = [])
+                     ArrayList supported_branches = [])
    {
      // setup special mail subject
      GenericMail.update_field(job, 'defaultSubject',
@@ -24,20 +24,6 @@ class GenericAnyJobGitHub
 
     // Get repo name for relativeTargetDirectory
     String github_repo_name = github_repo.substring(github_repo.lastIndexOf("/") + 1)
-
-    ArrayList supported_ros_branches = []
-    supported_ros_distros.each { ros_distro ->
-      if (ros_distro == Globals.get_ros2_development_distro()) {
-        // Latest unreleased distro points to ros2
-        supported_ros_branches.add("ros2")
-      } else if (Globals.get_ros2_suported_distros().contains(ros_distro)) {
-        supported_ros_branches.add(ros_distro)
-      } else {
-        // Keep the toString method to be sure that String is used and not
-        // GStringImp which will make the whole thing to fail.
-        supported_ros_branches.add("${ros_distro}-devel".toString())
-      }
-    }
 
     job.with
     {
@@ -68,9 +54,9 @@ class GenericAnyJobGitHub
             cron('')
             triggerPhrase('.*(re)?run test(s).*')
             allowMembersOfWhitelistedOrgsAsAdmin()
-            if (supported_ros_branches) {
-              // Only will be triggered in supported_ros_branches
-              whiteListTargetBranches(supported_ros_branches)
+            // Only will be triggered in supported_branches
+            if (supported_branches) {
+              whiteListTargetBranches(supported_branches)
             }
             permitAll(true)
             extensions {

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilationAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilationAnyGitHub.groovy
@@ -16,7 +16,7 @@ class OSRFLinuxCompilationAnyGitHub
                      String github_repo,
                      boolean enable_testing  = true,
                      boolean enable_cppcheck = true,
-                     ArrayList supported_ros_distros = [])
+                     ArrayList supported_branches = [])
   {
     // Do not include description from LinuxBase since the github pull request
     // builder set its own
@@ -24,6 +24,6 @@ class OSRFLinuxCompilationAnyGitHub
     OSRFLinuxCompilation.create(job, enable_testing, enable_cppcheck)
     Globals.rtools_description = true
 
-    GenericAnyJobGitHub.create(job, github_repo, supported_ros_distros)
+    GenericAnyJobGitHub.create(job, github_repo, supported_branches)
   }
 } // end of class

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -23,7 +23,7 @@ bloom_debbuild_jobs = [ 'gazebo-dev', 'gazebo-msgs', 'gazebo-plugins', 'gazebo-r
 
 Job create_common_compilation(String job_name,
                               String ubuntu_distro,
-                              String ros_distro,
+                              String ros_branch,
                               String gz_version,
                               String script_name)
 {
@@ -33,10 +33,10 @@ Job create_common_compilation(String job_name,
                                         "ros-simulation/gazebo_ros_pkgs",
                                         ENABLE_TESTS,
                                         DISABLE_CPPCHECK,
-                                        [ "${ros_distro}" ])
+                                        [ "${ros_branch}" ])
    include_common_params(comp_job,
                          ubuntu_distro,
-                         ros_distro,
+                         ros_branch,
                          gz_version,
                          script_name)
    return comp_job
@@ -143,7 +143,7 @@ void include_common_params(Job gazebo_ros_pkgs_job,
     def any_job_name = "${name_prefix}_gazebo_pkgs-ci-pr_any_${suffix_triplet}"
     Job any_job = create_common_compilation(any_job_name,
                                             ubuntu_distro,
-                                            ros_distro,
+                                            branch,
                                             "default",
                                             "gazebo_ros_pkgs-compilation")
 
@@ -210,7 +210,7 @@ void include_common_params(Job gazebo_ros_pkgs_job,
           def ci_pr_job_name = "${name_prefix}_gazebo${gz_version}_pkgs-ci-pr_any_${suffix_triplet}"
           Job ci_pr_job = create_common_compilation(ci_pr_job_name,
                                               ubuntu_distro,
-                                              ros_distro,
+                                              branch,
                                               gz_version,
                                               "gazebo_ros_pkgs-compilation")
         }
@@ -223,7 +223,7 @@ void include_common_params(Job gazebo_ros_pkgs_job,
         def regression_job_name = "${name_prefix}_gazebo_pkgs-ci-pr_regression_any_${suffix_triplet}"
         Job regression_job = create_common_compilation(regression_job_name,
                                                        ubuntu_distro,
-                                                       ros_distro,
+                                                       branch,
                                                        "default",
                                                        "gazebo_ros_pkgs-compilation_regression")
         // No melodic-devel branch in third party testing (yet)


### PR DESCRIPTION
I've removed all gazebo_ros_pkgs branches logic out of generic classes (it was duplicated inside `gazebo_ros_pkgs.dsl`).