### PR TITLE
Migrate VRX, SubT and gzdev to Github

### DIFF
--- a/jenkins-scripts/dsl/gzdev.dsl
+++ b/jenkins-scripts/dsl/gzdev.dsl
@@ -31,9 +31,6 @@ supported_distros.each { distro ->
         }
       }
 
-      // use only the most powerful nodes
-      label "large-memory"
-
       triggers {
         scm('*/5 * * * *')
       }
@@ -53,27 +50,12 @@ supported_distros.each { distro ->
     // --------------------------------------------------------------
     // 3. Create the testing any job
     def gzdev_any_job = job("gzdev-ci-pr_any-${distro}-${arch}")
-    // Use stub to supply a fake bitbucket repository. It is overwritten by the
-    // git scm section below. False to disable testing.
-    OSRFLinuxCompilationAny.create(gzdev_any_job, "repo_stub", false, false)
+    OSRFLinuxCompilationAnyGitHub.create(gzdev_any_job, "osrf/gzdev", false, false)
 
     gzdev_any_job.with
     {
       // use only the most powerful nodes
       label "large-memory"
-
-      scm {
-        git {
-          remote {
-            github('osrf/gzdev', 'https')
-            branch('${SRC_BRANCH}')
-
-            extensions {
-              relativeTargetDirectory('gzdev')
-            }
-          }
-        }
-      }
 
       steps {
         shell("""\
@@ -88,6 +70,3 @@ supported_distros.each { distro ->
     }
   }
 }
-
-
-

--- a/jenkins-scripts/dsl/subt.dsl
+++ b/jenkins-scripts/dsl/subt.dsl
@@ -169,7 +169,7 @@ all_supported_distros.each { distro ->
         git {
           remote {
             github("osrf/subt", 'https')
-            branch('${BRANCH}')
+            branch('master')
           }
 
           extensions {

--- a/jenkins-scripts/dsl/subt.dsl
+++ b/jenkins-scripts/dsl/subt.dsl
@@ -88,9 +88,9 @@ ci_distro.each { distro ->
     // 2. Create the any job
     ci_build_any_job_name_linux = "subt-ci-pr_any-${distro}-${arch}"
     def subt_ci_any_job = job(ci_build_any_job_name_linux)
-    OSRFLinuxCompilationAny.create(subt_ci_any_job,
-                                  'https://bitbucket.org/osrf/subt',
-                                  ENABLE_TESTS, DISABLE_CPPCHECK)
+    OSRFLinuxCompilationAnyGitHub.create(subt_ci_any_job,
+                                        'osrf/subt',
+                                        ENABLE_TESTS, DISABLE_CPPCHECK)
     common_params_compilation_job(subt_ci_any_job, distro, arch)
 
     // --------------------------------------------------------------
@@ -124,7 +124,7 @@ ci_distro.each { distro ->
     // 4. Install subt cloudsim mirror
     def install_cloud_job = job("subt-install-cloudsim_mirror-${distro}-${arch}")
     OSRFLinuxCompilation.create(install_cloud_job, DISABLE_TESTS, DISABLE_CPPCHECK)
-    OSRFBitbucketHg.create(install_cloud_job, "https://bitbucket.org/osrf/subt")
+    OSRFGitHub.create(install_cloud_job, "osrf/subt")
     // the gazebo output displays errors on rendering. This seems a bug in the
     // infrastructure, ignore it by now. The rest of the build is still useful
     // to check
@@ -166,9 +166,17 @@ all_supported_distros.each { distro ->
     long_run_job.with
     {
       scm {
-        hg('https://bitbucket.org/osrf/subt') {
-          branch('default')
-          subdirectory('subt')
+        git {
+          remote {
+            github("osrf/subt", 'https')
+            branch('${BRANCH}')
+          }
+
+          extensions {
+            cleanBeforeCheckout()
+            relativeTargetDirectory('subt')
+          }
+
         }
       }
 
@@ -200,12 +208,14 @@ OSRFLinuxBuildPkg.create(build_pkg_job)
 build_pkg_job.with
 {
   scm {
-    hg("https://bitbucket.org/osrf/subt") {
-      branch('default')
-      installation('Default')
-      subdirectory('repo')
-      configure { project ->
-       project / browser(class: 'hudson.plugins.mercurial.browser.BitBucket') / "url" <<  "https://bitbucket.org/osrf/subt"
+    git {
+      remote {
+        github("osrf/subt", 'https')
+        branch('master')
+      }
+      extensions {
+        cleanBeforeCheckout()
+        relativeTargetDirectory('repo')
       }
     }
   }

--- a/jenkins-scripts/dsl/vrx.dsl
+++ b/jenkins-scripts/dsl/vrx.dsl
@@ -47,9 +47,15 @@ ci_distro.each { distro, ros_distro ->
     vrx_ci_job.with
     {
         scm {
-          hg('https://bitbucket.org/osrf/vrx') {
-            branch('default')
-            subdirectory('vrx')
+          git {
+            remote {
+              github("osrf/vrx", 'https')
+              branch('master')
+            }
+            extensions {
+              cleanBeforeCheckout()
+              relativeTargetDirectory('vrx')
+            }
           }
         }
 
@@ -73,9 +79,9 @@ ci_distro.each { distro, ros_distro ->
     // --------------------------------------------------------------
     // 2. Create the any job
     def vrx_ci_any_job = job("vrx-ci-pr_any_${ros_distro}-${distro}-${arch}")
-    OSRFLinuxCompilationAny.create(vrx_ci_any_job,
-                                  'https://bitbucket.org/osrf/vrx',
-                                  ENABLE_TESTS, DISABLE_CPPCHECK)
+    OSRFLinuxCompilationAnyGitHub.create(vrx_ci_any_job,
+                                        'osrf/vrx',
+                                        ENABLE_TESTS, DISABLE_CPPCHECK)
     // GPU label and parselog
     include_parselog(vrx_ci_any_job)
 


### PR DESCRIPTION
//cc @caguero , @nkoenig 

Migrate the VRX, Subt and gzdev CI code to use github. These should be the last projects we change to the new CI integration.