### PR TITLE
👩‍🌾 Add 'default' jobs for extra gazebo_ros versions

### DIFF
--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -214,6 +214,16 @@ void include_common_params(Job gazebo_ros_pkgs_job,
                                               branch,
                                               gz_version,
                                               "gazebo_ros_pkgs-compilation")
+
+          // --------------------------------------------------------------
+          // 3.2 Extra default ci jobs
+          def default_ci_job_name = "${name_prefix}_gazebo${gz_version}_pkgs-ci-default_$suffix_triplet"
+          Job ci_pr_job = create_common_compilation(default_ci_job_name,
+                                              ubuntu_distro,
+                                              ros_distro,
+                                              gz_version,
+                                              "gazebo_ros_pkgs-compilation")
+
         }
       } // end of gazebo_versions
 

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -23,8 +23,12 @@ extra_gazebo_versions = [ 'kinetic' :  ['8','9'],
 bloom_debbuild_jobs = [ 'gazebo-dev', 'gazebo-msgs', 'gazebo-plugins', 'gazebo-ros', 'gazebo-ros-control', 'gazebo-ros-pkgs' ]
 
 String get_branch_from_rosdistro(ros_distro) {
-  if (ros_distro == current_ros2_branch)
-    return "ros2"
+  // ROS2 branches are named without the -devel postfix
+  if (ros2_distros.contains(ros_distro))
+    if (ros_distro == current_ros2_branch)
+      return "ros2"
+    else
+      return ros_distro
 
   return "${ros_distro}-devel"
 }

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -22,11 +22,18 @@ extra_gazebo_versions = [ 'kinetic' :  ['8','9'],
 
 bloom_debbuild_jobs = [ 'gazebo-dev', 'gazebo-msgs', 'gazebo-plugins', 'gazebo-ros', 'gazebo-ros-control', 'gazebo-ros-pkgs' ]
 
-Job create_common_compilation(String job_name,
-                              String ubuntu_distro,
-                              String ros_branch,
-                              String gz_version,
-                              String script_name)
+String get_branch_from_rosdistro(ros_distro) {
+  if (ros_distro == current_ros2_branch)
+    return "ros2"
+
+  return "${ros_distro}-devel"
+}
+
+Job create_pr_compilation(String job_name,
+                          String ubuntu_distro,
+                          String ros_distro,
+                          String gz_version,
+                          String script_name)
 {
    def comp_job = job(job_name)
 
@@ -34,14 +41,42 @@ Job create_common_compilation(String job_name,
                                         "ros-simulation/gazebo_ros_pkgs",
                                         ENABLE_TESTS,
                                         DISABLE_CPPCHECK,
-                                        [ "${ros_branch}" ])
+                                        [ get_branch_from_rosdistro(ros_distro) ])
    include_common_params(comp_job,
                          ubuntu_distro,
-                         ros_branch,
+                         ros_distro,
                          gz_version,
                          script_name)
    return comp_job
 }
+
+Job create_ci_compilation(String job_name,
+                          String ubuntu_distro,
+                          String ros_distro,
+                          String gz_version,
+                          String script_name)
+{
+    def default_ci_job = job(job_name)
+    OSRFLinuxCompilation.create(default_ci_job, ENABLE_TESTS, DISABLE_CPPCHECK)
+    OSRFGitHub.create(default_ci_job,
+                      "ros-simulation/gazebo_ros_pkgs",
+                      get_branch_from_rosdistro(ros_distro))
+    include_common_params(default_ci_job,
+                          ubuntu_distro,
+                          ros_distro,
+                          gz_version,
+                          script_name)
+
+    default_ci_job.with
+    {
+      triggers {
+        scm('*/5 * * * *')
+      }
+    }
+
+    return default_ci_job
+}
+
 
 void include_common_params(Job gazebo_ros_pkgs_job,
                            String ubuntu_distro,
@@ -98,53 +133,26 @@ void include_common_params(Job gazebo_ros_pkgs_job,
     suffix_triplet="${ros_distro}-${ubuntu_distro}-${ci_arch}"
 
     if (ros2_distros.contains(ros_distro)) {
-      branch = ros_distro
-      // leave the check here for the time of final testing of
-      // current_ros2_branch
-      if (ros_distro == current_ros2_branch)
-        branch = "ros2"
-      ros2_str = "export ROS2=true"
       name_prefix = "ros2"
     } else {
-      branch = "${ros_distro}-devel"
-      ros2_str = "export ROS2=false"
       name_prefix = "ros"
     }
 
     // --------------------------------------------------------------
     // 1. Create the default ci jobs (using ros-shadow-fixed by default)
-    def default_ci_job = job("${name_prefix}_gazebo_pkgs-ci-default_$suffix_triplet")
-    // Enable testing but not cppcheck
-    OSRFLinuxCompilation.create(default_ci_job, true, false)
-    OSRFGitHub.create(default_ci_job, "ros-simulation/gazebo_ros_pkgs", branch)
-    default_ci_job.with
-    {
-      label "gpu-reliable"
-
-      triggers {
-        scm('*/5 * * * *')
-      }
-
-      steps {
-        shell("""\
-              #!/bin/bash -xe
-
-              export ENABLE_ROS=true
-              ${ros2_str}
-              export ROS_DISTRO=${ros_distro}
-              export DISTRO=${ubuntu_distro}
-              export ARCH=${ci_arch}
-              /bin/bash -xe ./scripts/jenkins-scripts/docker/gazebo_ros_pkgs-compilation.bash
-              """.stripIndent())
-      }
-    }
+    def default_ci_job_name = "${name_prefix}_gazebo_pkgs-ci-default_$suffix_triplet"
+    Job default_ci_job = create_ci_compilation(default_ci_job_name,
+                                               ubuntu_distro,
+                                               ros_distro,
+                                               "default",
+                                               "gazebo_ros_pkgs-compilation")
 
     // --------------------------------------------------------------
     // 2. Create the default ci pr-any jobs
     def any_job_name = "${name_prefix}_gazebo_pkgs-ci-pr_any_${suffix_triplet}"
-    Job any_job = create_common_compilation(any_job_name,
+    Job any_job = create_pr_compilation(any_job_name,
                                             ubuntu_distro,
-                                            branch,
+                                            ros_distro,
                                             "default",
                                             "gazebo_ros_pkgs-compilation")
 
@@ -209,21 +217,20 @@ void include_common_params(Job gazebo_ros_pkgs_job,
           // --------------------------------------------------------------
           // 2.2 Extra ci pr-any jobs
           def ci_pr_job_name = "${name_prefix}_gazebo${gz_version}_pkgs-ci-pr_any_${suffix_triplet}"
-          Job ci_pr_job = create_common_compilation(ci_pr_job_name,
-                                              ubuntu_distro,
-                                              branch,
-                                              gz_version,
-                                              "gazebo_ros_pkgs-compilation")
+          Job ci_pr_job = create_pr_compilation(ci_pr_job_name,
+                                                ubuntu_distro,
+                                                ros_distro,
+                                                gz_version,
+                                                "gazebo_ros_pkgs-compilation")
 
           // --------------------------------------------------------------
           // 3.2 Extra default ci jobs
-          def default_ci_job_name = "${name_prefix}_gazebo${gz_version}_pkgs-ci-default_$suffix_triplet"
-          Job ci_pr_job = create_common_compilation(default_ci_job_name,
-                                              ubuntu_distro,
-                                              ros_distro,
-                                              gz_version,
-                                              "gazebo_ros_pkgs-compilation")
-
+          def extra_ci_job_name = "${name_prefix}_gazebo${gz_version}_pkgs-ci-default_$suffix_triplet"
+          Job extra_ci_job = create_ci_compilation(extra_ci_job_name,
+                                                   ubuntu_distro,
+                                                   ros_distro,
+                                                   gz_version,
+                                                   "gazebo_ros_pkgs-compilation")
         }
       } // end of gazebo_versions
 
@@ -232,11 +239,11 @@ void include_common_params(Job gazebo_ros_pkgs_job,
         // --------------------------------------------------------------
         // 2. Create the regressions ci pr-any jobs
         def regression_job_name = "${name_prefix}_gazebo_pkgs-ci-pr_regression_any_${suffix_triplet}"
-        Job regression_job = create_common_compilation(regression_job_name,
-                                                       ubuntu_distro,
-                                                       branch,
-                                                       "default",
-                                                       "gazebo_ros_pkgs-compilation_regression")
+        Job regression_job = create_pr_compilation(regression_job_name,
+                                                   ubuntu_distro,
+                                                   ros_distro,
+                                                   "default",
+                                                   "gazebo_ros_pkgs-compilation_regression")
         // No melodic-devel branch in third party testing (yet)
         if (ros_distro == 'melodic')
         {


### PR DESCRIPTION
The intention is to create "default" jobs for non-official gazebo-ros combinations, for example:

`ros_gazebo9_pkgs-ci-default_kinetic-xenial-amd64`

That should use:

* `gazebo_ros_pkgs`'s `kinetic-devel` branch
* Gazebo9 debs
* Kinetic debs

I just copied the definition of the equivalent `pr_any` jobs. The intention is that we periodically trigger the new ones so that this job's result reflects the default status without any pull request interference. My main goal is to get a meaningful badge :smile: 

In the future, it would be nice for these to be automatically triggered whenever something new is merged into the release branch, but I didn't look into how to enable that.

