### PR TITLE
Migrate from warnings plugin to warnings-ng

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
@@ -28,10 +28,41 @@ class OSRFBrewCompilation extends OSRFOsXBase
 
       publishers
       {
-         // compilers warnings
-         warnings(['Clang (LLVM based)'], null) {
-             thresholds(unstableTotal: [all: 0])
-         }
+        configure { project ->
+          project / publishers / 'io.jenkins.plugins.analysis.core.steps.IssuesRecorder' {
+            analysisTools {
+              'io.jenkins.plugins.analysis.warnings.Clang' {
+                id()
+                name()
+                pattern()
+                reportEncoding()
+                skipSymbolicLinks(false)
+              }
+            }
+
+            sourceCodeEncoding()
+            ignoreQualityGate(false)
+            ignoreFailedBuilds(true)
+            referenceJobName()
+            healthy(0)
+            unhealthy(0)
+            minimumSeverity {
+              name('LOW')
+            }
+            filters { }
+            isEnabledForFailure(false)
+            isAggregatingResults(false)
+            isBlameDisabled(false)
+
+            qualityGates {
+              'io.jenkins.plugins.analysis.core.util.QualityGate' {
+                threshold(1)
+                type('TOTAL')
+                status('WARNING')
+              }
+            }
+          }
+        }
       }
     } // end of job
   } // end of method createJob

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxCompilation.groovy
@@ -49,9 +49,47 @@ class OSRFLinuxCompilation extends OSRFLinuxBase
     {
       publishers
       {
-         // compilers warnings
-         warnings(['GNU C Compiler 4 (gcc)'], null) {
-             thresholds(unstableTotal: [all: 0])
+          configure { project ->
+            project / publishers / 'io.jenkins.plugins.analysis.core.steps.IssuesRecorder' {
+              analysisTools {
+                'io.jenkins.plugins.analysis.warnings.Gcc4' {
+                  id()
+                  name()
+                  pattern()
+                  reportEncoding()
+                  skipSymbolicLinks(false)
+                }
+                'io.jenkins.plugins.analysis.warnings.Cmake' {
+                  id()
+                  name()
+                  pattern()
+                  reportEncoding()
+                  skipSymbolicLinks(false)
+                }
+              }
+
+              sourceCodeEncoding()
+              ignoreQualityGate(false)
+              ignoreFailedBuilds(true)
+              referenceJobName()
+              healthy(0)
+              unhealthy(0)
+              minimumSeverity {
+                name('LOW')
+              }
+              filters { }
+              isEnabledForFailure(false)
+              isAggregatingResults(false)
+              isBlameDisabled(false)
+
+              qualityGates {
+                'io.jenkins.plugins.analysis.core.util.QualityGate' {
+                  threshold(1)
+                  type('TOTAL')
+                  status('WARNING')
+                }
+              }
+            }
          }
 
          if (enable_cppcheck)

--- a/jenkins-scripts/dsl/_configs_/OSRFWinCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFWinCompilation.groovy
@@ -26,8 +26,40 @@ class OSRFWinCompilation extends OSRFWinBase
 
       publishers
       {
-        warnings(['MSBuild'], null) {
-          thresholds(unstableTotal: [all: 0])
+        configure { project ->
+          project / publishers / 'io.jenkins.plugins.analysis.core.steps.IssuesRecorder' {
+            analysisTools {
+              'io.jenkins.plugins.analysis.warnings.MsBuild' {
+                id()
+                name()
+                pattern()
+                reportEncoding()
+                skipSymbolicLinks(false)
+              }
+            }
+
+            sourceCodeEncoding()
+            ignoreQualityGate(false)
+            ignoreFailedBuilds(true)
+            referenceJobName()
+            healthy(0)
+            unhealthy(0)
+            minimumSeverity {
+              name('LOW')
+            }
+            filters { }
+            isEnabledForFailure(false)
+            isAggregatingResults(false)
+            isBlameDisabled(false)
+
+            qualityGates {
+              'io.jenkins.plugins.analysis.core.util.QualityGate' {
+                threshold(1)
+                type('TOTAL')
+                status('WARNING')
+              }
+            }
+          }
         }
       }
     } // end of job


### PR DESCRIPTION
The `warning` plugin in Jenkins is deprecated and the upgrade is to use the new warnings-ng.

I suspect that part of the current warning run can kill memory in Jenkins, see https://github.com/osrf/buildfarmer/issues/75.

About the implementation:
 * The new plugin does not support the usual declarative DSL so I'm using here a directly injection by [the configure block](https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block).
 * The change will add cmake parser to our builds and probably trigger a good bunch of new warnings in some builds, I consider it as a desired improvement in QA and something maintainers probably want to fix.

Testing:
 * The XML produced locally seems to match what I found in jenkins jobs created manually. I run a gazebo11 test with this configuration: [![Build Status](https://build.osrfoundation.org/job/_test_warnings_ng_gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/3/badge/icon)](https://build.osrfoundation.org/job/_test_warnings_ng_gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/3/)