### PR TITLE
Trigger homebrew bottle builds from GitHub comments

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBrewCompilationAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewCompilationAnyGitHub.groovy
@@ -14,10 +14,13 @@ class OSRFBrewCompilationAnyGitHub
   static void create(Job job,
                      String github_repo,
                      boolean enable_testing  = true,
-                     ArrayList supported_ros_distros = [])
+                     ArrayList supported_branches = [],
+                     boolean enable_github_pr_integration = true)
   {
     OSRFBrewCompilation.create(job, enable_testing)
 
-    GenericAnyJobGitHub.create(job, github_repo, supported_ros_distros)
+    GenericAnyJobGitHub.create(job, github_repo,
+                               supported_branches,
+                               enable_github_pr_integration)
   }
 }

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -50,7 +50,7 @@ void include_common_params(Job job)
 // -------------------------------------------------------------------
 // 1. BREW pull request SHA updater
 def release_job = job("generic-release-homebrew_pull_request_updater")
-OSRFLinuxBase.create(release_job)
+OSRFUNIXBase.create(release_job)
 GenericRemoteToken.create(release_job)
 
 include_common_params(release_job)
@@ -236,7 +236,7 @@ bottle_job_builder.with
 // -------------------------------------------------------------------
 // 4. BREW bottle hash update
 def bottle_job_hash_updater = job(bottle_hash_updater_job_name)
