### PR TITLE
Fix git clone in nightly debbuilds

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -40,7 +40,7 @@ if ${NIGHTLY_MODE}; then
   if ${USE_REPO_DIRECTORY_FOR_NIGHTLY}; then
     mv ${WORKSPACE}/repo \$REAL_PACKAGE_NAME
   else
-    git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -r ${NIGHTLY_SRC_BRANCH}
+    git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -b ${NIGHTLY_SRC_BRANCH}
   fi
   PACKAGE_SRC_BUILD_DIR=\$REAL_PACKAGE_NAME
   cd \$REAL_PACKAGE_NAME

--- a/jenkins-scripts/lib/debbuild-base.bash
+++ b/jenkins-scripts/lib/debbuild-base.bash
@@ -78,7 +78,7 @@ REAL_PACKAGE_NAME=$(echo $PACKAGE | sed 's:[0-9]*$::g')
 
 # Step 1: Get the source (nightly builds or tarball)
 if ${NIGHTLY_MODE}; then
-  git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -r default
+  git clone https://github.com/${GITHUB_ORG}/\$REAL_PACKAGE_NAME -b default
   PACKAGE_SRC_BUILD_DIR=\$REAL_PACKAGE_NAME
   cd \$REAL_PACKAGE_NAME
   # Store revision for use in version


### PR DESCRIPTION
I broke all the nightly builds in #215.

Use "git clone -b" instead of "git clone -r".

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-transport7-debbuilder&build=489)](https://build.osrfoundation.org/view/debbuild/job/ign-transport7-debbuilder/489/) https://build.osrfoundation.org/view/debbuild/job/ign-transport7-debbuilder/489/

~~~
+ git clone https://github.com/ignitionrobotics/ign-transport -r ign-transport7
error: unknown switch `r'
~~~