### PR TITLE
Create new release repos with main branch

### DIFF
--- a/release-repo-scripts/new_ignition_release_repos.bash
+++ b/release-repo-scripts/new_ignition_release_repos.bash
@@ -26,7 +26,7 @@ repo_exists()
 empty_directory()
 {
     local dir=${1}
-       
+
     if [[ -d "${dir}/ubuntu" ]]; then
        echo false
     else
@@ -71,7 +71,7 @@ for repo_name in ${NEW_REPOS}; do
     version="$(sed  's/.*[^0-9]\([0-9]\+\)[^0-9]*$/\1/' <<< ${repo_name})"
     previous_version=$(expr ${version} - 1)
     previous_repo_github="${repo_github/[0-9]*}${previous_version}-release"
-    echo " + pull from previous version ${previous_repo_github}" 
+    echo " + pull from previous version ${previous_repo_github}"
     git remote add previous "https://github.com/${previous_repo_github}"
     git fetch previous
     git pull -q previous master >/dev/null 2>&1 || git pull -q previous main >/dev/null 2>&1
@@ -84,9 +84,10 @@ for repo_name in ${NEW_REPOS}; do
     echo
     echo " ? check output for possible FIXME messages"
     read -n 1 -s -r -p "  press any key to continue"
+    git checkout -b main
     git status
     echo " ? ready to commit --all and push ?"
     read -n 1 -s -r -p "  press any key to continue"
     git commit -m "Change metadata from ${previous_version} version to ${version}" --all
-    git push origin master || git push origin main
+    git push origin main
 done


### PR DESCRIPTION
Updating script introduced in #310 so that the newly created repository has a `main` branch instead of `master`.

I believe most of our infra supports either, but the nightly releases requires `--release-repo-branch main`:

https://github.com/ignition-tooling/release-tools/blob/34375f7489764209c6e934bcf06ba65bf621eb67/jenkins-scripts/dsl/ignition_collection.dsl#L623-L624

I created this repository with the updated script:

https://github.com/ignition-release/ign-math7-release/