### PR TITLE
Rename nightly suffix to fix problems with order between hg and git

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -54,7 +54,7 @@ if ${NIGHTLY_MODE}; then
     TIMESTAMP="git\$TIMESTAMP"
   elif [[ -d .git ]]; then
     REV=\$(git rev-parse HEAD)
-    TIMESTAMP="git\$TIMESTAMP"
+    TIMESTAMP="nightly+git\$TIMESTAMP"
   else
     REV=0
   fi


### PR DESCRIPTION
Since we change the VCS all +hg versions suffixes are having a greater version than new nightlies using +git. Proposed by @scpeters to use nightly to get the new ones to have greater versions (alpha order) than old +hg. 