### PR TITLE
Add Gazebo11 ROS packages for Melodic to CI

### DIFF
--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -17,7 +17,8 @@ Boolean ENABLE_TESTS = true
 Boolean DISABLE_CPPCHECK = false
 
 // version to test more than the official one in each ROS distro
-extra_gazebo_versions = [ 'kinetic' :  ['8','9']]
+extra_gazebo_versions = [ 'kinetic' :  ['8','9'],
+                          'melodic' :  ['11']]
 
 bloom_debbuild_jobs = [ 'gazebo-dev', 'gazebo-msgs', 'gazebo-plugins', 'gazebo-ros', 'gazebo-ros-control', 'gazebo-ros-pkgs' ]
 


### PR DESCRIPTION
Here we go [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros_gazebo11_pkgs-install_pkg_melodic-bionic-amd64&build=1)](https://build.osrfoundation.org/job/ros_gazebo11_pkgs-install_pkg_melodic-bionic-amd64/1/)

Part of issue https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1088