### PR TITLE
Replace mercurial with git in job installations. Install bc in agents.

### DIFF
--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -32,7 +32,7 @@ OSRF_DEPS="IGN_CMAKE IGN_TOOLS IGN_MATH IGN_MSGS IGN_TRANSPORT IGN_COMMON IGN_FU
 OSRF_DEPS_DONE=""
 for dep_uppercase in $OSRF_DEPS; do
   dep=`echo $dep_uppercase | tr '[:upper:]' '[:lower:]'`
-  DEPENDENCY_PKGS="${DEPENDENCY_PKGS} mercurial"
+  DEPENDENCY_PKGS="${DEPENDENCY_PKGS} git"
   eval dependecy_installation="\$BUILD_$dep_uppercase"
 
   # Prevent multiple builds of same dep

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -159,7 +159,7 @@ output_dir=$WORKSPACE/output
 work_dir=$WORKSPACE/work
 
 # TODO: Check for docker package
-NEEDED_HOST_PACKAGES="mercurial python-setuptools python-psutil qemu-user-static gpgv squid-deb-proxy bc"
+NEEDED_HOST_PACKAGES="git python-setuptools python-psutil qemu-user-static gpgv squid-deb-proxy bc"
 # python-argparse is integrated in libpython2.7-stdlib since raring
 # Check for precise in the HOST system (not valid DISTRO variable)
 if [[ $(lsb_release -sr | cut -c 1-5) == '12.04' ]]; then

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -159,7 +159,7 @@ output_dir=$WORKSPACE/output
 work_dir=$WORKSPACE/work
 
 # TODO: Check for docker package
-NEEDED_HOST_PACKAGES="mercurial python-setuptools python-psutil qemu-user-static gpgv squid-deb-proxy"
+NEEDED_HOST_PACKAGES="mercurial python-setuptools python-psutil qemu-user-static gpgv squid-deb-proxy bc"
 # python-argparse is integrated in libpython2.7-stdlib since raring
 # Check for precise in the HOST system (not valid DISTRO variable)
 if [[ $(lsb_release -sr | cut -c 1-5) == '12.04' ]]; then

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -239,7 +239,6 @@ DEPENDENCY_PKGS="devscripts \
 		 ca-certificates \
 		 equivs \
 		 dh-make \
-		 mercurial \
 		 git"
 
 . ${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash

--- a/jenkins-scripts/docker/lib/debbuild-bloom-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-bloom-base.bash
@@ -121,7 +121,6 @@ DEPENDENCY_PKGS="devscripts \
 		 ca-certificates \
 		 equivs \
 		 dh-make \
-		 mercurial \
 		 git \
 		 python-openssl \
                  ca-certificates \

--- a/jenkins-scripts/docker/lib/gazebo-base-default.bash
+++ b/jenkins-scripts/docker/lib/gazebo-base-default.bash
@@ -118,7 +118,7 @@ DELIM_DART
 # Process the source build of dependencies if needed
 for dep_uppercase in $GAZEBO_OSRF_DEPS; do
   dep=`echo $dep_uppercase | tr '[:upper:]' '[:lower:]'`
-  EXTRA_PACKAGES="${EXTRA_PACKAGES} mercurial"
+  EXTRA_PACKAGES="${EXTRA_PACKAGES} git"
   eval dependecy_installation="\$GAZEBO_BUILD_$dep_uppercase"
 
   if [[ -n ${dependecy_installation} ]] && ${dependecy_installation}; then

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -204,7 +204,6 @@ OSRF_REPOS_TO_USE=${ABI_JOB_REPOS}
 DEPENDENCY_PKGS="${ABI_JOB_PKG_DEPENDENCIES} \
                   git \
                   exuberant-ctags \
-                  mercurial \
                   ca-certificates"
 
 . ${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash

--- a/jenkins-scripts/docker/lib/simbody-release-base.bash
+++ b/jenkins-scripts/docker/lib/simbody-release-base.bash
@@ -106,7 +106,7 @@ RUN mkdir -p ${WORKSPACE}
 # automatic invalidation of the cache if day is different
 RUN echo "${TODAY_STR}"
 RUN apt-get update
-RUN apt-get install -y fakeroot debootstrap devscripts equivs dh-make ubuntu-dev-tools mercurial debhelper wget pkg-kde-tools bash-completion git
+RUN apt-get install -y fakeroot debootstrap devscripts equivs dh-make ubuntu-dev-tools debhelper wget pkg-kde-tools bash-completion git
 ADD build.sh build.sh
 RUN chmod +x build.sh
 DELIM_DOCKER

--- a/jenkins-scripts/gazebo-one_liner-homebrew.bash
+++ b/jenkins-scripts/gazebo-one_liner-homebrew.bash
@@ -8,10 +8,6 @@ echo '# BEGIN SECTION: cleanup brew installation'
 . ${SCRIPT_DIR}/lib/_homebrew_cleanup.bash
 echo '# END SECTION'
 
-echo '# BEGIN SECTION: re-install mercurial'
-brew install hg
-echo '# END SECTION'
-
 echo '# BEGIN SECTION: run the one-liner installation'
 # TODO: change this to 'curl -ssL https://get.gazebosim.org' once that supports https
 curl -ssL https://github.com/ignition-tooling/release-tools/raw/master/one-line-installations/gazebo.sh | sh -x

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -50,7 +50,7 @@ BASE_DEPENDENCIES="build-essential \\
                    net-tools       \\
                    locales"
 
-BREW_BASE_DEPENDCIES="mercurial git cmake"
+BREW_BASE_DEPENDCIES="git cmake"
 
 # 1. SDFORMAT
 # ruby for xml_schemas generation and libxml2-utils for xmllint used in tests
@@ -780,8 +780,7 @@ IGN_RNDF_DEPENDENCIES="libignition-cmake-dev \\
 #
 # SUBT
 #
-SUBT_DEPENDENCIES="mercurial \\
-                   wget \\
+SUBT_DEPENDENCIES="wget \\
                    curl \\
                    git  \\
                    ${ROS_CATKIN_BASE} \\

--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -51,7 +51,7 @@ export DISPLAY=$(ps ax \
 
 echo '# BEGIN SECTION: run test-bot'
 # The test-bot makes a full cleanup of all installed pkgs. Be sure of install back
-# mercurial to keep the slave working
+# git to keep the slave working
 export HOMEBREW_DEVELOPER=1
 brew tap osrf/simulation
 # replace with 'hub -C $(brew --repo osrf/simulation) pr checkout ${ghprbPullId}'


### PR DESCRIPTION
First commit 5374cf6 installs `bc` tool in agents, used to calculate docker version introduced in #282.
Second commit ee4eca4 replaces or removes the mercurial occurrences still present in the scripts.