### PR TITLE
debbuild: no-lintian for focal armhf also

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -186,7 +186,7 @@ echo '# BEGIN SECTION: create source package' \${OSRF_VERSION}
 
 # lintian triggers a problem on arm in Focal when using qemu, avoid it
 no_lintian_param=""
-if [[ ${DISTRO} == 'focal' && ${ARCH} == 'arm64' ]]; then
+if [[ ${DISTRO} == 'focal' && (${ARCH} == 'arm64' || ${ARCH} == 'armhf') ]]; then
   no_lintian_param="--no-lintian"
 fi
 


### PR DESCRIPTION
We disabled lintian for focal arm64 builds in #245, but focal armhf builds are hanging too:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-cmake2-debbuilder&build=542)](https://build.osrfoundation.org/job/ign-cmake2-debbuilder/542/) https://build.osrfoundation.org/job/ign-cmake2-debbuilder/542/

So disable lintian for focal armhf too. I queued a build for testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-cmake2-debbuilder&build=555)](https://build.osrfoundation.org/job/ign-cmake2-debbuilder/555/) https://build.osrfoundation.org/job/ign-cmake2-debbuilder/555/
