### PR TITLE
Fix C17 compiler support ign-gazebo4

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -467,8 +467,9 @@ ignition_debbuild.each { ign_sw ->
       major_version = ""
 
     extra_str = ""
-    if (("${ign_sw}" == "gazebo") ||
-        (("${ign_sw}" == "transport") && ("${major_version}" == "6"  || "${major_version}" == "7" )))
+    // Need to use gazebo4 as ign_sw since its a debbuild injection
+    if (("${ign_sw}" == "gazebo4") ||
+        (("${ign_sw}" == "transport") && ("${major_version}" == "7" )))
       extra_str="export NEED_C17_COMPILER=true"
 
     def build_pkg_job = job("ign-${ign_sw}${major_version}-debbuilder")

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -467,8 +467,7 @@ ignition_debbuild.each { ign_sw ->
       major_version = ""
 
     extra_str = ""
-    // Need to use gazebo4 as ign_sw since its a debbuild injection
-    if (("${ign_sw}" == "gazebo4") ||
+    if (ign_sw.contains("gazebo") ||
         (("${ign_sw}" == "transport") && ("${major_version}" == "7" )))
       extra_str="export NEED_C17_COMPILER=true"
 


### PR DESCRIPTION
The [`ignition_debbuild variable`](https://github.com/ignition-tooling/release-tools/compare/fix_c17_compiler_dsl?expand=1#diff-8c195dd6c7fec2a7aaf5895c7ebaad77R52) is composed from the usual dictionary of software names unversioned plus an array of supported versions and we add to it debbuilds for the software still unreleased in the form of an array of versioned software names. This mess needs to be fix properly in a different PR. This one makes ign-gazebo4-debbuilder to really use the `NEED_C17_COMPILER` variable.

As an extra ball, remove version 6 of transport which is unsupported.

Tested here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition&build=1030)](https://build.osrfoundation.org/view/All/job/_dsl_ignition/1030/)