### PR TITLE
Exclude */.git/* files when finding packages.apt

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -267,7 +267,7 @@ DELIM_DOCKER_WORKAROUND_SIMBODY
 fi
 
 # Install debian dependencies defined on the source code
-SOURCE_DEFINED_DEPS="$(sort -u $(find . -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
+SOURCE_DEFINED_DEPS="$(sort -u $(find . -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')"
 
 # Packages that will be installed and cached by docker. In a non-cache
 # run below, the docker script will check for the latest updates


### PR DESCRIPTION
If a git branch name contains `packages.apt`, it currently breaks our jenkins script (first noticed in osrf/sdformat#392). This adds a `grep -v '/\.git/' to exclude the contents of a `.git` folder.

Reproduced the failure with [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat9-bionic-amd64&build=42)](https://build.osrfoundation.org/job/sdformat-ci-sdformat9-bionic-amd64/42/) https://build.osrfoundation.org/job/sdformat-ci-sdformat9-bionic-amd64/42/

Testing this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat9-bionic-amd64&build=43)](https://build.osrfoundation.org/job/sdformat-ci-sdformat9-bionic-amd64/43/) https://build.osrfoundation.org/job/sdformat-ci-sdformat9-bionic-amd64/43/