### PR TITLE
ignition.dsl: disable dome xenial install jobs

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -324,21 +324,23 @@ ignition_software.each { ign_sw ->
             (("${ign_sw}" == "cmake")      && ("${major_version}" == "2")) ||
             (("${ign_sw}" == "common")     && ("${major_version}" == "3")) ||
             (("${ign_sw}" == "fuel-tools") &&
-              (("${major_version}" == "3") || ("${major_version}" == "4"))) ||
+              (("${major_version}" == "3") || ("${major_version}" == "4") ||
+               ("${major_version}" == "5"))) ||
              ("${ign_sw}" == "gazebo")     ||
              ("${ign_sw}" == "gui")        ||
              ("${ign_sw}" == "launch")     ||
             (("${ign_sw}" == "math")       && ("${major_version}" == "6")) ||
             (("${ign_sw}" == "msgs")       &&
               (("${major_version}" == "2") || ("${major_version}" == "3") ||
-               ("${major_version}" == "4") || ("${major_version}" == "5"))) ||
+               ("${major_version}" == "4") || ("${major_version}" == "5") ||
+               ("${major_version}" == "6"))) ||
              ("${ign_sw}" == "physics")    ||
              ("${ign_sw}" == "plugin")     ||
              ("${ign_sw}" == "rendering")  ||
              ("${ign_sw}" == "sensors")    ||
             (("${ign_sw}" == "transport")  &&
-              (("${major_version}" == "6") ||
-               ("${major_version}" == "7") || ("${major_version}" == "8")))))
+              (("${major_version}" == "6") || ("${major_version}" == "7") ||
+               ("${major_version}" == "8") || ("${major_version}" == "9")))))
           return
 
         extra_repos_str=""

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -25,7 +25,7 @@ ignition_collections = [
           'rendering' : [ debbuild: 'ign-rendering4' , branch: 'ign-rendering4' ],
           'sensors'   : [ debbuild: 'ign-sensors4'   , branch: 'ign-sensors4' ],
           'sdformat'  : [ debbuild: 'sdformat10'     , branch: 'sdf10'  ],
-          'transport' : [ debbuild: 'ign-transport9' , branch: 'ign-transort9' ],
+          'transport' : [ debbuild: 'ign-transport9' , branch: 'ign-transport9' ],
     ],
   ],
 ]


### PR DESCRIPTION
I failed to disable a few of the ignition dome xenial install jobs:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_msgs6-install-pkg-xenial-amd64&build=1)](https://build.osrfoundation.org/job/ignition_msgs6-install-pkg-xenial-amd64/1/) https://build.osrfoundation.org/job/ignition_msgs6-install-pkg-xenial-amd64/1/

This should fix it.

