### PR TITLE
Add report of testing to Github status

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -75,6 +75,7 @@ class GenericAnyJobGitHub
                     commitStatusContext '${JOB_NAME}'
                     triggeredStatus 'starting deployment to build.osrfoundation.org'
                     startedStatus 'deploying to build.osrfoundation.org'
+                    addTestResults(true)
                   }
               }
           }


### PR DESCRIPTION
I've looking into improve the Jenkins results published to github for cases where the build is not green but unstable. My findings are not very optimistic since the plugin is not maintained and seems to lack the ability to report Jenkins variables coming from warnings or even build status.

All I found is an option that comes with the plugin and report a summary of the testing run (see the bubble box, ignore the rest): ![image](https://user-images.githubusercontent.com/2098802/84543425-a8623a80-acfb-11ea-9195-bbc7b91d5d7b.png)

The only viable option I see to report more interesting things in Github statuses would be to add a post-build action against the github API, that would require far more work.

Test run for Gazebo seems happy https://build.osrfoundation.org/job/_dsl_gazebo_ros_pkgs/651/