### PR TITLE
Limit ABI and debbuild jobs to max of 200 builds

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
@@ -15,6 +15,10 @@ class OSRFLinuxBase
     // Base class for the job
     OSRFUNIXBase.create(job)
 
+    logRotator {
+      numToKeep(200)
+    }
+
     job.with
     {
         label "docker"


### PR DESCRIPTION
Found Jenkins consuming extensive CPU and one of the reasons could be the more 9k builds that are kept for debbuild or abi jobs. This change should keep a max of 200.