### PR TITLE
Replace more bitbucket urls with github

### DIFF
--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -1,9 +1,9 @@
 GAZEBO_RUNTIME_TEST="""
 echo '# BEGIN SECTION: test the script'
-wget -P /tmp/ https://bitbucket.org/osrf/gazebo_models/get/default.tar.gz
+wget -P /tmp/ https://github.com/osrf/gazebo_models/archive/master.tar.gz
 mkdir -p ~/.gazebo/models
-tar -xvf /tmp/default.tar.gz -C ~/.gazebo/models --strip 1
-rm /tmp/default.tar.gz
+tar -xvf /tmp/master.tar.gz -C ~/.gazebo/models --strip 1
+rm /tmp/master.tar.gz
 
 TEST_START=\`date +%s\`
 timeout --preserve-status 180 gazebo --verbose || true
@@ -18,10 +18,10 @@ echo '# END SECTION'
 """
 
 GAZEBO_MODEL_INSTALLATION="""
-wget -q https://bitbucket.org/osrf/gazebo_models/get/default.tar.gz -O /tmp/default.tar.gz
+wget -q https://github.com/osrf/gazebo_models/archive/master.tar.gz -O /tmp/master.tar.gz
 mkdir -p ~/.gazebo/models
-tar -xf /tmp/default.tar.gz -C ~/.gazebo/models --strip 1 >/dev/null 2>&1
-rm /tmp/default.tar.gz"""
+tar -xf /tmp/master.tar.gz -C ~/.gazebo/models --strip 1 >/dev/null 2>&1
+rm /tmp/master.tar.gz"""
 
 IGN_GAZEBO_RUNTIME_TEST="""
 echo '# BEGIN SECTION: test the script'

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -75,8 +75,8 @@ if [ -z ${ENABLE_REAPER} ]; then
 fi
 
 # We use ignitionsrobotics or osrf. osrf by default
-if [ -Z ${BITBUCKET_REPO} ]; then
-    BITBUCKET_REPO="osrf"
+if [ -Z ${GITHUB_ORG} ]; then
+    GITHUB_ORG="osrf"
 fi
 
 # By default, do not need to use C++11 compiler

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -40,7 +40,7 @@ if ${NIGHTLY_MODE}; then
   if ${USE_REPO_DIRECTORY_FOR_NIGHTLY}; then
     mv ${WORKSPACE}/repo \$REAL_PACKAGE_NAME
   else
-    hg clone https://bitbucket.org/${BITBUCKET_REPO}/\$REAL_PACKAGE_NAME -r ${NIGHTLY_SRC_BRANCH}
+    git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -r ${NIGHTLY_SRC_BRANCH}
   fi
   PACKAGE_SRC_BUILD_DIR=\$REAL_PACKAGE_NAME
   cd \$REAL_PACKAGE_NAME

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -406,7 +406,7 @@ fi
 
 cat >> Dockerfile << DELIM_WORKAROUND_91
 # Workaround to issue:
-# https://bitbucket.org/osrf/handsim/issue/91
+# https://github.com/osrf/handsim/issue/91
 RUN echo "en_GB.utf8 UTF-8" >> /etc/locale.gen
 RUN locale-gen en_GB.utf8
 ENV LC_ALL en_GB.utf8

--- a/jenkins-scripts/docker/lib/eigen-abi-checker.bash
+++ b/jenkins-scripts/docker/lib/eigen-abi-checker.bash
@@ -21,7 +21,7 @@ set -ex
 echo '# BEGIN SECTION: compile and install eigen 3.3.3 commit'
 mkdir  /tmp/eigen333
 cd /tmp/eigen333
-hg clone https://bitbucket.org/eigen/eigen/
+git clone https://gitlab.com/libeigen/eigen
 cd eigen
 hg up 3.3.3
 

--- a/jenkins-scripts/docker/lib/eigen_pcl-abi-checker.bash
+++ b/jenkins-scripts/docker/lib/eigen_pcl-abi-checker.bash
@@ -43,7 +43,7 @@ echo '# BEGIN SECTION: replace system eigen for 3.3.3'
 apt-get remove -y .*eigen.*
 mkdir  /tmp/eigen333
 cd /tmp/eigen333
-hg clone https://bitbucket.org/eigen/eigen/
+git clone https://gitlab.com/libeigen/eigen
 cd eigen
 hg up 3.3.3
 mkdir build

