### PR TITLE
Fix subt CI compilation by using ENABLE_ROS

### DIFF
--- a/jenkins-scripts/docker/lib/subt-compilation-base.bash
+++ b/jenkins-scripts/docker/lib/subt-compilation-base.bash
@@ -52,7 +52,7 @@ source ${SCRIPT_DIR}/lib/_ros_setup_buildsh.bash "subt"
 
 DEPENDENCY_PKGS="${DEPENDENCY_PKGS} ${SUBT_DEPENDENCIES} psmisc"
 # ROS packages come from the mirror in the own subt repository
-USE_ROS_REPO=true
+ENABLE_ROS=true
 OSRF_REPOS_TO_USE="stable"
 
 . ${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash

--- a/jenkins-scripts/docker/lib/subt-compilation-base.bash
+++ b/jenkins-scripts/docker/lib/subt-compilation-base.bash
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+# ROS packages come from the mirror in the own subt repository
+export ENABLE_ROS=true
 export ROS_DISTRO=melodic
 
 export GPU_SUPPORT_NEEDED=true
@@ -51,8 +53,6 @@ source ${SCRIPT_DIR}/lib/_ros_setup_buildsh.bash "subt"
 )
 
 DEPENDENCY_PKGS="${DEPENDENCY_PKGS} ${SUBT_DEPENDENCIES} psmisc"
-# ROS packages come from the mirror in the own subt repository
-ENABLE_ROS=true
 OSRF_REPOS_TO_USE="stable"
 
 . ${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -844,4 +844,5 @@ SUBT_DEPENDENCIES="mercurial \\
                    ros-${ROS_DISTRO}-rotors-control \\
                    ros-${ROS_DISTRO}-ros-control \\
                    ros-${ROS_DISTRO}-twist-mux \\
-                   ros-${ROS_DISTRO}-ros1-ign-bridge"
+                   ros-${ROS_DISTRO}-ros1-ign-bridge \\
+                   ros-${ROS_DISTRO}-theora-image-transport"


### PR DESCRIPTION
The problem was not to use the `ENABLE_ROS` parameter so python versions used was python3 instead of python2. 

The change to include theora-image-transport should help caching although the real fix is https://github.com/osrf/subt/pull/523

Tested:
[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=subt-ci-pr_any-bionic-amd64&build=1177)](https://build.osrfoundation.org/job/subt-ci-pr_any-bionic-amd64/1177/)

I've leaved this branch as default for job running today in subt since current code is pretty broken. Working on fixing the warning.