### PR TITLE
Workaround for missing pip3 on brew

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -78,7 +78,11 @@ fi
 
 if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   brew install python
-  pip3 install ${PIP_PACKAGES_NEEDED}
+  PIP=pip3
+  if ! which ${PIP}
+    PIP=/usr/local/opt/python/bin/pip3
+  fi
+  ${PIP} install ${PIP_PACKAGES_NEEDED}
 fi
 
 if [[ -z "${DISABLE_CCACHE}" ]]; then

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -79,7 +79,7 @@ fi
 if [[ -n "${PIP_PACKAGES_NEEDED}" ]]; then
   brew install python
   PIP=pip3
-  if ! which ${PIP}
+  if ! which ${PIP}; then
     PIP=/usr/local/opt/python/bin/pip3
   fi
   ${PIP} install ${PIP_PACKAGES_NEEDED}


### PR DESCRIPTION
Provide direct path to pip3 in case it is not linked to `/usr/local/bin`
Workaround until the following is merged:
https://github.com/Homebrew/homebrew-core/pull/57654

All gazebo brew builds are failing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-pr_any-homebrew-amd64&build=1993)](https://build.osrfoundation.org/job/gazebo-ci-pr_any-homebrew-amd64/1993/) https://build.osrfoundation.org/job/gazebo-ci-pr_any-homebrew-amd64/1993/