### PR TITLE
Add BUILDSYSTEM_TESTING flag to enable ign-cmake

### DIFF
--- a/jenkins-scripts/docker/ign_cmake-compilation.bash
+++ b/jenkins-scripts/docker/ign_cmake-compilation.bash
@@ -17,6 +17,9 @@ fi
 export BUILDING_SOFTWARE_DIRECTORY="ign-cmake"
 export BUILDING_DEPENDENCIES="pkg-config"
 
+# Enable long-running ign-cmake tests in CI.
+export BUILDING_EXTRA_CMAKE_PARAMS="-DBUILDSYSTEM_TESTING=True"
+
 # Identify IGN_CMAKE_MAJOR_VERSION to help with dependency resolution
 IGN_CMAKE_MAJOR_VERSION=$(\
   python ${SCRIPT_DIR}/../tools/detect_cmake_major_version.py \

--- a/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
@@ -4,4 +4,6 @@ set VCS_DIRECTORY=ign-cmake
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
+set EXTRA_CMAKE_TEST_ARGS=-DBUILDSYSTEM_TESTING:BOOL=True
+
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/lib/generic-default-devel-windows.bat
+++ b/jenkins-scripts/lib/generic-default-devel-windows.bat
@@ -6,6 +6,7 @@
 ::   - DEPEN_PKGS    : (optional) list of dependencies (separted by spaces)
 ::   - KEEP_WORKSPACE: (optional) true | false. Clean workspace at the end
 ::   - ENABLE_TESTS  : (optional) true | false. Do not compile and run tests 
+::   - EXTRA_CMAKE_TEST_ARGS : (optional) empty. String with cmake args to pass to testing step
 ::
 :: Actions
 ::   - Configure the compiler
@@ -82,7 +83,7 @@ if exist .\configure.bat (
 )
 
 :: We want to make sure that tests are enabled for this project's build
-cmake .. -DBUILD_TESTING:BOOL=%ENABLE_TESTS% -DBUILDSYSTEM_TESTING:BOOL=%ENABLE_TESTS% || echo "Second run of cmake (for enabling the tests) failed"
+cmake .. -DBUILD_TESTING:BOOL=%ENABLE_TESTS% %EXTRA_CMAKE_TEST_ARGS% || echo "Second run of cmake (for enabling the tests) failed"
 echo # END SECTION
 
 echo # BEGIN SECTION: Compiling %VCS_DIRECTORY%

--- a/jenkins-scripts/lib/generic-default-devel-windows.bat
+++ b/jenkins-scripts/lib/generic-default-devel-windows.bat
@@ -82,7 +82,7 @@ if exist .\configure.bat (
 )
 
 :: We want to make sure that tests are enabled for this project's build
-cmake .. -DBUILD_TESTING:BOOL=%ENABLE_TESTS% || echo "Second run of cmake (for enabling the tests) failed"
+cmake .. -DBUILD_TESTING:BOOL=%ENABLE_TESTS% -DBUILDSYSTEM_TESTING:BOOL=%ENABLE_TESTS% || echo "Second run of cmake (for enabling the tests) failed"
 echo # END SECTION
 
 echo # BEGIN SECTION: Compiling %VCS_DIRECTORY%


### PR DESCRIPTION
In support of ignitionrobotics/ign-cmake#97

Signed-off-by: Michael Carroll <michael@openrobotics.org>