### PR TITLE
New script to create multipe -release repos for new Ignition releases

### DIFF
--- a/release-repo-scripts/bump_major_version.bash
+++ b/release-repo-scripts/bump_major_version.bash
@@ -22,6 +22,8 @@
 old_version=${1}
 new_version=${2}
 
+set -e
+
 if [[ $# -lt 1 ]]; then
     echo "bump_major_version.bash <old_version> <new_version>"
     exit 1

--- a/release-repo-scripts/new_ignition_release_repos.bash
+++ b/release-repo-scripts/new_ignition_release_repos.bash
@@ -2,9 +2,7 @@
 
 set -e
 
-# Knowing Script dir beware of symlink
-[[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
-SCRIPT_DIR="${SCRIPT_DIR%/*}"
+SCRIPT_DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 if [[ $# -lt 1 ]]; then
     echo "$0 <list_of_new_ignition_names_space_separated"

--- a/release-repo-scripts/new_ignition_release_repos.bash
+++ b/release-repo-scripts/new_ignition_release_repos.bash
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -e
+
+# Knowing Script dir beware of symlink
+[[ -L ${0} ]] && SCRIPT_DIR=$(readlink ${0}) || SCRIPT_DIR=${0}
+SCRIPT_DIR="${SCRIPT_DIR%/*}"
+
+if [[ $# -lt 1 ]]; then
+    echo "$0 <list_of_new_ignition_names_space_separated"
+    echo " example: $0 ign-cmake3 ign-common22"
+    exit 1
+fi
+
+NEW_REPOS=${1}
+
+repo_exists()
+{
+    local repo_github=${1}
+
+    if gh repo view $repo_github 2>1 > /dev/null; then
+	echo true
+    else
+	echo false
+    fi
+}
+
+empty_directory()
+{
+    local dir=${1}
+       
+    if [[ -d "${dir}/ubuntu" ]]; then
+       echo false
+    else
+       echo true
+    fi
+}
+
+for repo_name in ${NEW_REPOS}; do
+    echo "Procesing ${repo_name}"
+    repo_fname="${repo_name}-release"
+    repo_github="ignition-release/${repo_fname}"
+    echo " + creating the repository "
+    # check destination directory
+    if [[ -d ${repo_fname} ]]; then
+       echo "  ? local dir ${repo_fname} exist in this directory. Is it emptY?"
+       if ! $(empty_directory ${repo_fname}); then
+       	  echo "   ! directory is not empty. Abort"
+    	  continue
+       fi
+       echo "   + ${repo_fname} is empty, assume github repo"
+    else
+	# check repo in github
+	if $(repo_exists ${repo_github}); then
+	    echo "  ? repository ${repo_github} already exists!. Is it empty?"
+	    gh repo clone ${repo_github} ${repo_fname} 2> /dev/null
+	    if ! $(empty_directory ${repo_fname}); then
+       	       echo "   ! directory is not empty. Abort"
+	       continue
+	    fi
+            echo "   + ${repo_fname} is empty"
+	else
+	 gh repo create \
+	      --confirm \
+		--public \
+		--enable-issues \
+		--description "Debian/Ubuntu metadata for ${repo_name}" \
+		${repo_github}
+     	fi
+    fi
+    # repository checkout in place
+    cd ${repo_fname}
+    version="$(sed  's/.*[^0-9]\([0-9]\+\)[^0-9]*$/\1/' <<< ${repo_name})"
+    previous_version=$(expr ${version} - 1)
+    previous_repo_github="${repo_github/[0-9]*}${previous_version}-release"
+    echo " + pull from previous version ${previous_repo_github}" 
+    git remote add previous "https://github.com/${previous_repo_github}"
+    git fetch previous
+    git pull -q previous master >/dev/null 2>&1 || git pull -q previous main >/dev/null 2>&1
+    git remote remove previous
+    echo " + run bump_major_version script ${previous_version} -> ${version}"
+    echo
+    echo " -------------------------------"
+    "${SCRIPT_DIR}/bump_major_version.bash" ${previous_version} ${version}
+    echo " -------------------------------"
+    echo
+    echo " ? check output for possible FIXME messages"
+    read -n 1 -s -r -p "  press any key to continue"
+    git status
+    echo " ? ready to commit --all and push ?"
+    read -n 1 -s -r -p "  press any key to continue"
+    git commit -m "Change metadata from ${previous_version} version to ${version}" --all
+    git push origin master || git push origin main
+done


### PR DESCRIPTION
Some bash lines to make our life easier when changing to a new version of Ignition collections. What it does:

 1. Create ign-fooY-release if it does not exits
 1. Clone to the current directory
 1. Pull from main/master branch from previous version, ign-fooX-release repository to have the whole history
 1. Run the  bump_major_version from X to Y
 1. Show the results
 1. commit/push all the changes

I've used it to create https://github.com/ignition-release/ign-fuel-tools6-release using:

```bash
~/code/release-tools/release-repo-scripts/new_ignition_release_repos.bash ign-fuel-tools6
```
Multiple space separated arguments can be passed. It requires that the user has the awesome https://github.com/cli/cli installed and configured.

