### PR TITLE
brew dsl: add parameters for brew branch and repo

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -157,6 +157,10 @@ bottle_job_builder.with
    {
      stringParam("PULL_REQUEST_URL", '',
                  'Pull request URL (osrf/homebrew-simulation) pointing to a pull request.')
+     stringParam("BREW_REPO", 'https://github.com/scpeters/brew.git',
+                 'Repository for fork of homebrew/brew.')
+     stringParam("BREW_BRANCH", 'still_working',
+                 'Branch of brew repository to use.')
      stringParam("TEST_BOT_REPO", 'https://github.com/scpeters/homebrew-test-bot.git',
                  'Repository for fork of homebrew/homebrew-test-bot.')
      stringParam("TEST_BOT_BRANCH", 'still_working',

--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -37,6 +37,10 @@ git -C $(brew --repo)/Library/Taps/homebrew/homebrew-test-bot \
     fetch ${TEST_BOT_REPO} ${TEST_BOT_BRANCH}
 git -C $(brew --repo)/Library/Taps/homebrew/homebrew-test-bot \
     checkout FETCH_HEAD
+
+git -C $(brew --repo) fetch ${BREW_REPO} ${BREW_BRANCH}
+git -C $(brew --repo) checkout FETCH_HEAD
+
 brew test-bot --tap=osrf/simulation \
               --root-url=https://osrf-distributions.s3.amazonaws.com/bottles-simulation \
               --ci-pr ${PULL_REQUEST_URL} \


### PR DESCRIPTION
Add `BREW_REPO` and `BREW_BRANCH` parameters to use in bottle builds
and default to still_working branch of scpeters/brew. This is needed since https://github.com/Homebrew/brew/pull/7700 broke our `still_working` branch of homebrew-test-bot.

Next week I'll try to update our workflow so we don't depend on old branches, but protobuf seems to break our bottles every week, so I'm just doing this to unbreak the bottles for now in https://github.com/osrf/homebrew-simulation/pull/1043.