### PR TITLE
ignition.dsl: disable some bottle install jobs

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -561,6 +561,17 @@ ignition_software.each { ign_sw ->
 
     install_default_job.with
     {
+      # disable some bottles
+      if (("${ign_sw}" == "cmake" && "${major_version}" == "1") ||
+          ("${ign_sw}" == "common" && "${major_version}" == "2") ||
+          ("${ign_sw}" == "fuel-tools" && "${major_version}" == "2") ||
+          ("${ign_sw}" == "gui" && "${major_version}" == "0") ||
+          ("${ign_sw}" == "math" && "${major_version}" == "5") ||
+          ("${ign_sw}" == "msgs" && "${major_version}" == "2") ||
+          ("${ign_sw}" == "rndf") ||
+          ("${ign_sw}" == "transport" && "${major_version}" == "5"))
+        disabled()
+
       triggers {
         cron('@daily')
       }

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -561,7 +561,7 @@ ignition_software.each { ign_sw ->
 
     install_default_job.with
     {
-      # disable some bottles
+      // disable some bottles
       if (("${ign_sw}" == "cmake" && "${major_version}" == "1") ||
           ("${ign_sw}" == "common" && "${major_version}" == "2") ||
           ("${ign_sw}" == "fuel-tools" && "${major_version}" == "2") ||


### PR DESCRIPTION
There are a few ignition packages that use ign-cmake1 that are needed for delphyne, but not on macOS, so disable the bottle install jobs for these packages since some of them are failing.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition&build=986)](https://build.osrfoundation.org/job/_dsl_ignition/986/) https://build.osrfoundation.org/job/_dsl_ignition/986/