### PR TITLE
Fix XML generation for the ghprb plugin in DSL

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -60,7 +60,7 @@ class GenericAnyJobGitHub
               onlyTriggerPhrase(false)
               permitAll(true)
               // do not remove the cron line otherwise it triggers an error in the log
-              cron('# not needed since GithubHooks is enabled')
+              cron('H/5 * * * *')
               whiteListTargetBranches {
                 supported_branches.each { supported_branch ->
                   'org.jenkinsci.plugins.ghprb.GhprbBranch' {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -60,7 +60,7 @@ class GenericAnyJobGitHub
               onlyTriggerPhrase(false)
               permitAll(true)
               // do not remove the cron line otherwise it triggers an error in the log
-              spec('H/5 * * * *')
+              spec('')
               whiteListTargetBranches {
                 supported_branches.each { supported_branch ->
                   'org.jenkinsci.plugins.ghprb.GhprbBranch' {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -53,12 +53,14 @@ class GenericAnyJobGitHub
           project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
               adminlist 'osrf-jenkins j-rivero'
               orgslist 'osrf'
-              useGitHubHooks(true)
               allowMembersOfWhitelistedOrgsAsAdmin(true)
-              useGitHubHooks(true)
+              // disable the automatic creation of github hooks to avoid admin
+              // permissions on github bots
+              useGitHubHooks(false)
               onlyTriggerPhrase(false)
               permitAll(true)
-              cron()
+              // do not remove the cron line otherwise it triggers an error in the log
+              cron('# not needed since GithubHooks is enabled')
               whiteListTargetBranches {
                 supported_branches.each { supported_branch ->
                   'org.jenkinsci.plugins.ghprb.GhprbBranch' {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -54,8 +54,6 @@ class GenericAnyJobGitHub
               adminlist 'osrf-jenkins j-rivero'
               orgslist 'osrf'
               allowMembersOfWhitelistedOrgsAsAdmin(true)
-              // disable the automatic creation of github hooks to avoid admin
-              // permissions on github bots
               useGitHubHooks(true)
               onlyTriggerPhrase(false)
               permitAll(true)

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -56,7 +56,7 @@ class GenericAnyJobGitHub
               allowMembersOfWhitelistedOrgsAsAdmin(true)
               // disable the automatic creation of github hooks to avoid admin
               // permissions on github bots
-              useGitHubHooks(false)
+              useGitHubHooks(true)
               onlyTriggerPhrase(false)
               permitAll(true)
               // do not remove the cron line otherwise it triggers an error in the log

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -60,7 +60,7 @@ class GenericAnyJobGitHub
               onlyTriggerPhrase(false)
               permitAll(true)
               // do not remove the cron line otherwise it triggers an error in the log
-              cron('H/5 * * * *')
+              spec('H/5 * * * *')
               whiteListTargetBranches {
                 supported_branches.each { supported_branch ->
                   'org.jenkinsci.plugins.ghprb.GhprbBranch' {


### PR DESCRIPTION
The configuration for the Github Pull Request plugin needs to be updated to avoid log problems coming from the fact that cron is not the right XML but spec. The other small change is to remove the duplicate `useGitHubHooks`.