### PR TITLE
Unify USE_GCC8 and NEED_C17_COMPILER variables

### DIFF
--- a/jenkins-scripts/docker/gazebo-compilation.bash
+++ b/jenkins-scripts/docker/gazebo-compilation.bash
@@ -21,7 +21,7 @@ OSRF_REPOS_TO_USE="stable"
 . ${SCRIPT_DIR}/lib/_gazebo_version_hook.bash
 
 if [[ $GAZEBO_MAJOR_VERSION -ge 11 ]]; then
-  USE_GCC8=true
+  NEED_C17_COMPILER=true
 fi
 
 export GZDEV_PROJECT_NAME="gazebo${GAZEBO_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_common-compilation.bash
+++ b/jenkins-scripts/docker/ign_common-compilation.bash
@@ -29,7 +29,7 @@ if ! [[ ${IGN_COMMON_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
 fi
 
 if [[ ${IGN_COMMON_MAJOR_VERSION} -ge 3 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 export GZDEV_PROJECT_NAME="ignition-common${IGN_COMMON_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_gazebo-compilation.bash
+++ b/jenkins-scripts/docker/ign_gazebo-compilation.bash
@@ -54,7 +54,7 @@ if [[ ${IGN_GAZEBO_MAJOR_VERSION} -ge 4 ]]; then
   export IGN_TRANSPORT_BRANCH=master
 fi
 
-export USE_GCC8=true
+export NEED_C17_COMPILER=true
 export GPU_SUPPORT_NEEDED=true
 
 export GZDEV_PROJECT_NAME="ignition-gazebo${IGN_GAZEBO_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_gui-compilation.bash
+++ b/jenkins-scripts/docker/ign_gui-compilation.bash
@@ -43,7 +43,7 @@ if [[ ${IGN_GUI_MAJOR_VERSION} -ge 4 ]]; then
 fi
 
 if [[ ${IGN_GUI_MAJOR_VERSION} -ge 1 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 export GPU_SUPPORT_NEEDED=true

--- a/jenkins-scripts/docker/ign_launch-compilation.bash
+++ b/jenkins-scripts/docker/ign_launch-compilation.bash
@@ -58,7 +58,7 @@ if [[ ${IGN_LAUNCH_MAJOR_VERSION} -ge 3 ]]; then
   export IGN_GAZEBO_BRANCH=master
 fi
 
-export USE_GCC8=true
+export NEED_C17_COMPILER=true
 
 export GZDEV_PROJECT_NAME="ignition-launch${IGN_LAUNCH_MAJOR_VERSION}"
 

--- a/jenkins-scripts/docker/ign_math-compilation.bash
+++ b/jenkins-scripts/docker/ign_math-compilation.bash
@@ -30,7 +30,7 @@ if ! [[ ${IGN_MATH_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
 fi
 
 if [[ ${IGN_MATH_MAJOR_VERSION} -ge 6 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 export GZDEV_PROJECT_NAME="ignition-math${IGN_MATH_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_msgs-compilation.bash
+++ b/jenkins-scripts/docker/ign_msgs-compilation.bash
@@ -31,7 +31,7 @@ if ! [[ ${IGN_MSGS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
 fi
 
 if [[ ${IGN_MSGS_MAJOR_VERSION} -ge 3 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 export GZDEV_PROJECT_NAME="ignition-msgs${IGN_MSGS_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_physics-compilation.bash
+++ b/jenkins-scripts/docker/ign_physics-compilation.bash
@@ -28,7 +28,7 @@ if ! [[ ${IGN_PHYSICS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-export USE_GCC8=true
+export NEED_C17_COMPILER=true
 export GZDEV_PROJECT_NAME="ignition-physics${IGN_PHYSICS_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_plugin-compilation.bash
+++ b/jenkins-scripts/docker/ign_plugin-compilation.bash
@@ -29,7 +29,7 @@ if ! [[ ${IGN_PLUGIN_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
 fi
 
 if [[ ${IGN_PLUGIN_MAJOR_VERSION} -ge 6 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 export GZDEV_PROJECT_NAME="ignition-plugin${IGN_PLUGIN_DEPENDENCIES}"

--- a/jenkins-scripts/docker/ign_rendering-compilation.bash
+++ b/jenkins-scripts/docker/ign_rendering-compilation.bash
@@ -35,7 +35,7 @@ if [[ ${IGN_RENDERING_MAJOR_VERSION} -ge 4 ]]; then
 fi
 
 if [[ ${IGN_RENDERING_MAJOR_VERSION} -ge 1 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 export GPU_SUPPORT_NEEDED=true

--- a/jenkins-scripts/docker/ign_sensors-compilation.bash
+++ b/jenkins-scripts/docker/ign_sensors-compilation.bash
@@ -46,7 +46,7 @@ if [[ ${IGN_SENSORS_MAJOR_VERSION} -ge 4 ]]; then
   export IGN_TRANSPORT_BRANCH=master
 fi
 
-export USE_GCC8=true
+export NEED_C17_COMPILER=true
 
 export GPU_SUPPORT_NEEDED=true
 export GZDEV_PROJECT_NAME="ignition-sensors${IGN_SENSORS_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_transport-compilation.bash
+++ b/jenkins-scripts/docker/ign_transport-compilation.bash
@@ -29,7 +29,7 @@ if ! [[ ${IGN_TRANSPORT_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
 fi
 
 if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -eq 9 ]]; then

--- a/jenkins-scripts/docker/ignition-abichecker.bash
+++ b/jenkins-scripts/docker/ignition-abichecker.bash
@@ -32,7 +32,7 @@ export IGN_NAME_PREFIX_MAJOR_VERSION=$(\
   ${WORKSPACE}/${ABI_JOB_SOFTWARE_NAME}/CMakeLists.txt)
 export ${IGN_NAME_PREFIX}_MAJOR_VERSION=${IGN_NAME_PREFIX_MAJOR_VERSION}
 
-# check if USE_GCC8 should be set
+# check if NEED_C17_COMPILER should be set
 if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo" ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-physics" ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-sensors" ]] || \
@@ -44,7 +44,7 @@ if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo" ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-rendering" && ${IGN_NAME_PREFIX_MAJOR_VERSION} -ge 1 ]] || \
   [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-transport" && ${IGN_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]]
 then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 # default to use stable repos

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -27,7 +27,7 @@ if [[ -z ${LINUX_DISTRO} ]]; then
   export LINUX_DISTRO="ubuntu"
 fi
 
-[[ -z ${USE_GCC8} ]] && USE_GCC8=false
+[[ -z ${NEED_C17_COMPILER} ]] && NEED_C17_COMPILER=false
 
 export APT_PARAMS=
 # workaround for changing our packages testing server
@@ -314,7 +314,7 @@ DELIM_DOCKER31
 
 # Beware of moving this code since it needs to run update-alternative after
 # installing the default compiler in PACKAGES_CACHE_AND_CHECK_UPDATES
-if ${USE_GCC8}; then
+if ${NEED_C17_COMPILER}; then
 cat >> Dockerfile << DELIM_GCC8
    RUN apt-get update \\
    && apt-get install -y g++-8 \\

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -33,7 +33,7 @@ if [[ -n "${DART_FROM_PKGS_VAR_NAME}" ]]; then
 fi
 
 ABI_CXX_STANDARD=c++11
-if [[ "${USE_GCC8}" == "true" ]]; then
+if [[ "${NEED_C17_COMPILER}" == "true" ]]; then
   ABI_CXX_STANDARD=c++17
 fi
 

--- a/jenkins-scripts/docker/sdformat-abichecker.bash
+++ b/jenkins-scripts/docker/sdformat-abichecker.bash
@@ -24,7 +24,7 @@ if [[ ${SDFORMAT_MAJOR_VERSION} -ge 6 ]]; then
 fi
 
 if [[ ${SDFORMAT_MAJOR_VERSION} -ge 8 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
   
 export ABI_JOB_REPOS="stable"

--- a/jenkins-scripts/docker/sdformat-compilation.bash
+++ b/jenkins-scripts/docker/sdformat-compilation.bash
@@ -23,7 +23,7 @@ if [[ ${SDFORMAT_MAJOR_VERSION} -ge 6 ]]; then
 fi
 
 if [[ ${SDFORMAT_MAJOR_VERSION} -ge 8 ]]; then
-  export USE_GCC8=true
+  export NEED_C17_COMPILER=true
 fi
 
 export GZDEV_PROJECT_NAME="sdformat${SDFORMAT_MAJOR_VERSION}"

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -469,7 +469,7 @@ ignition_debbuild.each { ign_sw ->
     extra_str = ""
     if (("${ign_sw}" == "gazebo") ||
         (("${ign_sw}" == "transport") && ("${major_version}" == "6"  || "${major_version}" == "7" )))
-      extra_str="export USE_GCC8=true"
+      extra_str="export NEED_C17_COMPILER=true"
 
     def build_pkg_job = job("ign-${ign_sw}${major_version}-debbuilder")
     OSRFLinuxBuildPkg.create(build_pkg_job)


### PR DESCRIPTION
As far as I can see we are using two variable for the same thing. I prefer `NEED_C17_COMPILER` so I changed all references to USE_GCC8 here to use it. Needs to be tested, alternative to #289 , close #288 