### PR TITLE
Install only one sdf dep for ign-physics

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -662,7 +662,7 @@ IGN_PHYSICS_DEPENDENCIES="libbenchmark-dev \\
 if [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 2 ]]; then
   IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
                             libsdformat9-dev"
-elif [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 1 ]]; then
+elif [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -eq 1 ]]; then
   IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
                             libsdformat8-dev"
 fi

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -658,9 +658,14 @@ IGN_PHYSICS_DEPENDENCIES="libbenchmark-dev \\
                           libignition-common3-dev \\
                           libignition-math6-dev \\
                           libignition-math6-eigen3-dev \\
-                          libignition-plugin-dev \\
-                          libsdformat9-dev \\
-                          libsdformat8-dev"
+                          libignition-plugin-dev"
+if [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 2 ]]; then
+  IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
+                            libsdformat9-dev"
+elif [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 1 ]]; then
+  IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
+                            libsdformat8-dev"
+fi
 IGN_PHYSICS_DART_FROM_PKGS="true"
 
 IGN_PLUGIN_DEPENDENCIES="libignition-cmake1-dev"


### PR DESCRIPTION
Follow-up to this comment ( https://github.com/ignition-tooling/release-tools/pull/194#discussion_r421742541 )from @j-rivero who correctly noted that the approach in #194 was a bit messy. The more precise approach is to install only one version of sdformat depending on the major version of ign-physics.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics1-bionic-amd64&build=44)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics1-bionic-amd64/44/) https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics1-bionic-amd64/44/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics2-bionic-amd64&build=21)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics2-bionic-amd64/21/) https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics2-bionic-amd64/21/