### PR TITLE
Check that /dev/snd exists before using it in docker run

### DIFF
--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -55,6 +55,11 @@ if $ENABLE_CCACHE; then
                     -v ${CCACHE_DIR}:${CCACHE_DIR}:rw"
 fi
 
+DEVICE_SND=""
+if [[ -d /dev/snd ]]; then
+    DEVICE_SND="--device /dev/snd"
+fi
+
 # DOCKER_FIX is for workaround https://github.com/docker/docker/issues/14203
 sudo ${docker_cmd} run $EXTRA_PARAMS_STR  \
             -e DOCKER_FIX=''  \
@@ -64,7 +69,7 @@ sudo ${docker_cmd} run $EXTRA_PARAMS_STR  \
             -v /dev/log:/dev/log:ro \
             -v /run/log:/run/log:ro \
             -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-            --device /dev/snd \
+            ${DEVICE_SND} \
             --tty \
             --rm \
             ${DOCKER_TAG} \


### PR DESCRIPTION
Given the audio capabilities present in Gazebo the CI script map the `/dev/snd` device when running docker to avoid warnings coming from gazebo when it can not find an audio environment. Some of our nodes could potentially not have a sound device, like the AWS nodes.

This PR check that it exists before pass it to the docker run command.

Tested here:
  * No `/dev/snd/` node: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-pr_any-ubuntu_auto-amd64&build=1129)](https://build.osrfoundation.org/view/All/job/sdformat-ci-pr_any-ubuntu_auto-amd64/1129/)
 * Node with `/dev/snd`: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-pr_any-ubuntu_auto-amd64&build=1130)](https://build.osrfoundation.org/view/All/job/sdformat-ci-pr_any-ubuntu_auto-amd64/1130/)