### PR TITLE
Compile msgs from source

### DIFF
--- a/jenkins-scripts/docker/ign_transport-compilation.bash
+++ b/jenkins-scripts/docker/ign_transport-compilation.bash
@@ -32,6 +32,13 @@ if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
   export USE_GCC8=true
 fi
 
+if [[ ${IGN_GUI_MAJOR_VERSION} -eq 9 ]]; then
+  export BUILD_IGN_MSGS=true
+  export IGN_MSGS_MAJOR_VERSION=6
+  export IGN_MSGS_BRANCH=master
+fi
+
+
 export GZDEV_PROJECT_NAME="ignition-transport${IGN_TRANSPORT_MAJOR_VERSION}"
 
 . "${SCRIPT_DIR}/lib/generic-building-base.bash"

--- a/jenkins-scripts/docker/ign_transport-compilation.bash
+++ b/jenkins-scripts/docker/ign_transport-compilation.bash
@@ -32,7 +32,7 @@ if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
   export USE_GCC8=true
 fi
 
-if [[ ${IGN_GUI_MAJOR_VERSION} -eq 9 ]]; then
+if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -eq 9 ]]; then
   export BUILD_IGN_MSGS=true
   export IGN_MSGS_MAJOR_VERSION=6
   export IGN_MSGS_BRANCH=master


### PR DESCRIPTION
The PR is needed to compile ign-msgs6 in transport9 from sources

Tested here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_transport-ci-pr_any-ubuntu_auto-amd64&build=385)](https://build.osrfoundation.org/job/ignition_transport-ci-pr_any-ubuntu_auto-amd64/385/)