### PR TITLE
Migrate release.py to python3

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -621,7 +621,7 @@ nightly_scheduler_job.with
               fi
 
               echo "releasing \${n} (as \${alias}) from branch \${src_branch} \${ignitionrepo}"
-              python ./scripts/release.py \${dry_run_str} "\${n}" nightly "\${PASS}" -a \${alias} --extra-osrf-repo prerelease --release-repo-branch main --nightly-src-branch \${src_branch} --upload-to-repo nightly  \${ignitionrepo} > log || echo "MARK_AS_UNSTABLE"
+              python3 ./scripts/release.py \${dry_run_str} "\${n}" nightly "\${PASS}" -a \${alias} --extra-osrf-repo prerelease --release-repo-branch main --nightly-src-branch \${src_branch} --upload-to-repo nightly  \${ignitionrepo} > log || echo "MARK_AS_UNSTABLE"
               echo " - done"
           done
 

--- a/release.py
+++ b/release.py
@@ -295,14 +295,13 @@ def check_s3cmd_configuration():
     return True
 
 def sanity_checks(args, repo_dir):
-    check_s3cmd_configuration()
-
     sanity_package_name_underscore(args.package, args.package_alias)
     sanity_package_name(repo_dir, args.package, args.package_alias)
     sanity_check_repo_name(args.upload_to_repository)
     sanity_use_prerelease_branch(args.release_repo_branch)
 
     if not NIGHTLY:
+        check_s3cmd_configuration()
         sanity_package_version(repo_dir, args.version, str(args.release_version))
         sanity_check_gazebo_versions(args.package, args.version)
         sanity_check_sdformat_versions(args.package, args.version)

--- a/release.py
+++ b/release.py
@@ -365,9 +365,9 @@ def check_call(cmd, ignore_dry_run = False):
             # bitbucket for the first one, github for the second
             if (b"404" in err) or (b"Repository not found" in err):
                 raise ErrorURLNotFound404()
-            if "Permission denied" in out:
+            if b"Permission denied" in out:
                 raise ErrorNoPermsRepo()
-            if "abort: no username supplied" in err:
+            if b"abort: no username supplied" in err:
                 raise ErrorNoUsernameSupplied()
             # Unkown exception
             print('Error running command (%s).'%(' '.join(cmd)))

--- a/release.py
+++ b/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import subprocess
@@ -196,16 +196,16 @@ def sanity_package_name(repo_dir, package, package_alias):
 
     cmd = ["find", repo_dir, "-name", "changelog","-exec","head","-n","1","{}",";"]
     out, err = check_call(cmd, IGNORE_DRY_RUN)
-    for line in out.split("\n"):
+    for line in out.split('\n'.encode()):
         if not line:
             continue
         # Check that first word is the package alias or name
-        if line.partition(' ')[0] != expected_name:
-            error("Error in changelog package name or alias: " + line)
+        if line.partition(' '.encode())[0] != expected_name:
+            error("Error in changelog package name or alias: " + line.decode())
 
     cmd = ["find", repo_dir, "-name", "control","-exec","grep","-H","Source:","{}",";"]
     out, err = check_call(cmd, IGNORE_DRY_RUN)
-    for line in out.split("\n"):
+    for line in out.split('\n'.encode()):
         if not line:
             continue
         # Check that first word is the package alias or name
@@ -217,7 +217,7 @@ def sanity_package_name(repo_dir, package, package_alias):
 def sanity_package_version(repo_dir, version, release_version):
     cmd = ["find", repo_dir, "-name", "changelog","-exec","head","-n","1","{}",";"]
     out, err = check_call(cmd, IGNORE_DRY_RUN)
-    for line in out.split("\n"):
+    for line in out.split('\n'.encode()):
         if not line:
             continue
         # return full version in brackets
@@ -324,7 +324,7 @@ def discover_distros(repo_dir):
     if not os.path.isdir(repo_dir):
         return None
 
-    root, subdirs, files = os.walk(repo_dir).next()
+    _, subdirs, files = os.walk(repo_dir).__next__()
     repo_arch_exclusion = get_exclusion_arches(files)
 
     if '.git' in subdirs: subdirs.remove('.git')
