### PR TITLE
bottle PR script: use python3

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
@@ -19,9 +19,9 @@ PULL_REQUEST_API_URL=$(echo ${PULL_REQUEST_URL} \
   | sed -e 's@^https://github\.com/@https://api.github.com/repos/@' \
         -e 's@/pull/\([0-9]\+\)/*$@/pulls/\1@')
 PULL_REQUEST_HEAD_REPO=$(curl ${PULL_REQUEST_API_URL} \
-  | python -c 'import json, sys; print(json.loads(sys.stdin.read())["head"]["repo"]["ssh_url"])')
+  | python3 -c 'import json, sys; print(json.loads(sys.stdin.read())["head"]["repo"]["ssh_url"])')
 PULL_REQUEST_BRANCH=$(curl ${PULL_REQUEST_API_URL} \
-  | python -c 'import json, sys; print(json.loads(sys.stdin.read())["head"]["ref"])')
+  | python3 -c 'import json, sys; print(json.loads(sys.stdin.read())["head"]["ref"])')
 echo '# END SECTION'
 
 # note that matrix projects use subdirectories on pkgs/ with the label of different configurations


### PR DESCRIPTION
We didn't change all the homebrew scripts to use `python3` in #314 because mojave (10.14) doesn't have a system version of `python3`. The `homebrew_bottle_pullrequest.bash` script is executed on Linux, so it should use python3.

I noticed this from the following failure trying to update https://github.com/osrf/homebrew-simulation/pull/1186:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_pr_bottle_hash_updater&build=1075)](https://build.osrfoundation.org/job/generic-release-homebrew_pr_bottle_hash_updater/1075/) https://build.osrfoundation.org/job/generic-release-homebrew_pr_bottle_hash_updater/1075/

with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_pr_bottle_hash_updater&build=1076)](https://build.osrfoundation.org/job/generic-release-homebrew_pr_bottle_hash_updater/1076/) https://build.osrfoundation.org/job/generic-release-homebrew_pr_bottle_hash_updater/1076/