--- a/jenkins-scripts/docker/lib/vrx-compilation-base.bash
+++ b/jenkins-scripts/docker/lib/vrx-compilation-base.bash
@@ -34,7 +34,7 @@ source ./install/setup.bash || true
 ${GAZEBO_MODEL_INSTALLATION}
 
 # we can not run smoke test due to problem with gazebo issue
-# https://bitbucket.org/osrf/gazebo/issues/2607/error-restcc-205-during-startup-gazebo
+# https://github.com/osrf/gazebo/issues/2607
 # Don't add the OSRF repo to workaround on this since it brings new versions of 
 # dependencies not avilable in the ros buildfarm
 # \${VRX_SMOKE_TEST}

--- a/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
+++ b/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
@@ -6,7 +6,7 @@ SCRIPT_DIR="${SCRIPT_DIR%/*}"
 
 export RELEASE_REPO_DIRECTORY=${DISTRO}
 export ENABLE_ROS=false
-export BITBUCKET_REPO=ignitionrobotics
+export GITHUB_ORG=ignitionrobotics
 export NEED_C11_COMPILER=true
 
 . ${SCRIPT_DIR}/lib/debbuild-base.bash

--- a/jenkins-scripts/docker/vrx-install-test-job.bash
+++ b/jenkins-scripts/docker/vrx-install-test-job.bash
@@ -15,7 +15,7 @@ ${VRX_SMOKE_TEST}
 
 export USE_ROS_REPO=true
 # OSRF repo is only used to workaround on issue 
-# https://bitbucket.org/osrf/gazebo/issues/2607/error-restcc-205-during-startup-gazebo
+# https://github.com/osrf/gazebo/issues/2607
 export OSRF_REPOS_TO_USE=stable
 
 . ${SCRIPT_DIR}/lib/generic-install-base.bash

--- a/jenkins-scripts/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/lib/boilerplate_prepare.sh
@@ -26,8 +26,8 @@ if [ -z ${ENABLE_REAPER} ]; then
 fi
 
 # We use ignitionsrobotics or osrf. osrf by default
-if [ -Z ${BITBUCKET_REPO} ]; then
-    BITBUCKET_REPO="osrf"
+if [ -Z ${GITHUB_ORG} ]; then
+    GITHUB_ORG="osrf"
 fi
 
 # By default, do not need to use C++11 compiler

--- a/jenkins-scripts/lib/debbuild-base.bash
+++ b/jenkins-scripts/lib/debbuild-base.bash
@@ -78,7 +78,7 @@ REAL_PACKAGE_NAME=$(echo $PACKAGE | sed 's:[0-9]*$::g')
 
 # Step 1: Get the source (nightly builds or tarball)
 if ${NIGHTLY_MODE}; then
-  hg clone https://bitbucket.org/${BITBUCKET_REPO}/\$REAL_PACKAGE_NAME -r default
+  git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -r default
   PACKAGE_SRC_BUILD_DIR=\$REAL_PACKAGE_NAME
   cd \$REAL_PACKAGE_NAME
   # Store revision for use in version

--- a/jenkins-scripts/multidistribution-ignition-debbuild.bash
+++ b/jenkins-scripts/multidistribution-ignition-debbuild.bash
@@ -7,7 +7,7 @@ SCRIPT_DIR="${SCRIPT_DIR%/*}"
 export RELEASE_REPO_DIRECTORY=${DISTRO}
 export ENABLE_ROS=false
 export WORKAROUND_PBUILDER_BUG=true
-export BITBUCKET_REPO=ignitionrobotics
+export GITHUB_ORG=ignitionrobotics
 export NEED_C11_COMPILER=true
 
 . ${SCRIPT_DIR}/lib/debbuild-base.bash

--- a/one-line-installations/gazebo.sh
+++ b/one-line-installations/gazebo.sh
@@ -313,7 +313,7 @@ do_install() {
 	cat >&2 <<-'EOF_END'
 
 	Either your platform is not easily detectable, is not supported by this
-	installer script (yet - PRs welcome! [https://bitbucket.org/osrf/release-tools])
+	installer script (yet - PRs welcome! [https://github.com/ignition-tooling/release-tools])
     or does not yet have a package for gazebo.  Please visit the following URL for more detailed
 	installation instructions:
 


### PR DESCRIPTION
I grepped for `://bitbucket` to see which files are still using bitbucket URL's, and I've replaced many of them. Two commits change URL's in comments, and one changes a URL for eigen's ABI-checking jobs. The more consequential changes are in 3aed217, which fetches the gazebo_models tarball from GitHub now, and 06ce0dd, which clones from GitHub for nightly builds.