### PR TITLE
Fix sdformat10 debbuilder job

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -58,7 +58,6 @@ ignition_debbuild = ignition_software + [ 'fuel-tools5',
                                           'physics3',
                                           'rendering4',
                                           'sensors4',
-                                          'sdformat10',
                                           'transport9']
 // DESC: exclude ignition from generate any install testing job
 ignition_no_pkg_yet         = [ 'rndf' ]

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -2,9 +2,9 @@ import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
 def sdformat_supported_branches = [ 'sdformat4', 'sdformat6', 'sdformat8' , 'sdformat9' ]
-def sdformat_gz11_branches = [ 'sdformat8', 'sdformat9', 'master' ]
+def sdformat_gz11_branches = [ 'sdformat8', 'sdformat9', 'sdformat10', 'master' ]
 // nightly and prereleases
-def extra_sdformat_debbuilder = [ 'sdformat7' ]
+def extra_sdformat_debbuilder = [ 'sdformat10' ]
 
 // Main platform using for quick CI
 def ci_distro               = Globals.get_ci_distro()


### PR DESCRIPTION
It needs to be defined in sdformat.dsl, not ignition.dsl because otherwise it makes the job like this:

* https://build.osrfoundation.org/job/ign-sdformat10-debbuilder/

Replace sdformat7-debbuilder with sdformat10-debbuilder, since we aren't planning to make sdformat7 releases.

Don't add sdformat10 to supported branches yet because we don't need ABI checking.