### PR TITLE
Replace old packages uploader

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBackportPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBackportPkg.groovy
@@ -85,7 +85,7 @@ class OSRFLinuxBackportPkg
 
             publishers {
               downstreamParameterized {
-                trigger('repository_uploader_ng') {
+                trigger('repository_uploader_packages') {
                   parameters {
                     currentBuild()
                     predefinedProp("PROJECT_NAME_TO_COPY_ARTIFACTS", "\${JOB_NAME}")

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkg.groovy
@@ -100,7 +100,7 @@ class OSRFLinuxBuildPkg
         }
 
         downstreamParameterized {
-	  trigger('repository_uploader_ng') {
+	  trigger('repository_uploader_packages') {
 	    condition('UNSTABLE_OR_BETTER')
 	    parameters {
 	      currentBuild()

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -200,10 +200,10 @@ bottle_job_builder.with
        allowEmpty()
      }
 
-     // call to the repository_uploader_ng to upload to S3 the binary
+     // call to the repository_uploader_packages to upload to S3 the binary
      downstreamParameterized
      {
-        trigger('repository_uploader_ng') {
+        trigger('repository_uploader_packages') {
           condition('SUCCESS')
           parameters {
             currentBuild()

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -107,7 +107,7 @@ gbp_repo_debbuilds.each { software ->
       }
 
       downstreamParameterized {
-        trigger('repository_uploader_ng') {
+        trigger('repository_uploader_packages') {
           condition('SUCCESS')
           parameters {
             currentBuild()

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -326,7 +326,7 @@ bloom_debbuild_jobs.each { bloom_pkg ->
 
       publishers {
         downstreamParameterized {
-	  trigger('repository_uploader_ng') {
+	  trigger('repository_uploader_packages') {
 	    condition('SUCCESS')
 	    parameters {
 	      currentBuild()

--- a/jenkins-scripts/dsl/ros1_ign_bridge.dsl
+++ b/jenkins-scripts/dsl/ros1_ign_bridge.dsl
@@ -64,7 +64,7 @@ bridge_packages.each { pkg ->
 
     publishers {
       downstreamParameterized {
-        trigger('repository_uploader_ng') {
+        trigger('repository_uploader_packages') {
           condition('SUCCESS')
             parameters {
               currentBuild()


### PR DESCRIPTION
This change replace the use of the old `repository_uploader_ng` that uploaded packages to build.osrfoundation.org to `repository_uploader_packages` that uploads packages directly to packages.osrfoundation.org. Currently the first one was forwarded calls to the second one which is the most important.

This will kill the old.packages.osrfoundation.org, announced long ago [here](https://community.gazebosim.org/t/packages-osrfoundation-org-new-machine/426/3?u=jrivero)