-OSRFLinuxBase.create(bottle_job_hash_updater)
+OSRFUNIXBase.create(bottle_job_hash_updater)
 GenericRemoteToken.create(bottle_job_hash_updater)
 
 include_common_params(bottle_job_hash_updater)

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -161,7 +161,9 @@ bottle_job_builder.with
           build.setDescription(
           '<b><a href="https://github.com/osrf/homebrew-simulation/pull/' +
           build.buildVariableResolver.resolve('ghprbPullId') + '">PR ' +
-          build.buildVariableResolver.resolve('ghprbPullId') + '</a></b>');
+          build.buildVariableResolver.resolve('ghprbPullId') + '</a></b>' +
+          '<br />' +
+          'RTOOLS_BRANCH: ' + build.buildVariableResolver.resolve('RTOOLS_BRANCH'));
           """.stripIndent()
         )
 

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -178,6 +178,7 @@ bottle_job_builder.with
      project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
          adminlist 'osrf-jenkins j-rivero scpeters'
          orgslist 'ignitionrobotics'
+         whitelist 'osrfbuild'
          useGitHubHooks(true)
          allowMembersOfWhitelistedOrgsAsAdmin(true)
          useGitHubHooks(true)

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -9,6 +9,10 @@ bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_update
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'
 
+def DISABLE_TESTS = false
+def NO_SUPPORTED_BRANCHES = []
+def DISABLE_GITHUB_INTEGRATION = false
+
 /*
   release.py
   -> update upstream source tarball hash in formula
@@ -120,7 +124,9 @@ def bottle_job_builder = matrixJob(bottle_builder_job_name)
 // set enable_github_pr_integration flag to false so we can customize trigger behavior
 OSRFBrewCompilationAnyGitHub.create(bottle_job_builder,
                                     "osrf/homebrew-simulation",
-                                    false, [], false)
+                                    DISABLE_TESTS,
+                                    NO_SUPPORTED_BRANCHES,
+                                    DISABLE_GITHUB_INTEGRATION)
 GenericRemoteToken.create(bottle_job_builder)
 
 bottle_job_builder.with

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -177,9 +177,9 @@ bottle_job_builder.with
      }
      project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
          adminlist 'osrf-jenkins j-rivero scpeters'
-         orgslist 'osrf'
+         orgslist 'ignitionrobotics'
          useGitHubHooks(true)
-         allowMembersOfWhitelistedOrgsAsAdmin(false)
+         allowMembersOfWhitelistedOrgsAsAdmin(true)
          useGitHubHooks(true)
          onlyTriggerPhrase(true)
          permitAll(false)

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -6,7 +6,7 @@ Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 // first distro in list is used as touchstone
 brew_supported_distros         = [ "highsierra", "mojave" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
-bottle_builder_job_name        = 'generic-release-homebrew_bottle_builder'
+bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'
 
 /*
@@ -111,32 +111,29 @@ release_job.with
        pattern("${PR_URL_export_file_name}")
        allowEmpty()
      }
-
-     downstreamParameterized
-     {
-        trigger(bottle_builder_job_name)
-        {
-          condition('SUCCESS')
-          parameters {
-            currentBuild()
-            propertiesFile("${PR_URL_export_file_name}")
-          }
-        }
-     }
    }
 }
 
 // -------------------------------------------------------------------
 // 2. BREW bottle creation MATRIX job from pullrequest
 def bottle_job_builder = matrixJob(bottle_builder_job_name)
-OSRFOsXBase.create(bottle_job_builder)
+// set enable_github_pr_integration flag to false so we can customize trigger behavior
+OSRFBrewCompilationAnyGitHub.create(bottle_job_builder,
+                                    "osrf/homebrew-simulation",
+                                    false, [], false)
 GenericRemoteToken.create(bottle_job_builder)
 
-include_common_params(bottle_job_builder)
 bottle_job_builder.with
 {
    wrappers {
         preBuildCleanup()
+        credentialsBinding {
+          string('GITHUB_TOKEN', '6f03ada6-fae8-4e74-9e2b-d6d0cf4b97a2')
+        }
+   }
+
+   properties {
+     priority 100
    }
 
    logRotator {
@@ -144,7 +141,7 @@ bottle_job_builder.with
    }
 
    axes {
-     // use labels osx_$osxdistro  
+     // use labels osx_$osxdistro
      label('label', brew_supported_distros.collect { "osx_$it" })
    }
 
@@ -153,36 +150,17 @@ bottle_job_builder.with
 
    touchStoneFilter("label == ${touchstone_label}")
 
-   parameters
-   {
-     stringParam("PULL_REQUEST_URL", '',
-                 'Pull request URL (osrf/homebrew-simulation) pointing to a pull request.')
-     stringParam("BREW_REPO", 'https://github.com/scpeters/brew.git',
-                 'Repository for fork of homebrew/brew.')
-     stringParam("BREW_BRANCH", 'still_working',
-                 'Branch of brew repository to use.')
-     stringParam("TEST_BOT_REPO", 'https://github.com/scpeters/homebrew-test-bot.git',
-                 'Repository for fork of homebrew/homebrew-test-bot.')
-     stringParam("TEST_BOT_BRANCH", 'still_working',
-                 'Branch of homebrew-test-bot repository to use.')
-   }
-
    steps {
         systemGroovyCommand("""\
           build.setDescription(
-          '<b>' + build.buildVariableResolver.resolve('PACKAGE_ALIAS') + '-' +
-           build.buildVariableResolver.resolve('VERSION') + '</b>' +
-          '<br />' +
-          'pull request:<b> <a href="' + build.buildVariableResolver.resolve('PULL_REQUEST_URL') +
-          '">' + build.buildVariableResolver.resolve('PULL_REQUEST_URL') + '</a></b>' +
-          '<br />' +
-          'RTOOLS_BRANCH: ' + build.buildVariableResolver.resolve('RTOOLS_BRANCH'));
+          '<b><a href="https://github.com/osrf/homebrew-simulation/pull/' +
+          build.buildVariableResolver.resolve('ghprbPullId') + '">PR ' +
+          build.buildVariableResolver.resolve('ghprbPullId') + '</a></b>');
           """.stripIndent()
         )
 
         shell("""\
               #!/bin/bash -xe
