### PR TITLE
sdformat.dsl: enable sdformat10 linux install job

### DIFF
--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 def sdformat_supported_branches = [ 'sdformat4', 'sdformat6', 'sdformat8' , 'sdformat9', 'sdformat10' ]
 def sdformat_gz11_branches = [ 'sdformat8', 'sdformat9', 'sdformat10', 'master' ]
 // nightly and prereleases
-def extra_sdformat_debbuilder = [ 'sdformat10' ]
+def extra_sdformat_debbuilder = [  ]
 
 // Main platform using for quick CI
 def ci_distro               = Globals.get_ci_distro()
@@ -246,10 +246,6 @@ sdformat_supported_branches.each { branch ->
          triggers {
            cron(Globals.CRON_EVERY_THREE_DAYS)
          }
-
-         // sdformat10 hasn't been released yet
-         if ("${branch}" == "sdformat10")
-	   disabled()
 
          def dev_package = "lib${branch}-dev"
 


### PR DESCRIPTION
This project is still disabled even though the stable release has been made. It's safe to enable it now.

https://build.osrfoundation.org/view/ign-dome/job/sdformat-install-sdformat10_pkg-bionic-amd64/