### PR TITLE
Use new foxy branch

### DIFF
--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -26,14 +26,13 @@ bloom_debbuild_jobs = [ 'gazebo-dev', 'gazebo-msgs', 'gazebo-plugins', 'gazebo-r
 
 // ROS1 branches use $ros_distro-devel schema
 // ROS2 branches use $ros_distro with the expections:
-//  - foxy or rolling -> ros2
+//  - rolling -> ros2
 //  - branch under development -> ros2
 String get_branch_from_rosdistro(ros_distro) {
   if (! ros2_distros.contains(ros_distro))
     return "${ros_distro}-devel"
 
   switch(ros_distro) {
-    case 'foxy':
     case 'rolling':
     case current_ros2_branch:
       return 'ros2'


### PR DESCRIPTION
Foxy has branched off `ros2` on https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1184 and now has a dedicated branch.