### PR TITLE
Add tinyxml2 dependency for windows builds

### DIFF
--- a/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-gazebo
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: dlfcn
-set DEPEN_PKGS="dlfcn-win32 cuda curl jsoncpp freeimage ogre gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf"
+set DEPEN_PKGS="dlfcn-win32 cuda curl jsoncpp freeimage ogre gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gazebo
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_physics-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_physics-default-devel-windows-amd64.bat
@@ -4,7 +4,7 @@ set VCS_DIRECTORY=ign-physics
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="eigen3"
+set DEPEN_PKGS="eigen3 tinyxml2"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-physics
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_sensors-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_sensors-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-sensors
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="protobuf"
+set DEPEN_PKGS="protobuf tinyxml2"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-sensors
 set COLCON_AUTO_MAJOR_VERSION=true


### PR DESCRIPTION
sdformat10 now uses tinyxml2, so add it as a vcpkg dependency for ign-physics, sensors, and gazebo builds. Related to https://github.com/ignitionrobotics/ign-physics/pull/85