-
               /bin/bash -xe ./scripts/jenkins-scripts/lib/homebrew_bottle_creation.bash
               """.stripIndent())
    }
@@ -190,6 +168,25 @@ bottle_job_builder.with
    configure { project ->
      project / 'properties' / 'hudson.plugins.copyartifact.CopyArtifactPermissionProperty' / 'projectNameList' {
       'string' "${bottle_hash_updater_job_name}"
+     }
+     project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
+         adminlist 'osrf-jenkins j-rivero scpeters'
+         orgslist 'osrf'
+         useGitHubHooks(true)
+         allowMembersOfWhitelistedOrgsAsAdmin(false)
+         useGitHubHooks(true)
+         onlyTriggerPhrase(true)
+         permitAll(false)
+         cron()
+         triggerPhrase '.*build bottle.*'
+         extensions {
+             'org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus' {
+               commitStatusContext '${JOB_NAME}'
+               triggeredStatus 'starting deployment to build.osrfoundation.org'
+               startedStatus 'deploying to build.osrfoundation.org'
+               addTestResults(true)
+             }
+         }
      }
    }
 
@@ -222,7 +219,7 @@ bottle_job_builder.with
           condition('SUCCESS')
           parameters {
             currentBuild()
-              predefinedProp("PULL_REQUEST_URL", "\${PULL_REQUEST_URL}")
+              predefinedProp("PULL_REQUEST_URL", "https://github.com/osrf/homebrew-simulation/pull/\${ghprbPullId}")
           }
         }
      }

--- a/jenkins-scripts/lib/_homebrew_github_commit.bash
+++ b/jenkins-scripts/lib/_homebrew_github_commit.bash
@@ -52,7 +52,10 @@ if ${GIT} rev-parse --verify ${PULL_REQUEST_BRANCH} ; then
 else
   ${GIT} checkout -b ${PULL_REQUEST_BRANCH}
 fi
-${GIT} commit ${FORMULA_PATH} -m "${PACKAGE_ALIAS}: update ${VERSION}${COMMIT_MESSAGE_SUFFIX}"
+if [ -n "${PACKAGE_ALIAS}" ]; then
+  COMMIT_MESSAGE_PREFIX="${PACKAGE_ALIAS}: "
+fi
+${GIT} commit ${FORMULA_PATH} -m "${COMMIT_MESSAGE_PREFIX}update ${VERSION}${COMMIT_MESSAGE_SUFFIX}"
 echo
 ${GIT} status
 echo

--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -54,8 +54,12 @@ echo '# BEGIN SECTION: run test-bot'
 # mercurial to keep the slave working
 export HOMEBREW_DEVELOPER=1
 brew tap osrf/simulation
-hub -C $(brew --repo osrf/simulation) \
-    pr checkout ${ghprbPullId}
+# replace with 'hub -C $(brew --repo osrf/simulation) pr checkout ${ghprbPullId}'
+# after the following hub issue is resolved:
+# https://github.com/github/hub/issues/2612
+pushd $(brew --repo osrf/simulation) && \
+  hub pr checkout ${ghprbPullId} && \
+  popd
 
 # test-bot wants to 'git fetch --unshallow' over ssh, which has permission issues
 # explicitly unshallow using https instead


### PR DESCRIPTION
This fixes the scripts for building homebrew bottles for the osrf/homebrew-simulation tap since our infrastructure is out of date (https://github.com/osrf/homebrew-simulation/issues/1049). Instead of passing a pull request URL as an argument to `brew test-bot`, the tap needs to be checked out to the correct revision first, so we use `hub pr checkout` with the integer pull request ID to checkout the correct branch. Using `hub pr` requires a `GITHUB_TOKEN`, which @j-rivero was kind enough to assist with configuring.

Additionally, builds can now be triggered by a comment from an authorized user that contains the phrase `build bottle` (see https://github.com/osrf/homebrew-simulation/pull/1122 for an example). Note that testing this required hard-coding the release-tools branch with d828118b89dda5088f95b503926e5e2e81c99e03, though I've redacted that commit from this branch for now.

I've disconnected bottle builds from the https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/ job; after this is merged, I'll look into how to trigger them during pull request creation, perhaps if the pull request description contains the `build bottle` phrase, but I'd like to get this merged as is without adding too much scope.