### PR TITLE
Disable github integration in gazebo+sdformat+ignition

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -14,7 +14,8 @@ class GenericAnyJobGitHub
 {
    static void create(Job job,
                      String github_repo,
-                     ArrayList supported_branches = [])
+                     ArrayList supported_branches = [],
+                     boolean enable_github_pr_integration = true)
    {
      // setup special mail subject
      GenericMail.update_field(job, 'defaultSubject',
@@ -53,30 +54,32 @@ class GenericAnyJobGitHub
         }
       }
 
-      configure { project ->
-        project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
-            adminList 'osrf-jenkins j-rivero'
-            useGitHubHooks(true)
-            allowMembersOfWhitelistedOrgsAsAdmin(true)
-            useGitHubHooks(true)
-            onlyTriggerPhrase(false)
-            permitAll(true)
-            cron()
-            whiteListTargetBranches {
-              'org.jenkinsci.plugins.ghprb.GhprbBranch' {
-                 branch supported_branches.join(" ")
-              }
-            }
-            triggerPhrase '.*(re)?run test(s).*'
-            extensions {
-                'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus' {
-                  commitStatusContext '${JOB_NAME}'
-                  triggeredStatus 'starting deployment to build.osrfoundation.org'
-                  startedStatus 'deploying to build.osrfoundation.org'
+      if (enable_github_pr_integration) {
+        configure { project ->
+          project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
+              adminList 'osrf-jenkins j-rivero'
+              useGitHubHooks(true)
+              allowMembersOfWhitelistedOrgsAsAdmin(true)
+              useGitHubHooks(true)
+              onlyTriggerPhrase(false)
+              permitAll(true)
+              cron()
+              whiteListTargetBranches {
+                'org.jenkinsci.plugins.ghprb.GhprbBranch' {
+                   branch supported_branches.join(" ")
                 }
               }
-            }
+              triggerPhrase '.*(re)?run test(s).*'
+              extensions {
+                  'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus' {
+                    commitStatusContext '${JOB_NAME}'
+                    triggeredStatus 'starting deployment to build.osrfoundation.org'
+                    startedStatus 'deploying to build.osrfoundation.org'
+                  }
+              }
           }
+        }
+      }
     } // end of with
   } // end of create method
 }

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilationAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilationAnyGitHub.groovy
@@ -16,7 +16,8 @@ class OSRFLinuxCompilationAnyGitHub
                      String github_repo,
                      boolean enable_testing  = true,
                      boolean enable_cppcheck = true,
-                     ArrayList supported_branches = [])
+                     ArrayList supported_branches = [],
+                     boolean enable_github_pr_integration = true)
   {
     // Do not include description from LinuxBase since the github pull request
     // builder set its own
@@ -24,6 +25,6 @@ class OSRFLinuxCompilationAnyGitHub
     OSRFLinuxCompilation.create(job, enable_testing, enable_cppcheck)
     Globals.rtools_description = true
 
-    GenericAnyJobGitHub.create(job, github_repo, supported_branches)
+    GenericAnyJobGitHub.create(job, github_repo, supported_branches, enable_github_pr_integration)
   }
 } // end of class

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -24,6 +24,7 @@ def experimental_arches     = Globals.get_experimental_arches()
 def all_supported_gpus      = Globals.get_all_supported_gpus()
 
 def DISABLE_TESTS = false
+def DISABLE_GITHUB_INTEGRATION = false
 
 String ci_distro_default_str = ci_distro_default[0]
 String ci_distro_str = ci_distro[0]
@@ -288,7 +289,7 @@ ci_distro.each { distro ->
   supported_arches.each { arch ->
     ci_gpu.each { gpu ->
       def multi_any_job = job("gazebo-ci-pr_any+sdformat_any+ign_any-${distro}-${arch}-gpu-${gpu}")
-      OSRFLinuxCompilationAnyGitHub.create(multi_any_job, "osrf/gazebo")
+      OSRFLinuxCompilationAnyGitHub.create(multi_any_job, "osrf/gazebo", true, true, [], DISABLE_GITHUB_INTEGRATION)
       multi_any_job.with
       {
         parameters


### PR DESCRIPTION
Implement the support to generate jobs that can work with PR git references but they are not automatically integrated with github PRs. This is the case of the `gazebo-ci-pr_any+sdformat_any+ign_any-${distro}-${arch}-gpu-${gpu}` that should not appear in github notifications.