### PR TITLE
Use colcon.meta file to fix cmake warning

### DIFF
--- a/jenkins-scripts/docker/lib/gazebo_ros_pkgs-base.bash
+++ b/jenkins-scripts/docker/lib/gazebo_ros_pkgs-base.bash
@@ -8,7 +8,19 @@ DOCKER_JOB_NAME="gazebo_ros_pkgs_ci"
 . ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 # Generate the first part of the build.sh file for ROS
-CATKIN_EXTRA_ARGS="--cmake-args -DENABLE_DISPLAY_TESTS:BOOL=ON"
+ROS_WS_PREBUILD_HOOK="""
+${ROS_WS_PREBUILD_HOOK}
+cd ${CATKIN_WS}
+cat >> colcon.meta << DELIM_PREBUILD_HOOK
+{
+    "names": {
+        "gazebo_plugins": {
+            "catkin-cmake-args": ["-DENABLE_DISPLAY_TESTS:BOOL=ON"]
+        }
+    }
+}
+DELIM_PREBUILD_HOOK
+"""
 
 ROS_SETUP_PREINSTALL_HOOK="""
 ${GAZEBO_MODEL_INSTALLATION}


### PR DESCRIPTION
The gazebo_ros_pkgs CI builds have a cmake warning:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros_gazebo_pkgs-ci-default_melodic-bionic-amd64&build=61)](https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_melodic-bionic-amd64/61/) https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_melodic-bionic-amd64/61/cmake/

~~~
CMake Warning:
  Manually-specified variables were not used by the project:

    ENABLE_DISPLAY_TESTS
~~~

We are passing this cmake option intended for gazebo_plugins to all the packages in a gazebo_ros_pkgs workspace, which causes the cmake warning. This PR creates a [colcon.meta file](https://colcon.readthedocs.io/en/released/user/configuration.html#using-meta-files) using the `ROS_WS_PREBUILD_HOOK` to target the `gazebo_plugins` package instead of using the `--cmake-args` command-line argument to colcon.

Test with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros_gazebo_pkgs-ci-default_melodic-bionic-amd64&build=62)](https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_melodic-bionic-amd64/62/) https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_melodic-bionic-amd64/62/