### PR TITLE
Change frenquency of install jobs to 1 every three days

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -10,6 +10,9 @@ class Globals
    static rtools_description = true
    static gazebodistro_branch = false
 
+
+   static CRON_EVERY_THREE_DAYS = 'H H * * H/3'
+
    static gpu_by_distro  = [ xenial  : [ 'nvidia' ] ,
                              bionic  : [ 'nvidia' ]]
 

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -29,36 +29,6 @@ packages.each { repo_name, pkgs ->
  pkgs.each { pkg ->
 
   // --------------------------------------------------------------
-  // 1. Create the job that tries to install packages
-  def install_job = job("${pkg}-install-pkg-debian_sid-amd64")
-  OSRFLinuxInstall.create(install_job)
-  install_job.with
-  {
-     triggers {
-       cron('@weekly')
-     }
-
-    // No accepted in Sid yet
-    if ((pkg == 'sdformat6') || (pkg == 'ignition-transport4'))
-    {
-      disabled()
-    }
-
-     steps {
-      shell("""\
-            #!/bin/bash -xe
-
-            export LINUX_DISTRO=debian
-            export DISTRO=sid
-            export ARCH=amd64
-            # Hack to select the latest -dev of series
-            export INSTALL_JOB_PKG="\\\$(apt-cache search ${pkg} | grep '${pkg}[0-9]-dev -' | tail -1 | awk '{print \\\$1}')"
-            /bin/bash -x ./scripts/jenkins-scripts/docker/generic-install-test-job.bash
-            """.stripIndent())
-    }
-  }
-
-  // --------------------------------------------------------------
   // 2. Create the job that tries to build the package and run lintian
   def ci_job = job("${pkg}-pkg_builder-master-debian_sid-amd64")
   OSRFLinuxBuildPkgBase.create(ci_job)
@@ -76,10 +46,6 @@ packages.each { repo_name, pkgs ->
 
           branch('refs/heads/master')
         }
-      }
-
-      triggers {
-        scm('@daily')
       }
 
       properties {

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -48,7 +48,7 @@ void generate_install_job(Job job, gz_branch, distro, arch, use_osrf_repos = fal
   job.with
   {
     triggers {
-      cron('@daily')
+      cron(Globals.CRON_EVERY_THREE_DAYS)
     }
 
     // Branch is exactly in the form of gazeboN
@@ -449,7 +449,7 @@ all_supported_distros.each { distro ->
     install_default_job.with
     {
       triggers {
-        cron('@daily')
+        cron(Globals.CRON_EVERY_THREE_DAYS)
       }
 
       label "gpu-reliable"

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -183,7 +183,7 @@ void include_common_params(Job gazebo_ros_pkgs_job,
       install_default_job.with
       {
         triggers {
-          cron('@daily')
+          cron(Globals.CRON_EVERY_THREE_DAYS)
         }
       }
 
@@ -200,7 +200,7 @@ void include_common_params(Job gazebo_ros_pkgs_job,
       install_stable_default_job.with
       {
         triggers {
-          cron('@daily')
+          cron(Globals.CRON_EVERY_THREE_DAYS)
         }
       }
 
@@ -223,7 +223,7 @@ void include_common_params(Job gazebo_ros_pkgs_job,
           install_alternative_job.with
           {
             triggers {
-              cron('@daily')
+              cron(Globals.CRON_EVERY_THREE_DAYS)
             }
           }
 

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -90,6 +90,7 @@ abi_job_names = [:]
 
 Globals.extra_emails = "caguero@osrfoundation.org"
 
+
 String ci_distro_str = ci_distro[0]
 
 // Map of lists to use in CIWorkflow
@@ -368,7 +369,7 @@ ignition_software.each { ign_sw ->
         install_default_job.with
         {
           triggers {
-            cron('@daily')
+            cron(Globals.CRON_EVERY_THREE_DAYS)
           }
 
           def dev_package = "libignition-${ign_sw}${major_version}-dev"

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -298,7 +298,7 @@ ignition_collections.each { ign_collection ->
     install_default_job.with
     {
       triggers {
-        cron('@daily')
+        cron(Globals.CRON_EVERY_THREE_DAYS)
       }
 
       def dev_package = "ignition-${ign_collection_name}"

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -244,7 +244,7 @@ sdformat_supported_branches.each { branch ->
       install_default_job.with
       {
          triggers {
-           cron('@daily')
+           cron(Globals.CRON_EVERY_THREE_DAYS)
          }
 
          // sdformat10 hasn't been released yet

--- a/jenkins-scripts/dsl/subt.dsl
+++ b/jenkins-scripts/dsl/subt.dsl
@@ -105,7 +105,7 @@ ci_distro.each { distro ->
     install_default_job.with
     {
       triggers {
-        cron('@daily')
+        cron(Globals.CRON_EVERY_THREE_DAYS)
       }
 
       label "gpu-nvidia-docker2"
@@ -133,7 +133,7 @@ ci_distro.each { distro ->
     install_cloud_job.with
     {
       triggers {
-        cron('@daily')
+        cron(Globals.CRON_EVERY_THREE_DAYS)
       }
 
       label "gpu-nvidia-docker2"
@@ -181,7 +181,7 @@ all_supported_distros.each { distro ->
       }
 
       triggers {
-        cron('@daily')
+        cron(Globals.CRON_EVERY_THREE_DAYS)
       }
 
       label "gpu-reliable"

--- a/jenkins-scripts/dsl/vrx.dsl
+++ b/jenkins-scripts/dsl/vrx.dsl
@@ -117,7 +117,7 @@ ci_distro.each { distro, ros_distro ->
         disabled()
 
       triggers {
-        cron('@daily')
+        cron(Globals.CRON_EVERY_THREE_DAYS)
       }
 
       label "gpu-reliable"


### PR DESCRIPTION
The PR changes the frequency of our -install- jobs on Linux from once a day to once every three days. As an extra ball, all debian install jobs are removed since Debian has its own QA methods.