### PR TITLE
More QML dependencies for ign-gui

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -614,13 +614,18 @@ IGN_GUI_NO_IGN_DEPENDENCIES="qtbase5-dev \\
 
 if [[ ${DISTRO} != 'xenial' ]]; then
   IGN_GUI_NO_IGN_DEPENDENCIES="${IGN_GUI_NO_IGN_DEPENDENCIES} \\
-                      qml-module-qtquick2 \\
+                      qml-module-qt-labs-folderlistmodel \\
+                      qml-module-qt-labs-settings \\
+                      qml-module-qtcharts \\
+                      qml-module-qtgraphicaleffects \\
+                      qml-module-qtqml-models2 \\
                       qml-module-qtquick-controls \\
                       qml-module-qtquick-controls2 \\
                       qml-module-qtquick-dialogs \\
                       qml-module-qtquick-layouts \\
-                      qml-module-qt-labs-folderlistmodel \\
-                      qml-module-qt-labs-settings \\
+                      qml-module-qtquick-templates2 \\
+                      qml-module-qtquick-window2 \\
+                      qml-module-qtquick2 \\
                       qtquickcontrols2-5-dev"
 fi
 


### PR DESCRIPTION
We're missing some QML dependencies, which is causing test failures on https://github.com/ignitionrobotics/ign-gui/pull/69/. 

Test build using this branch queued: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-pr_any-ubuntu_auto-amd64&build=567)](https://build.osrfoundation.org/job/ignition_gui-ci-pr_any-ubuntu_auto-amd64/567/)