### PR TITLE
Do not use ~ (tilde) in git tags

### DIFF
--- a/release.py
+++ b/release.py
@@ -444,7 +444,8 @@ def generate_upload_tarball(args):
     os.chdir(sourcedir)
 
     try:
-        tag = '%s_%s'%(args.package_alias, args.version)
+        # tilde is not a valid character in git
+        tag = '%s_%s' % (args.package_alias, args.version.replace('~','-'))
         check_call(['git', 'tag', '-f', tag])
         check_call(['git', 'push', '--tags'])
     except ErrorNoPermsRepo as e:


### PR DESCRIPTION
Git does not support `~` in tag names. I'm changing it to use a `-` in repository tags. I don't think that we are using the tags for anything in release-tools, if that is correct we don't need to change anything more.