### PR TITLE
Use the recommended script to install brew on Linux

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -34,8 +34,8 @@ export GITHUB_TOKEN=`cat $GITHUB_TOKEN_FILE`
 set -x # back to debug
 echo '# END SECTION'
 
-echo '# BEGIN SECTION: download linuxbrew'
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+echo '# BEGIN SECTION: download brew'
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/homebrew/install/master/install.sh)"
 echo '# END SECTION'
 
 BREW_PREFIX="/home/linuxbrew/.linuxbrew"


### PR DESCRIPTION
From the console output of [this job](https://build.osrfoundation.org/job/generic-release-homebrew_pr_bottle_hash_updater/1078/console):

~~~
Warning: Linuxbrew has been merged into Homebrew.
Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
~~~

This updates to use the recommended script to install brew on Linux.