### PR TITLE
Don't need to unshallow taps anymore

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -61,11 +61,6 @@ pushd $(brew --repo osrf/simulation) && \
   hub pr checkout ${ghprbPullId} && \
   popd
 
-# test-bot wants to 'git fetch --unshallow' over ssh, which has permission issues
-# explicitly unshallow using https instead
-git -C $(brew --repo osrf/simulation) fetch --unshallow \
-    https://github.com/${GITHUB_REPOSITORY}
-
 brew test-bot --tap=osrf/simulation \
               --fail-fast \
               --root-url=https://osrf-distributions.s3.amazonaws.com/bottles-simulation


### PR DESCRIPTION
Since Homebrew/brew#8883, tapped repositories in CI are not shallow, so we don't need to unshallow them.

I noticed this while debugging the following build failure related to https://github.com/osrf/homebrew-simulation/pull/1179:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder%2Flabel%3Dosx_highsierra&build=66)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_highsierra/66/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/66/label=osx_highsierra/console