### PR TITLE
ignition-abichecker: set GZDEV_PROJECT_NAME

### DIFF
--- a/jenkins-scripts/docker/ignition-abichecker.bash
+++ b/jenkins-scripts/docker/ignition-abichecker.bash
@@ -47,15 +47,10 @@ then
   export USE_GCC8=true
 fi
 
+# default to use stable repos
 export ABI_JOB_REPOS="stable"
 
-# Enable prerelease repos until a certain date
-if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo" ]] || \
-  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-sensors" ]]
-then
-  if [[ $(date +%Y%m%d) -le 20190619 ]]; then
-    export ABI_JOB_REPOS="${ABI_JOB_REPOS} prerelease"
-  fi
-fi
+# set GZDEV_PROJECT_NAME so it can override repos if necessary
+export GZDEV_PROJECT_NAME=${ABI_JOB_SOFTWARE_NAME/ign-/ignition-}${IGN_NAME_PREFIX_MAJOR_VERSION}
 
 . ${SCRIPT_DIR}/lib/generic-abi-base.bash


### PR DESCRIPTION
I noticed while reviewing https://github.com/ignitionrobotics/ign-physics/pull/86 that the ignition ABI checker jenkins jobs aren't setting the `GZDEV_PROJECT_NAME` variable, since I enabled prerelease repositories for `ignition-physics2` in https://github.com/osrf/gzdev/pull/16 which fixed the other Ubuntu jobs but not the ABI checker.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-abichecker-any_to_any-ubuntu_auto-amd64&build=493)](https://build.osrfoundation.org/job/ignition_physics-abichecker-any_to_any-ubuntu_auto-amd64/493/) https://build.osrfoundation.org/job/ignition_physics-abichecker-any_to_any-ubuntu_auto-amd64/493

The `ABI_JOB_SOFTWARE_NAME` variable is currently `ign-${IGN_DESIGNATION}`, so expand "ign-" to "ignition-" and append the major version.

Also removes some old code that was enabling prerelease repos.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>