### PR TITLE
Use OSRFUnixBase for nightly scheduler

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -451,7 +451,7 @@ collection_data.each { job ->
 }
 
 def nightly_scheduler_job = job("ignition-${ignition_nightly}-nightly-scheduler")
-OSRFLinuxBase.create(nightly_scheduler_job)
+OSRFUnixBase.create(nightly_scheduler_job)
 
 nightly_scheduler_job.with
 {


### PR DESCRIPTION
OSRFLinuxBase jobs expect a Dockerfile and build.sh, which causes the nightly scheduler job to fail, but OSRFUnixBase should work instead.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-dome-nightly-scheduler&build=75)](https://build.osrfoundation.org/job/ignition-dome-nightly-scheduler/75/) https://build.osrfoundation.org/job/ignition-dome-nightly-scheduler/75/

Similar to 9aa5dbe3cbc88a9e65033d30937a51e82274c23e from #280.