### PR TITLE
Integrate ABI jobs in Github

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -26,12 +26,6 @@ class GenericAnyJobGitHub
     // Get repo name for relativeTargetDirectory
     String github_repo_name = github_repo.substring(github_repo.lastIndexOf("/") + 1)
 
-    // Transform GStringImp into real string
-    ArrayList supported_branches_str = []
-    supported_branches.each { branch ->
-      supported_branches_str.add(branch.toString())
-    }
-
     job.with
     {
       parameters
@@ -65,8 +59,10 @@ class GenericAnyJobGitHub
               permitAll(true)
               cron()
               whiteListTargetBranches {
-                'org.jenkinsci.plugins.ghprb.GhprbBranch' {
-                   branch supported_branches.join(" ")
+                supported_branches.each { supported_branch ->
+                  'org.jenkinsci.plugins.ghprb.GhprbBranch' {
+                    branch supported_branch
+                  }
                 }
               }
               triggerPhrase '.*(re)?run test(s).*'

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -32,13 +32,13 @@ String get_sdformat_branch_name(String full_branch_name)
 
 // ABI Checker job
 // Need to be the before ci-pr_any so the abi job name is defined
+abi_branches = sdformat_supported_branches.collect { it -> get_sdformat_branch_name(it) }
 abi_distro.each { distro ->
   supported_arches.each { arch ->
     abi_job_name = "sdformat-abichecker-any_to_any-ubuntu_auto-${arch}"
     def abi_job = job(abi_job_name)
     OSRFLinuxABIGitHub.create(abi_job)
-    OSRFGitHub.create(abi_job, "osrf/sdformat",
-                               '${DEST_BRANCH}')
+    GenericAnyJobGitHub(abi_job, 'osrf/sdformat', abi_branches)
     abi_job.with
     {
       steps {
@@ -57,6 +57,10 @@ abi_distro.each { distro ->
               fi
 
               export ARCH=${arch}
+              export DEST_BRANCH=\${DEST_BRANCH:-\$ghprbTargetBranch}
+              export SRC_BRANCH=\${SRC_BRANCH:-\$ghprbSourceBranch}
+              export SRC_REPO=\${SRC_REPO:-\$ghprbAuthorRepoGitUrl}
+
               /bin/bash -xe ./scripts/jenkins-scripts/docker/sdformat-abichecker.bash
 	      """.stripIndent())
       } // end of steps
@@ -107,19 +111,6 @@ abi_distro.each { distro ->
            {
              not {
                expression('${ENV, var="ghprbTargetBranch"}', 'master')
-             }
-
-             steps {
-               downstreamParameterized {
-                 trigger("${abi_job_name}") {
-                   parameters {
-                     currentBuild()
-                     predefinedProp('DEST_BRANCH', '$ghprbTargetBranch')
-                     predefinedProp('SRC_BRANCH', '$ghprbSourceBranch')
-                     predefinedProp('SRC_REPO', '$ghprbAuthorRepoGitUrl')
-                   }
-                 }
-               }
              }
            }
          }

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -38,7 +38,7 @@ abi_distro.each { distro ->
     abi_job_name = "sdformat-abichecker-any_to_any-ubuntu_auto-${arch}"
     def abi_job = job(abi_job_name)
     OSRFLinuxABIGitHub.create(abi_job)
-    GenericAnyJobGitHub(abi_job, 'osrf/sdformat', abi_branches)
+    GenericAnyJobGitHub.create(abi_job, 'osrf/sdformat', abi_branches)
     abi_job.with
     {
       steps {


### PR DESCRIPTION
The pull request change how ABI jobs are triggered:
  * Before, it was a conditional step in compilation jobs if target branch was different than master
  * After: the abi job integrates itself in github calls only if the target branch is a supported branch (major version branches)

I'm leaving the same parameters as before to be able to run builds manually in the same way.

**Testing:**

Be careful to run dsl changes on Jenkins since they will affect production code. I've used my fork to check:
 * Test PR with ABI breaking against sdf9 https://github.com/j-rivero/sdformat/pull/1
 * Test PR with no ABI breaking changes in sdf8 https://github.com/j-rivero/sdformat/pull/2

All DSL runs fine on my local system and the produced xml for branches seems fine to me.

Closes #191 