### PR TITLE
Enable GCC8 for ign-gazebo deb builds

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -174,13 +174,13 @@ g++ --version
 echo '# END SECTION'
 fi
 
-#if $NEED_C17_COMPILER; then
+if $NEED_C17_COMPILER; then
 echo '# BEGIN SECTION: install C++17 compiler'
 apt-get install -y gcc-8 g++-8
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 g++ --version
 echo '# END SECTION'
-#fi
+fi
 
 echo '# BEGIN SECTION: create source package' \${OSRF_VERSION}
 

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -174,13 +174,13 @@ g++ --version
 echo '# END SECTION'
 fi
 
-if $NEED_C17_COMPILER; then
+#if $NEED_C17_COMPILER; then
 echo '# BEGIN SECTION: install C++17 compiler'
 apt-get install -y gcc-8 g++-8
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 g++ --version
 echo '# END SECTION'
-fi
+#fi
 
 echo '# BEGIN SECTION: create source package' \${OSRF_VERSION}
 

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -469,7 +469,7 @@ ignition_debbuild.each { ign_sw ->
     extra_str = ""
     if (("${ign_sw}" == "gazebo") ||
         (("${ign_sw}" == "transport") && ("${major_version}" == "6"  || "${major_version}" == "7" )))
-      extra_cmd_str = "export NEED_C17_COMPILER=true"
+      extra_str = "export NEED_C17_COMPILER=true"
 
     def build_pkg_job = job("ign-${ign_sw}${major_version}-debbuilder")
     OSRFLinuxBuildPkg.create(build_pkg_job)

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -469,7 +469,7 @@ ignition_debbuild.each { ign_sw ->
     extra_str = ""
     if (("${ign_sw}" == "gazebo") ||
         (("${ign_sw}" == "transport") && ("${major_version}" == "6"  || "${major_version}" == "7" )))
-      extra_str="export USE_GCC8=true"
+      extra_cmd_str = "export NEED_C17_COMPILER=true"
 
     def build_pkg_job = job("ign-${ign_sw}${major_version}-debbuilder")
     OSRFLinuxBuildPkg.create(build_pkg_job)


### PR DESCRIPTION
Possible solution to #288 

Copied the approach from SDF:

https://github.com/ignition-tooling/release-tools/blob/35e122906ccf7b6cff8623a82cd150bf5b364386/jenkins-scripts/dsl/sdformat.dsl#L275-L282