### PR TITLE
Remove the gazebo-ci-pr_any-ubuntu-none jobs

### DIFF
--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -124,9 +124,6 @@ abi_distro.each { distro ->
   } // end of arch
 } // end of distro
 
-// MAIN CI job
-ci_build_any_job_name_linux_no_gpu = ""
-
 // CI JOBS @ SCM/5 min
 ci_distro.each { distro ->
   ci_gpu.each { gpu ->
@@ -142,9 +139,6 @@ ci_distro.each { distro ->
 
         steps
         {
-           // save the name to be used in the Workflow job
-           ci_build_any_job_name_linux_no_gpu = gazebo_ci_any_job_name
-
            shell("""\
            #!/bin/bash -xe
            wget https://raw.githubusercontent.com/osrf/bash-yaml/master/yaml.sh -O yaml.sh
@@ -616,6 +610,5 @@ all_branches.each { branch ->
 def gazebo_ci_main = pipelineJob("gazebo-ci-manual_any")
 OSRFCIWorkFlowMultiAnyGitHub.create(gazebo_ci_main,
                                    [ci_build_any_job_name_linux,
-                                    ci_build_any_job_name_linux_no_gpu,
                                     ci_build_any_job_name_win7,
                                     ci_build_any_job_name_brew])

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -128,10 +128,8 @@ abi_distro.each { distro ->
 ci_build_any_job_name_linux_no_gpu = ""
 
 // CI JOBS @ SCM/5 min
-ci_gpu_include_gpu_none = ci_gpu + [ 'none' ]
-
 ci_distro.each { distro ->
-  ci_gpu_include_gpu_none.each { gpu ->
+  ci_gpu.each { gpu ->
     supported_arches.each { arch ->
       // --------------------------------------------------------------
       // 1. Create the any job
@@ -140,19 +138,12 @@ ci_distro.each { distro ->
       OSRFLinuxCompilationAnyGitHub.create(gazebo_ci_any_job, "osrf/gazebo")
       gazebo_ci_any_job.with
       {
-        if (gpu != 'none')
-        {
-          label "gpu-reliable"
-        }
+        label "gpu-reliable"
 
         steps
         {
-           String gpu_needed = 'true'
-           if (gpu == 'none') {
-              gpu_needed = 'false'
-              // save the name to be used in the Workflow job
-              ci_build_any_job_name_linux_no_gpu = gazebo_ci_any_job_name
-           }
+           // save the name to be used in the Workflow job
+           ci_build_any_job_name_linux_no_gpu = gazebo_ci_any_job_name
 
            shell("""\
            #!/bin/bash -xe
@@ -171,7 +162,7 @@ ci_distro.each { distro ->
            fi
 
            export ARCH=${arch}
-           export GPU_SUPPORT_NEEDED=${gpu_needed}
+           export GPU_SUPPORT_NEEDED=true
            /bin/bash -xe ./scripts/jenkins-scripts/docker/gazebo-compilation.bash
            """.stripIndent())
          }
@@ -189,18 +180,10 @@ ci_distro.each { distro ->
 
       gazebo_ci_job.with
       {
-        if (gpu != 'none')
-        {
-          label "gpu-reliable"
-        }
+        label "gpu-reliable"
 
         triggers {
           scm('*/5 * * * *')
-        }
-
-        String gpu_needed = 'true'
-        if (gpu == 'none') {
-          gpu_needed = 'false'
         }
 
         steps {
@@ -209,7 +192,7 @@ ci_distro.each { distro ->
 
                 export DISTRO=${ci_distro_default_str}
                 export ARCH=${arch}
-                export GPU_SUPPORT_NEEDED=${gpu_needed}
+                export GPU_SUPPORT_NEEDED=true
                 /bin/bash -xe ./scripts/jenkins-scripts/docker/gazebo-compilation.bash
                 """.stripIndent())
         }


### PR DESCRIPTION
The PR removes the -none job that is part of the Gazebo CI in pull request. The results are covered by the use ci-pr_any-ubuntu-gpu-nvidia job.