@@ -339,7 +339,7 @@ def discover_distros(repo_dir):
 
     distro_arch_list = {}
     for d in subdirs:
-        files = os.walk(repo_dir + '/' + d).next()[2]
+        files = os.walk(repo_dir + '/' + d).__next__()[2]
         distro_arch_exclusion = get_exclusion_arches(files)
         excluded_arches = distro_arch_exclusion + repo_arch_exclusion
         arches_supported = [x for x in SUPPORTED_ARCHS if x not in excluded_arches]

--- a/release.py
+++ b/release.py
@@ -363,7 +363,7 @@ def check_call(cmd, ignore_dry_run = False):
         out, err = po.communicate()
         if po.returncode != 0:
             # bitbucket for the first one, github for the second
-            if ("404" in err) or ("Repository not found" in err):
+            if (b"404" in err) or (b"Repository not found" in err):
                 raise ErrorURLNotFound404()
             if "Permission denied" in out:
                 raise ErrorNoPermsRepo()

--- a/release.py
+++ b/release.py
@@ -5,8 +5,8 @@ import subprocess
 import sys
 import tempfile
 import os
-import urllib
 import urllib.parse
+import urllib.request
 import argparse
 import shutil
 import re
@@ -555,7 +555,7 @@ def go(argv):
                                                    params_query)
     if not DRY_RUN and not NIGHTLY:
         print('- Brew: %s'%(brew_url))
-        urllib.urlopen(brew_url)
+        urllib.request.urlopen(brew_url)
 
     # RELEASING FOR LINUX
     for l in LINUX_DISTROS:
@@ -603,7 +603,7 @@ def go(argv):
                 print('- Linux: %s'%(url))
 
                 if not DRY_RUN:
-                    urllib.urlopen(url)
+                    urllib.request.urlopen(url)
 
 if __name__ == '__main__':
     go(sys.argv)

--- a/release.py
+++ b/release.py
@@ -65,7 +65,7 @@ def is_catkin_package():
 
 def github_repo_exists(url):
     try:
-        check_call(['git', 'ls-remote', url], IGNORE_DRY_RUN)
+        check_call(['git', 'ls-remote', '-q', '--exit-code', url], IGNORE_DRY_RUN)
     except ErrorURLNotFound404 as e:
         return False
     except Exception as e:
@@ -151,9 +151,10 @@ def parse_args(argv):
     return args
 
 def get_release_repository_info(package):
-    # if fails with http URL for github, it will ask for auth in stdin. Use the
-    # git@ approach to avoid interaction
-    github_test_url = "git@github.com:ignition-release/" + package + "-release"
+    # Do not use git@github method since it fails in non existant repositories
+    # asking for stdin user/pass. Same happen if no user/pass is provided
+    # using the fake foo:foo here seems to work
+    github_test_url = "https://foo:foo@github.com/ignition-release/" + package + "-release"
     if (github_repo_exists(github_test_url)):
         github_url = "https://github.com/ignition-release/" + package + "-release"
         return 'git', github_url

--- a/release.py
+++ b/release.py
@@ -48,6 +48,9 @@ class ErrorNoUsernameSupplied(Exception):
 class ErrorURLNotFound404(Exception):
     pass
 
+class ErrorNoOutput(Exception):
+    pass
+
 def error(msg):
     print("\n !! " + msg + "\n")
     sys.exit(1)
@@ -67,7 +70,7 @@ def is_catkin_package():
 def github_repo_exists(url):
     try:
         check_call(['git', 'ls-remote', '-q', '--exit-code', url], IGNORE_DRY_RUN)
-    except ErrorURLNotFound404 as e:
+    except (ErrorURLNotFound404, ErrorNoOutput) as e:
         return False
     except Exception as e:
         error("Unexpected problem checking for git repo: " + str(e))
@@ -370,6 +373,10 @@ def check_call(cmd, ignore_dry_run = False):
                 raise ErrorNoPermsRepo()
             if b"abort: no username supplied" in err:
                 raise ErrorNoUsernameSupplied()
+            if not out and not err:
+                # assume that call is only for getting return code
+                raise ErrorNoOutput()
+
             # Unkown exception
             print('Error running command (%s).'%(' '.join(cmd)))
             print('stdout: %s'%(out))

