### PR TITLE
Do not fail uploades of source packages

### DIFF
--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -85,7 +85,8 @@ upload_dsc_package()
     # try to upload and if failed, specify the values
     # see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=768046
     sudo GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror includedsc $DISTRO ${pkg} || \
-	sudo GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror --section science --priority extra includedsc $DISTRO ${pkg}
+	sudo GNUPGHOME=$HOME/.gnupg reprepro --nothingiserror --section science --priority extra includedsc $DISTRO ${pkg} || \
+		echo "MARK_BUILD_UNSTABLE"
 }
 
 NEEDED_HOST_PACKAGES="reprepro openssh-client jq"


### PR DESCRIPTION
Some nightly packages have problems uploading the source package since they conflict between distributions. While is not a critical problem itself (few use cases for source packages) it makes the uploads to fail so no binaries go to the repo which in fact it is a critical problem. I'm making the script not to fail but report unstable until I code the right fix for the whole thing.

Tested:

 * Failing [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=repository_uploader_ng&build=14910)](https://build.osrfoundation.org/view/All/job/repository_uploader_ng/14910/)
 * Good (although the parser was not properly setup) [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=repository_uploader_ng&build=14913)](https://build.osrfoundation.org/view/All/job/repository_uploader_ng/14913/)