### PR TITLE
👩‍🌾 Disable Gazebo7 CI on macOS

### DIFF
--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -549,6 +549,9 @@ all_branches.each { branch ->
 
   gazebo_brew_ci_job.with
   {
+      if (("${branch}" == "gazebo7"))
+        disabled()
+
       label osx_label
 
       triggers {


### PR DESCRIPTION
Related to https://github.com/osrf/homebrew-simulation/issues/1110

I think it would be good to also disable CI for PRs targeting `gazebo7`, but I'm not sure where to do that.