### PR TITLE
Export Dockerfile/build.sh as artifacts from each build 

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
@@ -19,5 +19,10 @@ class OSRFLinuxBase
      {
          label "docker"
      }
+
+      publishers {
+        archiveArtifacts('Dockerfile')
+        archiveArtifacts('build.sh')
+      }
    }
 }

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
@@ -10,19 +10,21 @@ import javaposse.jobdsl.dsl.Job
 */
 class OSRFLinuxBase
 {
-   static void create(Job job)
-   {
-     // Base class for the job
-     OSRFUNIXBase.create(job)
+  static void create(Job job)
+  {
+    // Base class for the job
+    OSRFUNIXBase.create(job)
 
-     job.with
-     {
-         label "docker"
-     }
+    job.with
+    {
+        label "docker"
 
-      publishers {
-        archiveArtifacts('Dockerfile')
-        archiveArtifacts('build.sh')
+        publishers {
+          archiveArtifacts {
+            pattern('Dockerfile')
+            pattern('build.sh')
+        }
       }
-   }
+    }
+  }
 }


### PR DESCRIPTION
This should help people to reproduce the Jenkins builds locally. The first commit is the only one interesting https://github.com/ignition-tooling/release-tools/commit/e2b17390fbf405b471daba6403929c815d8e5e48, second is just proper tabs.

Testing in DSL here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_sdformat&build=912)](https://build.osrfoundation.org/view/All/job/_dsl_sdformat/912/)