### PR TITLE
Fix download link for jom utility

### DIFF
--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -43,7 +43,7 @@ call %win_lib% :download_unzip_install qwt_6.1.2~osrf_qt5.zip
 call %win_lib% :download_unzip_install tbb43_20141023oss_win.zip
 call %win_lib% :download_unzip_install zziplib-0.13.62-vc12-x64-release-debug.zip
 
-call %win_lib% :wget http://download.qt-project.org/official_releases/jom/jom.zip jom.zip
+call %win_lib% :wget http://download.qt.io/official_releases/jom/jom.zip jom.zip
 call %win_lib% :unzip_7za jom.zip
 
 echo # END SECTION

--- a/jenkins-scripts/lib/gazebo9_10-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo9_10-base-windows.bat
@@ -41,7 +41,7 @@ call %win_lib% :download_unzip_install qwt_6.1.2~osrf_qt5.zip
 call %win_lib% :download_unzip_install tbb43_20141023oss_win.zip
 call %win_lib% :download_unzip_install zziplib-0.13.62-vc12-x64-release-debug.zip
 
-call %win_lib% :wget http://download.qt-project.org/official_releases/jom/jom.zip jom.zip
+call %win_lib% :wget http://download.qt.io/official_releases/jom/jom.zip jom.zip
 call %win_lib% :unzip_7za jom.zip
 
 echo # END SECTION


### PR DESCRIPTION
Some gazebo windows CI builds are failing on [win-windows_local.win8](https://build.osrfoundation.org/computer/win-windows_local.win8/) due to a lack of the `jom` utility. It looks like the download link is out of date, so I've updated it.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-pr_any-windows7-amd64&build=3064)](https://build.osrfoundation.org/job/gazebo-ci-pr_any-windows7-amd64/3064/) https://build.osrfoundation.org/job/gazebo-ci-pr_any-windows7-amd64/3064/