### PR TITLE
Stop building homebrew bottles for High Sierra

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 
 // first distro in list is used as touchstone
-brew_supported_distros         = [ "highsierra", "mojave" ]
+brew_supported_distros         = [ "mojave" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -540,8 +540,6 @@ all_branches.each { branch ->
     Globals.extra_emails = Globals.build_cop_email
 
   def osx_label = 'osx_gazebo'
-  if (branch == "gazebo7")
-    osx_label = 'osx_highsierra'
 
   def gazebo_brew_ci_job = job("gazebo-ci-${branch}-homebrew-amd64")
   OSRFBrewCompilation.create(gazebo_brew_ci_job)


### PR DESCRIPTION
macOS Big Sur (11.0) has been released, and [homebrew is no longer building bottles for high sierra](https://github.com/Homebrew/brew/pull/9054/files#diff-b5752027e688b330ed260dd944dbf2674c98c1b44355282d93ead10f89dbc3fdL58-R58), so we will stop building them as well. Once we have configured a macOS catalina machine, we can instruct it to build bottles for that platform as well.

I've also removed a bit of outdated logic from `gazebo.dsl`.