### PR TITLE
ignition.dsl: stop CI for ign-rendering0

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -38,7 +38,7 @@ ignition_branches           = [ 'cmake'      : [ '1', '2' ],
                                 'msgs'       : [ '1', '2', '4', '5' ],
                                 'physics'    : [ '1', '2' ],
                                 'plugin'     : [ '0', '1' ],
-                                'rendering'  : [ '0', '2', '3' ],
+                                'rendering'  : [ '2', '3' ],
                                 'sensors'    : [ '2', '3' ],
                                 'transport'  : [ '4', '5', '7', '8' ],
                                 'tools'      : [ '0', '1' ]]


### PR DESCRIPTION
This package is no longer used by delphyne or anything else,
so we can stop running its CI jobs.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>