### PR TITLE
Use still_working branch of test-bot

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -157,9 +157,9 @@ bottle_job_builder.with
    {
      stringParam("PULL_REQUEST_URL", '',
                  'Pull request URL (osrf/homebrew-simulation) pointing to a pull request.')
-     stringParam("TEST_BOT_REPO", 'https://github.com/homebrew/homebrew-test-bot.git',
+     stringParam("TEST_BOT_REPO", 'https://github.com/scpeters/homebrew-test-bot.git',
                  'Repository for fork of homebrew/homebrew-test-bot.')
-     stringParam("TEST_BOT_BRANCH", 'master',
+     stringParam("TEST_BOT_BRANCH", 'still_working',
                  'Branch of homebrew-test-bot repository to use.')
    }
 


### PR DESCRIPTION
The master branch has breaking changes, so use the `still_working` branch from my fork until they have been resolved. I've been manually restarting these jobs with these parameters (most recently https://github.com/osrf/homebrew-simulation/pull/1009 ), so let's just automate it for now.

* homebrew:master: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_bottle_builder&build=774)](https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/774/) https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/774/parameters/
* scpeters:still_working: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_bottle_builder&build=777)](https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/777/) https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/777/parameters/

This is a sequel to #199.