### PR TITLE
dsl: fix capitalization in OSRFUNIXBase

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -451,7 +451,7 @@ collection_data.each { job ->
 }
 
 def nightly_scheduler_job = job("ignition-${ignition_nightly}-nightly-scheduler")
-OSRFUnixBase.create(nightly_scheduler_job)
+OSRFUNIXBase.create(nightly_scheduler_job)
 
 nightly_scheduler_job.with
 {


### PR DESCRIPTION
Fix typo in #283.

I should have tested #283:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition_collection&build=237)](https://build.osrfoundation.org/job/_dsl_ignition_collection/237/) https://build.osrfoundation.org/job/_dsl_ignition_collection/237/

This should fix it:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition_collection&build=238)](https://build.osrfoundation.org/job/_dsl_ignition_collection/238/) https://build.osrfoundation.org/job/_dsl_ignition_collection/238/