### PR TITLE
Default docker_in_docker to false

### DIFF
--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -13,6 +13,7 @@ sudo rm -fr ${WORKSPACE}/build
 sudo mkdir -p ${WORKSPACE}/build
 
 [[ -z ${DOCKER_DO_NOT_CACHE} ]] && DOCKER_DO_NOT_CACHE=false
+[[ -z ${USE_DOCKER_IN_DOCKER} ]] && export USE_DOCKER_IN_DOCKER=false
 
 # Remove intermediate containers even if the build is not successful
 if $DOCKER_DO_NOT_CACHE; then


### PR DESCRIPTION
As part of the works in #262 I'm rescuing here the relevant bits, mostly to make all our builds not to use the `DOCKER_IN_DOCKER` which should give us builds without `--priveledge` mode. Need a good bunch of testing before merge to be sure nothing is broken.

Testing:
 * sdformat ci-pr_any [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-pr_any-ubuntu_auto-amd64&build=1132)](https://build.osrfoundation.org/view/All/job/sdformat-ci-pr_any-ubuntu_auto-amd64/1132/) . Unstable for other reasons.
* subt ci-pr_any [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=subt-ci-pr_any-bionic-amd64&build=1268)](https://build.osrfoundation.org/job/subt-ci-pr_any-bionic-amd64/1268/)
* gazebo install [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-gazebo10_pkg-xenial-amd64)](https://build.osrfoundation.org/view/main/view/gazebo/job/gazebo-install-gazebo10_pkg-xenial-amd64/)
* gazebo_ros_pkgs ci [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros2_gazebo11_pkgs-ci-default_eloquent-bionic-amd64&build=5)](https://build.osrfoundation.org/job/ros2_gazebo11_pkgs-ci-default_eloquent-bionic-amd64/5/)