### PR TITLE
brew bottle build: fetch test-bot branch instead of pull

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -34,7 +34,9 @@ echo '# BEGIN SECTION: run test-bot'
 export HOMEBREW_DEVELOPER=1
 brew tap homebrew/test-bot
 git -C $(brew --repo)/Library/Taps/homebrew/homebrew-test-bot \
-    pull ${TEST_BOT_REPO} ${TEST_BOT_BRANCH}
+    fetch ${TEST_BOT_REPO} ${TEST_BOT_BRANCH}
+git -C $(brew --repo)/Library/Taps/homebrew/homebrew-test-bot \
+    checkout FETCH_HEAD
 brew test-bot --tap=osrf/simulation \
               --root-url=https://osrf-distributions.s3.amazonaws.com/bottles-simulation \
               --ci-pr ${PULL_REQUEST_URL} \


### PR DESCRIPTION
As I noted in https://github.com/osrf/homebrew-simulation/issues/1005#issuecomment-626047465, [homebrew-test-bot](https://github.com/Homebrew/homebrew-test-bot) has changed a lot recently, and our bottle build script no longer works with the master branch of that repo. We have the ability to use custom branches of `homebrew-test-bot`, but it currently uses `git pull`, which can only merge commits into the current branch; it can't rewind to an old state. So this PR changes the `git pull` to a `git fetch` and `git checkout`. I used it successfully with https://github.com/osrf/homebrew-simulation/pull/1006.