### PR TITLE
Fix ABI jobs integration on ignition CI

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -51,7 +51,8 @@ class GenericAnyJobGitHub
       if (enable_github_pr_integration) {
         configure { project ->
           project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
-              adminList 'osrf-jenkins j-rivero'
+              adminlist 'osrf-jenkins j-rivero'
+              orgslist 'osrf'
               useGitHubHooks(true)
               allowMembersOfWhitelistedOrgsAsAdmin(true)
               useGitHubHooks(true)

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxABIGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxABIGitHub.groovy
@@ -17,12 +17,6 @@ import javaposse.jobdsl.dsl.Job
 
 class OSRFLinuxABIGitHub
 {
-  static void create(Job job, String repo)
-  {
-    OSRFLinuxABIGitHub.create(job)
-    OSRFGitHub.create(job, repo, '${DEST_BRANCH}')
-  }
-
   static void create(Job job)
   {
     OSRFLinuxBase.create(job)

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -222,9 +222,9 @@ ignition_software.each { ign_sw ->
       abi_job_names[ign_sw] = "ignition_${ign_sw}-abichecker-any_to_any-ubuntu_auto-${arch}"
       def abi_job = job(abi_job_names[ign_sw])
       checkout_subdir = "ign-${ign_sw}"
-      OSRFLinuxABIGitHub.create(abi_job, checkout_subdir)
-      GenericAnyJobGitHub.create(abi_job,
-                        "ignitionrobotics/ign-${ign_sw}",
+      repo = "ignitionrobotics/ign-${ign_sw}"
+      OSRFLinuxABIGitHub.create(abi_job, repo)
+      GenericAnyJobGitHub.create(abi_job, repo,
                         all_branches(ign_sw) - [ 'master'])
       abi_job.with
       {

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -222,9 +222,9 @@ ignition_software.each { ign_sw ->
       abi_job_names[ign_sw] = "ignition_${ign_sw}-abichecker-any_to_any-ubuntu_auto-${arch}"
       def abi_job = job(abi_job_names[ign_sw])
       checkout_subdir = "ign-${ign_sw}"
-      repo = "ignitionrobotics/ign-${ign_sw}"
-      OSRFLinuxABIGitHub.create(abi_job, repo)
-      GenericAnyJobGitHub.create(abi_job, repo,
+      OSRFLinuxABIGitHub.create(abi_job)
+      GenericAnyJobGitHub.create(abi_job,
+                        "ignitionrobotics/ign-${ign_sw}",
                         all_branches(ign_sw) - [ 'master'])
       abi_job.with
       {


### PR DESCRIPTION
There was a mistake in a parameter when calling `OSRFLinuxABIGitHub` using checkout subir instead of repository qualified name. This PR should fix the problem and also add correct XML tags for permissions. 