### PR TITLE
Use crendential alias in new server for GITHUB_TOKEN

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -134,7 +134,8 @@ bottle_job_builder.with
    wrappers {
         preBuildCleanup()
         credentialsBinding {
-          string('GITHUB_TOKEN', '6f03ada6-fae8-4e74-9e2b-d6d0cf4b97a2')
+          // crendetial name needs to be in sync with provision code at infra/osrf-chef repo
+          string('GITHUB_TOKEN', 'osrf-migration-token')
         }
    }
 


### PR DESCRIPTION
New credential is being deployed in the new server invalidate current hash

 * Failing: https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_highsierra/74/console
 * With this change: https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_highsierra/76/console
