### PR TITLE
dependencies_archive.sh: fix bash syntax

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -59,7 +59,7 @@ SDFORMAT_NO_IGN_DEPENDENCIES="${pythonv}     \\
                               libtinyxml-dev"
 
 # SDFORMAT 10 and above use tinyxml2
-if [[ ${SDFORMAT_MAJOR_VERSION} -ge 10]]; then
+if [[ ${SDFORMAT_MAJOR_VERSION} -ge 10 ]]; then
   SDFORMAT_NO_IGN_DEPENDENCIES="${SDFORMAT_NO_IGN_DEPENDENCIES} \\
                                 libtinyxml2-dev"
 fi


### PR DESCRIPTION
I just merged #220 but it has a syntax error:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_cmake-install-pkg-xenial-amd64&build=936)](https://build.osrfoundation.org/job/ignition_cmake-install-pkg-xenial-amd64/936/) https://build.osrfoundation.org/job/ignition_cmake-install-pkg-xenial-amd64/936/

~~~
./scripts/jenkins-scripts/docker/../lib/dependencies_archive.sh: line 62: syntax error in conditional expression: unexpected token `;'
~~~