### PR TITLE
brew: decode bottle filename as URI.

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -56,7 +56,7 @@ for j in $(ls *.bottle.json); do
   SRC_BOTTLE=$(brew ruby -e \
     "puts JSON.load(IO.read(\"${j}\")).values[0]['bottle']['tags'].values[0]['local_filename']")
   DEST_BOTTLE=$(brew ruby -e \
-    "puts JSON.load(IO.read(\"${j}\")).values[0]['bottle']['tags'].values[0]['filename']")
+    "puts URI.decode(JSON.load(IO.read(\"${j}\")).values[0]['bottle']['tags'].values[0]['filename'])")
   mv ${SRC_BOTTLE} ${DEST_BOTTLE}
 done
 mv *.bottle*.tar.gz ${PKG_DIR}


### PR DESCRIPTION
I noticed that the dartsim@6.10.0 bottle filename had changed the `@` character to `%40` before upload to s3, which caused it to fail to download during `brew install dartsim@6.10.0` (see the build artifacts in https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/830/label=osx_highsierra/ ).

This is caused by https://github.com/Homebrew/brew/pull/7532 which encodes the filename in json. This PR decodes it, which should fix the problem.
