### PR TITLE
👩‍🌾 Only install dependencies from library being tested

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -267,7 +267,7 @@ DELIM_DOCKER_WORKAROUND_SIMBODY
 fi
 
 # Install debian dependencies defined on the source code
-SOURCE_DEFINED_DEPS="$(sort -u $(find . -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')"
+SOURCE_DEFINED_DEPS="$(sort -u $(find ${SOFTWARE_DIR} -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')"
 
 # Packages that will be installed and cached by docker. In a non-cache
 # run below, the docker script will check for the latest updates

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -267,7 +267,8 @@ DELIM_DOCKER_WORKAROUND_SIMBODY
 fi
 
 # Install debian dependencies defined on the source code
-SOURCE_DEFINED_DEPS="$(sort -u $(find ${SOFTWARE_DIR} -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')"
+DEPENDENCIES_PATH_TO_SEARCH=${SOFTWARE_DIR:=.}
+SOURCE_DEFINED_DEPS="$(sort -u $(find ${DEPENDENCIES_PATH_TO_SEARCH} -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')"
 
 # Packages that will be installed and cached by docker. In a non-cache
 # run below, the docker script will check for the latest updates


### PR DESCRIPTION
I'm not sure where this script is being run, but it looks like there may be other libraries in the same workspace (maybe left-overs from previous builds?). This causes occasional build failures in case the other libraries need nightlies for example.

This change makes sure that only the dependencies for the branch being tested are installed. See these 2 test builds:

[Without this PR](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64/4410/consoleFull), an `ign-gazebo` build is also installing dependencies for many other libraries that happen to be in the workspace. In this case the build didn't fail because the other libraries happened to be compatible.

```
++++ sort -u ./ign_rendering/.github/ci/packages.apt ./ign_fuel_tools/.github/ci/packages.apt ./ign_sensors/.github/ci/packages.apt ./ign_physics/.github/ci/packages.apt ./ign_physics/.github/ci/packages-bionic.apt ./ign-gazebo/.github/ci/packages.apt ./ign-gazebo/.github/ci/packages-bionic.apt ./ign_gui/.github/ci/packages.apt ./ign_transport/.github/ci/packages.apt
+++ SOURCE_DEFINED_DEPS='curl dart6-data freeglut3-dev libbenchmark-dev libcurl4-openssl-dev libdart6-collision-ode-dev libdart6-dev libdart6-utils-urdf-dev libeigen3-dev libfreeimage-dev libgflags-dev libglew-dev libignition-cmake2-dev libignition-common3-dev libignition-fuel-tools4-dev libignition-gui3-dev libignition-math6-dev libignition-math6-eigen3-dev libignition-msgs5-dev libignition-msgs6-dev libignition-physics2-dev libignition-plugin-dev libignition-rendering3-dev libignition-rendering4-dev libignition-sensors3-dev libignition-tools-dev libignition-transport8-dev libignition-transport9-dev libjsoncpp-dev libogre-1.9-dev libogre-2.1-dev libprotobuf-dev libprotoc-dev libsdformat10-dev libsdformat9-dev libsqlite3-dev libtinyxml2-dev libxi-dev libxmu-dev libyaml-dev libzip-dev libzmq3-dev pkg-config protobuf-compiler qml-module-qt-labs-folderlistmodel qml-module-qt-labs-platform qml-module-qt-labs-settings qml-module-qtgraphicaleffects qml-module-qtqml-models2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-layouts qml-module-qtquick-templates2 qml-module-qtquick-window2 qml-module-qtquick2 qtbase5-dev qtdeclarative5-dev qtquickcontrols2-5-dev uuid-dev xvfb '
```

[With this PR](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64/4411/consoleFull), the same `ign-gazebo` build only installs dependencies for that library:

```
++++ sort -u ign-gazebo/.github/ci/packages-bionic.apt ign-gazebo/.github/ci/packages.apt
+++ SOURCE_DEFINED_DEPS='dart6-data libdart6-collision-ode-dev libdart6-dev libdart6-utils-urdf-dev libignition-cmake2-dev libignition-common3-dev libignition-fuel-tools4-dev libignition-gui3-dev libignition-math6-eigen3-dev libignition-msgs5-dev libignition-physics2-dev libignition-plugin-dev libignition-rendering3-dev libignition-sensors3-dev libignition-tools-dev libignition-transport8-dev libsdformat9-dev qml-module-qtqml-models2 xvfb '
```
