### PR TITLE
Remove SRC_BRANCH parameter from ABI jobs. Use sha1 instead

### DIFF
--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -114,7 +114,7 @@ abi_distro.each { distro ->
 
               export ARCH=${arch}
               export DEST_BRANCH=\${DEST_BRANCH:-\$ghprbTargetBranch}
-              export SRC_BRANCH=\${SRC_BRANCH:-\$ghprbSourceBranch}
+              export SRC_BRANCH=\${SRC_BRANCH:-\$sha1}
               export SRC_REPO=\${SRC_REPO:-\$ghprbAuthorRepoGitUrl}
 
               /bin/bash -xe ./scripts/jenkins-scripts/docker/gazebo-abichecker.bash


### PR DESCRIPTION
Remove `SRC_BRANCH` from the list of parameters in ABI jobs and replace it by the use of `sha1` 

sha1 parameter is coming from the Jenkins plugin and host the git refspec when using GitHub integration. We can not change the name so let's try to life with good descriptions in parameters so users that call the job manually can find it quick and know how to use it.

This should fix #242. It might require #237 first.

Need to test it when the buildfarm has low traffic not to break any production run.