### PR TITLE
URI decode bottle filename before uploading

### DIFF
--- a/jenkins-scripts/lib/repository_uploader.bash
+++ b/jenkins-scripts/lib/repository_uploader.bash
@@ -89,7 +89,7 @@ upload_dsc_package()
 		echo "MARK_BUILD_UNSTABLE"
 }
 
-NEEDED_HOST_PACKAGES="reprepro openssh-client jq"
+NEEDED_HOST_PACKAGES="reprepro openssh-client jq gridsite-clients"
 QUERY_HOST_PACKAGES=$(dpkg-query -Wf'${db:Status-abbrev}' ${NEEDED_HOST_PACKAGES} 2>&1) || true
 if [[ -n ${QUERY_HOST_PACKAGES} ]]; then
   sudo apt-get update
@@ -162,7 +162,7 @@ done
 # .bottle | brew binaries
 for pkg in `find "$pkgs_path" -name '*.bottle*.json'`; do
   # Extract bottle name and root_url from json file
-  bottle_filename=$(dirname $pkg)/$(jq -r '.[]["bottle"]["tags"][]["filename"]' < $pkg)
+  bottle_filename=$(urlencode -d $(dirname $pkg)/$(jq -r '.[]["bottle"]["tags"][]["filename"]' < $pkg))
   root_url=$(jq -r '.[]["bottle"]["root_url"]' < $pkg)
   s3_directory=${root_url#https://osrf-distributions\.s3\.amazonaws\.com/}
 


### PR DESCRIPTION
The bottles for `dartsim@6.10.0` were rebuilt in https://github.com/osrf/homebrew-simulation/pull/1148, but they failed to upload:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder&build=34)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/34/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/34/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=repository_uploader_packages&build=6626)](https://build.osrfoundation.org/job/repository_uploader_packages/6626/) https://build.osrfoundation.org/job/repository_uploader_packages/6626/

I had  previously attempted to fix a related problem in #208, but it needs a follow-up here, which is to URI decode the filename specified in the bottle son before upload, to match the filename created  in the bottle creator script. This uses the `urlencode -d` command from the `gridsite-clients` apt package.

As an aside, this failed upload is motivation to improve the GitHub actions workflow to test uploaded bottles before merging an osrf/homebrew-simulation PR (https://github.com/osrf/homebrew-simulation/issues/1139).

I have downloaded the bottles from this job and can upload manually, but I was hoping to retry the failed uploader job after merging this to master to confirm that it works.