### PR TITLE
Update copy artifact configuration with permissions

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBackportPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBackportPkg.groovy
@@ -32,6 +32,12 @@ class OSRFLinuxBackportPkg
         priority 300
       }
 
+      configure { project ->
+        project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
+          'string' 'repository_uploader_*'
+        }
+      }
+
       logRotator {
         artifactNumToKeep(20)
       }

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
@@ -112,6 +112,12 @@ class OSRFLinuxBuildPkg
 	  }
         }
       }
+
+      configure { project ->
+        project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
+          'string' 'repository_uploader_*'
+        }
+      }
     } // end of job
   } // end of method createJob
 } // end of class

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -187,6 +187,12 @@ bottle_job_builder.with
               """.stripIndent())
    }
 
+   configure { project ->
+     project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
+      'string' "${bottle_hash_updater_job_name}"
+     }
+   }
+
    publishers {
      archiveArtifacts
      {

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -118,6 +118,12 @@ gbp_repo_debbuilds.each { software ->
         }
       }
 
+      configure { project ->
+        project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
+          'string' 'repository_uploader_*'
+        }
+      }
+
       postBuildScripts {
         steps {
           shell("""\

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -278,6 +278,12 @@ bloom_debbuild_jobs.each { bloom_pkg ->
         priority 100
       }
 
+      configure { project ->
+        project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
+          'string' 'repository_uploader_*'
+        }
+      }
+
       parameters {
         stringParam("PACKAGE","${bloom_pkg}","Package name to be built")
         stringParam("VERSION",null,"Packages version to be built")

--- a/jenkins-scripts/dsl/ros1_ign_bridge.dsl
+++ b/jenkins-scripts/dsl/ros1_ign_bridge.dsl
@@ -26,6 +26,12 @@ bridge_packages.each { pkg ->
       priority 100
     }
 
+    configure { project ->
+      project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
+        'string' 'repository_uploader_*'
+      }
+    }
+
     parameters {
       stringParam("PACKAGE","$pkg_dashed","Package name to be built")
         stringParam("VERSION",null,"Packages version to be built")


### PR DESCRIPTION
The copy artifact plugin we are using to copy generated binaries from one jobs to another (mainly pkgs -> repository uploader and brew bottles -> hash updater) has changed the behavior and [we need to make explicit which jobs are allowed to import the binaries]( https://github.com/jenkinsci/copyartifact-plugin#CopyArtifactPlugin-MigrationMode).

The DSL does not implement this option so I needed to inject code using the configure block. Tested in brew here: https://build.osrfoundation.org/job/_dsl_brew_release/435/console . The permission show up just fine if you open the job configuration.

Mental note: remind to change the working mode of the plugin from migration to production.