### PR TITLE
Disable ABI checker for ign-cmake and ign-tools

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -240,6 +240,10 @@ ignition_software.each { ign_sw ->
         if (ign_sw == 'physics')
           label "huge-memory"
 
+        // Packages without ABI
+        if (ign_sw == 'tools' || ign_sw == 'cmake')
+          disabled()
+
         steps {
           shell("""\
                 #!/bin/bash -xe

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -228,6 +228,10 @@ boolean is_a_colcon_package(String ign_software_name)
 ignition_software.each { ign_sw ->
   abi_distro.each { distro ->
     supported_arches.each { arch ->
+      // Packages without ABI
+      if (ign_sw == 'tools' || ign_sw == 'cmake')
+        return
+
       abi_job_names[ign_sw] = "ignition_${ign_sw}-abichecker-any_to_any-ubuntu_auto-${arch}"
       def abi_job = job(abi_job_names[ign_sw])
       checkout_subdir = "ign-${ign_sw}"
@@ -239,10 +243,6 @@ ignition_software.each { ign_sw ->
       {
         if (ign_sw == 'physics')
           label "huge-memory"
-
-        // Packages without ABI
-        if (ign_sw == 'tools' || ign_sw == 'cmake')
-          disabled()
 
         steps {
           shell("""\


### PR DESCRIPTION
These packages don't have C++ code, so they don't need ABI checking.