### PR TITLE
Ubuntu CI: install both sdf8/9 for physics

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -659,6 +659,7 @@ IGN_PHYSICS_DEPENDENCIES="libbenchmark-dev \\
                           libignition-math6-dev \\
                           libignition-math6-eigen3-dev \\
                           libignition-plugin-dev \\
+                          libsdformat9-dev \\
                           libsdformat8-dev"
 IGN_PHYSICS_DART_FROM_PKGS="true"
 


### PR DESCRIPTION
@azeey noticed that we weren't installing sdformat9 in our Ubuntu CI:

* https://github.com/ignitionrobotics/ign-physics/pull/54#issuecomment-625319079