### PR TITLE
Support to use ignition_version to release ign_ros_bridge

### DIFF
--- a/bloom/release-bloom.py
+++ b/bloom/release-bloom.py
@@ -6,7 +6,7 @@ import sys
 import urllib
 import argparse
 
-USAGE = 'release-bloom.py <package> <version> <upstream_release_repo> <ros_distro> [--ignition-collection collection_name] <jenkinstoken>'
+USAGE = 'release-bloom.py <package> <version> <upstream_release_repo> <ros_distro> [--ignition-version version_name] <jenkinstoken>'
 JENKINS_URL = 'http://build.osrfoundation.org'
 JOB_NAME_PATTERN = '%s-bloom-debbuilder'
 
@@ -36,8 +36,8 @@ def parse_args(argv):
                         help='Release version suffix; usually 1 (e.g., 1')
     parser.add_argument('--upload-to-repo', dest='upload_to_repository', default="stable",
                         help='OSRF repo to upload: stable | prerelease | nightly')
-    parser.add_argument('--ignition-collection', action='store', default=None,
-                        help='Ignition Collection to use in the binary packages')
+    parser.add_argument('--ignition-version', action='store', default=None,
+                        help='Ignition version to use in the binary packages')
 
     args = parser.parse_args()
     DRY_RUN = args.dry_run
@@ -79,8 +79,8 @@ def call_jenkins_jobs(argv):
         params['ROS2'] = True
         ubuntu_per_ros_distro = UBUNTU_DISTROS_IN_ROS2
 
-    if args.ignition_collection:
-        params['IGNITION_COLLECTION'] = args.ignition_collection
+    if args.ignition_version:
+        params['IGNITION_VERSION'] = args.ignition_version
 
     if not args.release_version:
         args.release_version = 0

--- a/bloom/release-bloom.py
+++ b/bloom/release-bloom.py
@@ -6,7 +6,7 @@ import sys
 import urllib
 import argparse
 
-USAGE = 'release-bloom.py <package> <version> <upstream_release_repo> <ros_distro> <jenkinstoken>'
+USAGE = 'release-bloom.py <package> <version> <upstream_release_repo> <ros_distro> [--ignition-collection collection_name] <jenkinstoken>'
 JENKINS_URL = 'http://build.osrfoundation.org'
 JOB_NAME_PATTERN = '%s-bloom-debbuilder'
 
@@ -36,6 +36,8 @@ def parse_args(argv):
                         help='Release version suffix; usually 1 (e.g., 1')
     parser.add_argument('--upload-to-repo', dest='upload_to_repository', default="stable",
                         help='OSRF repo to upload: stable | prerelease | nightly')
+    parser.add_argument('--ignition-collection', action='store', default=None,
+                        help='Ignition Collection to use in the binary packages')
 
     args = parser.parse_args()
     DRY_RUN = args.dry_run
@@ -76,6 +78,9 @@ def call_jenkins_jobs(argv):
     if args.ros_distro in UBUNTU_DISTROS_IN_ROS2:
         params['ROS2'] = True
         ubuntu_per_ros_distro = UBUNTU_DISTROS_IN_ROS2
+
+    if args.ignition_collection:
+        params['IGNITION_COLLECTION'] = args.ignition_collection
 
     if not args.release_version:
         args.release_version = 0

--- a/jenkins-scripts/dsl/ros1_ign_bridge.dsl
+++ b/jenkins-scripts/dsl/ros1_ign_bridge.dsl
@@ -33,7 +33,8 @@ bridge_packages.each { pkg ->
     }
 
     parameters {
-      stringParam("PACKAGE","$pkg_dashed","Package name to be built")
+        stringParam("PACKAGE","$pkg_dashed","Package name to be built")
+        stringParam("IGNITION_VERSION", '', 'Ignition Collection supported in the binaries')
         stringParam("VERSION",null,"Packages version to be built")
         stringParam("RELEASE_VERSION", null, "Packages release version")
         stringParam("LINUX_DISTRO", 'ubuntu', "Linux distribution to build packages for")

--- a/jenkins-scripts/dsl/ros1_ign_bridge.dsl
+++ b/jenkins-scripts/dsl/ros1_ign_bridge.dsl
@@ -34,7 +34,7 @@ bridge_packages.each { pkg ->
 
     parameters {
         stringParam("PACKAGE","$pkg_dashed","Package name to be built")
-        stringParam("IGNITION_VERSION", '', 'Ignition Collection supported in the binaries')
+        stringParam("IGNITION_VERSION", '', 'Ignition release supported in the binaries')
         stringParam("VERSION",null,"Packages version to be built")
         stringParam("RELEASE_VERSION", null, "Packages release version")
         stringParam("LINUX_DISTRO", 'ubuntu', "Linux distribution to build packages for")


### PR DESCRIPTION
Add a new parameter called `IGNITION_COLLECTION` to support builds of `ros_ign` with custom ignition releases.

DSL is tested here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ros1_ign_bridge&build=29)](https://build.osrfoundation.org/job/_dsl_ros1_ign_bridge/29/)

Output of release script displays correctly the use of the parameter and the inclusion in the Jenkins call:
```
jrivero@nium bloom $ (ign_bridge) ./ros_ign_bridge-release.py.bash 1.0.0 foo-release melodic pass --ignition-collection blueprint -r 1 --dry-run
Accessing: http://build.osrfoundation.org/job/ros-ign-image-bloom-debbuilder/buildWithParameters?PACKAGE=ros-ign-image&UPLOAD_TO_REPO=stable&RELEASE_VERSION=1&UPSTREAM_RELEASE_REPO=foo-release&token=pass&VERSION=1.0.0&IGNITION_COLLECTION=blueprint&ARCH=amd64&DISTRO=bionic&ROS_DISTRO=melodic
```