### PR TITLE
Install dependencies defined on packages.apt file in source code 

### DIFF
--- a/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
+++ b/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
@@ -29,12 +29,6 @@ if ! [[ ${IGN_FUEL_TOOLS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_FUEL_TOOLS_MAJOR_VERSION} -ge 5 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-fi
-
 export GZDEV_PROJECT_NAME="ignition-fuel-tools${IGN_FUEL_TOOLS_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_gazebo-compilation.bash
+++ b/jenkins-scripts/docker/ign_gazebo-compilation.bash
@@ -28,32 +28,6 @@ if ! [[ ${IGN_GAZEBO_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_GAZEBO_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_FUEL_TOOLS=true
-  export IGN_FUEL_TOOLS_MAJOR_VERSION=5
-  export IGN_FUEL_TOOLS_BRANCH=master
-
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=master
-
-  export BUILD_IGN_PHYSICS=true
-  export IGN_PHYSICS_MAJOR_VERSION=3
-  export IGN_PHYSICS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_SENSORS=true
-  export IGN_SENSORS_MAJOR_VERSION=4
-  export IGN_SENSORS_BRANCH=master
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=9
-  export IGN_TRANSPORT_BRANCH=master
-fi
-
 export NEED_C17_COMPILER=true
 export GPU_SUPPORT_NEEDED=true
 

--- a/jenkins-scripts/docker/ign_gui-compilation.bash
+++ b/jenkins-scripts/docker/ign_gui-compilation.bash
@@ -28,20 +28,6 @@ if ! [[ ${IGN_GUI_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_GUI_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=9
-  export IGN_TRANSPORT_BRANCH=master
-fi
-
 if [[ ${IGN_GUI_MAJOR_VERSION} -ge 1 ]]; then
   export NEED_C17_COMPILER=true
 fi

--- a/jenkins-scripts/docker/ign_launch-compilation.bash
+++ b/jenkins-scripts/docker/ign_launch-compilation.bash
@@ -28,36 +28,6 @@ if ! [[ ${IGN_LAUNCH_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_LAUNCH_MAJOR_VERSION} -ge 3 ]]; then
-  export BUILD_IGN_FUEL_TOOLS=true
-  export IGN_FUEL_TOOLS_MAJOR_VERSION=5
-  export IGN_FUEL_TOOLS_BRANCH=master
-
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=master
-
-  export BUILD_IGN_PHYSICS=true
-  export IGN_PHYSICS_MAJOR_VERSION=3
-  export IGN_PHYSICS_BRANCH=master
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_SENSORS=true
-  export IGN_SENSORS_MAJOR_VERSION=4
-  export IGN_SENSORS_BRANCH=master
-
-  export BUILD_IGN_GAZEBO=true
-  export IGN_GAZEBO_MAJOR_VERSION=4
-  export IGN_GAZEBO_BRANCH=master
-fi
-
 export NEED_C17_COMPILER=true
 
 export GZDEV_PROJECT_NAME="ignition-launch${IGN_LAUNCH_MAJOR_VERSION}"

--- a/jenkins-scripts/docker/ign_rendering-compilation.bash
+++ b/jenkins-scripts/docker/ign_rendering-compilation.bash
@@ -28,12 +28,6 @@ if ! [[ ${IGN_RENDERING_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_RENDERING_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_COMMON=true
-  export IGN_COMMON_MAJOR_VERSION=3
-  export IGN_COMMON_BRANCH=ign-common3
-fi
-
 if [[ ${IGN_RENDERING_MAJOR_VERSION} -ge 1 ]]; then
   export NEED_C17_COMPILER=true
 fi

--- a/jenkins-scripts/docker/ign_sensors-compilation.bash
+++ b/jenkins-scripts/docker/ign_sensors-compilation.bash
@@ -28,24 +28,6 @@ if ! [[ ${IGN_SENSORS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_SENSORS_MAJOR_VERSION} -ge 4 ]]; then
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=4
-  export IGN_GUI_BRANCH=master
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=4
-  export IGN_RENDERING_BRANCH=master
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=9
-  export IGN_TRANSPORT_BRANCH=master
-fi
-
 export NEED_C17_COMPILER=true
 
 export GPU_SUPPORT_NEEDED=true

--- a/jenkins-scripts/docker/ign_transport-compilation.bash
+++ b/jenkins-scripts/docker/ign_transport-compilation.bash
@@ -32,13 +32,6 @@ if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
-if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -eq 9 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=6
-  export IGN_MSGS_BRANCH=master
-fi
-
-
 export GZDEV_PROJECT_NAME="ignition-transport${IGN_TRANSPORT_MAJOR_VERSION}"
 
 . "${SCRIPT_DIR}/lib/generic-building-base.bash"

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -30,7 +30,7 @@ DELIM_HEADER
 # Install debian dependencies defined on the source code
 # These dependencies are not cached
 SYSTEM_VERSION=`lsb_release -cs`
-apt -y install \
+sudo apt -y install \
   $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
 
 # Process the source build of dependencies if needed

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -27,6 +27,12 @@ if $GENERIC_ENABLE_TIMING; then
 fi
 DELIM_HEADER
 
+# Install debian dependencies defined on the source code
+# These dependencies are not cached
+SYSTEM_VERSION=`lsb_release -cs`
+apt -y install \
+  $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+
 # Process the source build of dependencies if needed
 OSRF_DEPS="IGN_CMAKE IGN_TOOLS IGN_MATH IGN_MSGS IGN_TRANSPORT IGN_COMMON IGN_FUEL_TOOLS SDFORMAT IGN_PHYSICS IGN_RENDERING IGN_SENSORS IGN_GUI IGN_GAZEBO"
 OSRF_DEPS_DONE=""

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -27,12 +27,6 @@ if $GENERIC_ENABLE_TIMING; then
 fi
 DELIM_HEADER
 
-# Install debian dependencies defined on the source code
-# These dependencies are not cached
-SYSTEM_VERSION=`lsb_release -cs`
-sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
-
 # Process the source build of dependencies if needed
 OSRF_DEPS="IGN_CMAKE IGN_TOOLS IGN_MATH IGN_MSGS IGN_TRANSPORT IGN_COMMON IGN_FUEL_TOOLS SDFORMAT IGN_PHYSICS IGN_RENDERING IGN_SENSORS IGN_GUI IGN_GAZEBO"
 OSRF_DEPS_DONE=""

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -266,9 +266,12 @@ RUN add-apt-repository ppa:j-rivero/simbody-artful
 DELIM_DOCKER_WORKAROUND_SIMBODY
 fi
 
+# Install debian dependencies defined on the source code
+SOURCE_DEFINED_DEPS="$(sort -u $(find . -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
+
 # Packages that will be installed and cached by docker. In a non-cache
 # run below, the docker script will check for the latest updates
-PACKAGES_CACHE_AND_CHECK_UPDATES="${BASE_DEPENDENCIES} ${DEPENDENCY_PKGS}"
+PACKAGES_CACHE_AND_CHECK_UPDATES="${BASE_DEPENDENCIES} ${DEPENDENCY_PKGS} ${SOURCE_DEFINED_DEPS}"
 
 if $USE_GPU_DOCKER; then
   PACKAGES_CACHE_AND_CHECK_UPDATES="${PACKAGES_CACHE_AND_CHECK_UPDATES} ${GRAPHIC_CARD_PKG}"


### PR DESCRIPTION
Related tickets: https://github.com/ignition-tooling/release-tools/issues/190 / https://github.com/ignition-tooling/action-ignition-ci/pull/15 / https://github.com/ignition-tooling/release-tools/pull/316

All Ignition libraries now have `.github/ci/package*.apt` files in their source code defining all their debian dependencies. An elaborate example is `ign-gazebo`, which has [3 packages files](https://github.com/ignitionrobotics/ign-gazebo/tree/main/.github/ci):

* `packages.apt` for dependencies common to all platforms
* `packages-bionic.apt` for dependencies specific to Bionic
* `packages-focal.apt` for dependencies specific to Focal

These files are being used by the GitHub actions CI in https://github.com/ignition-tooling/action-ignition-ci , and we can use them here too. Having these files living next to the source code make it easier to update dependencies at the same time as the source code changes.

Nothing is broken if a library doesn't have `packages.apt` files.

This was tested [here](https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-ubuntu_auto-amd64/431/console), see how the packages listed [here](https://github.com/ignitionrobotics/ign-fuel-tools/blob/main/.github/ci/packages.apt) ended up in the `PACKAGES_CACHE_AND_CHECK_UPDATES` variable.

With this change, I think we don't need to keep [dependencies_archive.sh](https://github.com/ignition-tooling/release-tools/blob/master/jenkins-scripts/lib/dependencies_archive.sh) updated whenever dependencies are added to Ignition libraries anymore? Not sure if that's used for something other than CI.

