### PR TITLE
Dome CI: don't need to build deps from source

### DIFF
--- a/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
+++ b/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
@@ -29,12 +29,6 @@ if ! [[ ${IGN_FUEL_TOOLS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_FUEL_TOOLS_MAJOR_VERSION} -ge 5 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-fi
-
 export GZDEV_PROJECT_NAME="ignition-fuel-tools${IGN_FUEL_TOOLS_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_gazebo-compilation.bash
+++ b/jenkins-scripts/docker/ign_gazebo-compilation.bash
@@ -28,32 +28,6 @@ if ! [[ ${IGN_GAZEBO_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_GAZEBO_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_FUEL_TOOLS=true
-  export IGN_FUEL_TOOLS_MAJOR_VERSION=5
-  export IGN_FUEL_TOOLS_BRANCH=master
-
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=master
-
-  export BUILD_IGN_PHYSICS=true
-  export IGN_PHYSICS_MAJOR_VERSION=3
-  export IGN_PHYSICS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_SENSORS=true
-  export IGN_SENSORS_MAJOR_VERSION=4
-  export IGN_SENSORS_BRANCH=master
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=9
-  export IGN_TRANSPORT_BRANCH=master
-fi
-
 export NEED_C17_COMPILER=true
 export GPU_SUPPORT_NEEDED=true
 

--- a/jenkins-scripts/docker/ign_gui-compilation.bash
+++ b/jenkins-scripts/docker/ign_gui-compilation.bash
@@ -28,20 +28,6 @@ if ! [[ ${IGN_GUI_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_GUI_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=9
-  export IGN_TRANSPORT_BRANCH=master
-fi
-
 if [[ ${IGN_GUI_MAJOR_VERSION} -ge 1 ]]; then
   export NEED_C17_COMPILER=true
 fi

--- a/jenkins-scripts/docker/ign_launch-compilation.bash
+++ b/jenkins-scripts/docker/ign_launch-compilation.bash
@@ -28,36 +28,6 @@ if ! [[ ${IGN_LAUNCH_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_LAUNCH_MAJOR_VERSION} -ge 3 ]]; then
-  export BUILD_IGN_FUEL_TOOLS=true
-  export IGN_FUEL_TOOLS_MAJOR_VERSION=5
-  export IGN_FUEL_TOOLS_BRANCH=master
-
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=master
-
-  export BUILD_IGN_PHYSICS=true
-  export IGN_PHYSICS_MAJOR_VERSION=3
-  export IGN_PHYSICS_BRANCH=master
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_SENSORS=true
-  export IGN_SENSORS_MAJOR_VERSION=4
-  export IGN_SENSORS_BRANCH=master
-
-  export BUILD_IGN_GAZEBO=true
-  export IGN_GAZEBO_MAJOR_VERSION=4
-  export IGN_GAZEBO_BRANCH=master
-fi
-
 export NEED_C17_COMPILER=true
 
 export GZDEV_PROJECT_NAME="ignition-launch${IGN_LAUNCH_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_rendering-compilation.bash
+++ b/jenkins-scripts/docker/ign_rendering-compilation.bash
@@ -28,12 +28,6 @@ if ! [[ ${IGN_RENDERING_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_RENDERING_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_COMMON=true
-  export IGN_COMMON_MAJOR_VERSION=3
-  export IGN_COMMON_BRANCH=ign-common3
-fi
-
 if [[ ${IGN_RENDERING_MAJOR_VERSION} -ge 1 ]]; then
   export NEED_C17_COMPILER=true
 fi

--- a/jenkins-scripts/docker/ign_sensors-compilation.bash
+++ b/jenkins-scripts/docker/ign_sensors-compilation.bash
@@ -28,24 +28,6 @@ if ! [[ ${IGN_SENSORS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_SENSORS_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=master
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=9
-  export IGN_TRANSPORT_BRANCH=master
-fi
-
 export NEED_C17_COMPILER=true
 
 export GPU_SUPPORT_NEEDED=true

--- a/jenkins-scripts/docker/ign_transport-compilation.bash
+++ b/jenkins-scripts/docker/ign_transport-compilation.bash
@@ -32,13 +32,6 @@ if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
-if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -eq 9 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-fi
-
-
 export GZDEV_PROJECT_NAME="ignition-transport${IGN_TRANSPORT_MAJOR_VERSION}"
 
 . "${SCRIPT_DIR}/lib/generic-building-base.bash"


### PR DESCRIPTION
All dome packages have been released, so we don't need to build any dome dependencies from source anymore.