### PR TITLE
Run vcs pull after vcs import to get latest changes

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -145,7 +145,8 @@ if "%GAZEBODISTRO_BRANCH%" == "" (set GAZEBODISTRO_BRANCH=master)
 
 if exist %gzdistro_dir% (rmdir /s /q %gzdistro_dir%)
 git clone https://github.com/ignition-tooling/gazebodistro %gzdistro_dir% -b %GAZEBODISTRO_BRANCH%
-vcs import --force --retry 5  < "%gzdistro_dir%\%1" "%2" || goto :error
+vcs import --retry 5  < "%gzdistro_dir%\%1" "%2" || goto :error
+vcs pull || goto :error
 goto :EOF
 
 :: ##################################

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -145,7 +145,7 @@ if "%GAZEBODISTRO_BRANCH%" == "" (set GAZEBODISTRO_BRANCH=master)
 
 if exist %gzdistro_dir% (rmdir /s /q %gzdistro_dir%)
 git clone https://github.com/ignition-tooling/gazebodistro %gzdistro_dir% -b %GAZEBODISTRO_BRANCH%
-vcs import --retry 5  < "%gzdistro_dir%\%1" "%2" || goto :error
+vcs import --force --retry 5  < "%gzdistro_dir%\%1" "%2" || goto :error
 goto :EOF
 
 :: ##################################


### PR DESCRIPTION
While testing some changes in ign-cmake I realize that the CI job preserve the workspace and `vcs import` does not update the checkout directories if they exists. Adding a `vcs pull` updates all repositories to latest commits.

Testing it here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_gui-pr-win&build=328)](https://build.osrfoundation.org/view/All/job/ign_gui-pr-win/328/)