--- a/release.py
+++ b/release.py
@@ -69,7 +69,7 @@ def github_repo_exists(url):
     except ErrorURLNotFound404 as e:
         return False
     except Exception as e:
-        error("Unexpected problem checking for git repo: " + e.what())
+        error("Unexpected problem checking for git repo: " + str(e))
     return True
 
 def generate_package_source(srcdir, builddir):

--- a/release.py
+++ b/release.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import os
 import urllib
+import urllib.parse
 import argparse
 import shutil
 import re
@@ -196,16 +197,16 @@ def sanity_package_name(repo_dir, package, package_alias):
 
     cmd = ["find", repo_dir, "-name", "changelog","-exec","head","-n","1","{}",";"]
     out, err = check_call(cmd, IGNORE_DRY_RUN)
-    for line in out.split('\n'.encode()):
+    for line in out.decode().split('\n'):
         if not line:
             continue
         # Check that first word is the package alias or name
-        if line.partition(' '.encode())[0] != expected_name:
+        if line.partition(' ')[0] != expected_name:
             error("Error in changelog package name or alias: " + line.decode())
 
     cmd = ["find", repo_dir, "-name", "control","-exec","grep","-H","Source:","{}",";"]
     out, err = check_call(cmd, IGNORE_DRY_RUN)
-    for line in out.split('\n'.encode()):
+    for line in out.decode().split('\n'):
         if not line:
             continue
         # Check that first word is the package alias or name
@@ -217,7 +218,7 @@ def sanity_package_name(repo_dir, package, package_alias):
 def sanity_package_version(repo_dir, version, release_version):
     cmd = ["find", repo_dir, "-name", "changelog","-exec","head","-n","1","{}",";"]
     out, err = check_call(cmd, IGNORE_DRY_RUN)
-    for line in out.split('\n'.encode()):
+    for line in out.decode().split('\n'):
         if not line:
             continue
         # return full version in brackets
@@ -546,7 +547,7 @@ def go(argv):
     else:
         job_name = JOB_NAME_PATTERN%(args.package)
 
-    params_query = urllib.urlencode(params)
+    params_query = urllib.parse.urlencode(params)
 
     # RELEASING FOR BREW
     brew_url = '%s/job/%s/buildWithParameters?%s'%(JENKINS_URL,
@@ -596,7 +597,7 @@ def go(argv):
                 if (NIGHTLY and a == 'i386'):
                     continue
 
-                linux_platform_params_query = urllib.urlencode(linux_platform_params)
+                linux_platform_params_query = urllib.parse.urlencode(linux_platform_params)
 
                 url = '%s/job/%s/buildWithParameters?%s'%(JENKINS_URL, job_name, linux_platform_params_query)
                 print('- Linux: %s'%(url))

--- a/release.py
+++ b/release.py
@@ -400,8 +400,13 @@ def create_tarball_path(tarball_name, version, builddir, dry_run):
                 error("Can not find a tarball at: " + tarball_path + " or at " + alt_tarball_path)
         tarball_path = alt_tarball_path
 
-    shasum_out_err = check_call(['shasum', '--algorithm', '256', tarball_path])
-    return shasum_out_err[0].decode().split(' ')[0], tarball_fname, tarball_path
+    out, err = check_call(['shasum', '--algorithm', '256', tarball_path])
+    if err:
+        error("shasum returned an error: " + err.decode())
+    if isinstance(out, bytes):
+        out = out.decode()
+
+    return out.split(' ')[0], tarball_fname, tarball_path
 
 def generate_upload_tarball(args):
     ###################################################


### PR DESCRIPTION
The PR changes release.py to use python3. Needed to work in nightlies of the new server 20.04 where no python is present.

Some changes:
 * urllib.encode is now under urllib.parse
 * output from subcalls needs to be decoded
 * next attribute in generators is now __next__()

Non related to python3:
 * Move sc3md check to only in non nightly mode 7711c4c 
 * Fix bad use of Exception what df3e11f 
 * Change way of checking git remote repositories fa533e2

Tested:
 * dry run in nightly scheduler [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-edifice-nightly-scheduler&build=12)](https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/12/)