### PR TITLE
Replace jom path to new location

### DIFF
--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -43,7 +43,7 @@ call %win_lib% :download_unzip_install qwt_6.1.2~osrf_qt5.zip
 call %win_lib% :download_unzip_install tbb43_20141023oss_win.zip
 call %win_lib% :download_unzip_install zziplib-0.13.62-vc12-x64-release-debug.zip
 
-call %win_lib% :wget http://download.qt-project.org/official_releases/jom/jom.zip jom.zip
+call %win_lib% :wget http://mirrors.ukfast.co.uk/sites/qt.io/official_releases/jom/jom_1_1_3.zip jom.zip
 call %win_lib% :unzip_7za jom.zip
 
 echo # END SECTION

--- a/jenkins-scripts/lib/gazebo9_10-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo9_10-base-windows.bat
@@ -41,7 +41,7 @@ call %win_lib% :download_unzip_install qwt_6.1.2~osrf_qt5.zip
 call %win_lib% :download_unzip_install tbb43_20141023oss_win.zip
 call %win_lib% :download_unzip_install zziplib-0.13.62-vc12-x64-release-debug.zip
 
-call %win_lib% :wget http://download.qt-project.org/official_releases/jom/jom.zip jom.zip
+call %win_lib% :wget http://mirrors.ukfast.co.uk/sites/qt.io/official_releases/jom/jom_1_1_3.zip jom.zip
 call %win_lib% :unzip_7za jom.zip
 
 echo # END SECTION


### PR DESCRIPTION
Failing Windows jobs: https://build.osrfoundation.org/job/gazebo-ci-pr_any-windows7-amd64/3062/consoleFull

```
Downloading http://download.qt-project.org/official_releases/jom/jom.zip
SYSTEM_WGETRC = c:/progra~1/wget/etc/wgetrc
syswgetrc = C:\Program Files (x86)\GnuWin32/etc/wgetrc
--2020-11-18 08:18:39--  http://download.qt-project.org/official_releases/jom/jom.zip
Resolving download.qt-project.org... 77.86.229.90
Connecting to download.qt-project.org|77.86.229.90|:80... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://mirrors.ocf.berkeley.edu/qt/official_releases/jom/jom_1_1_3.zip [following]
--2020-11-18 08:18:39--  https://mirrors.ocf.berkeley.edu/qt/official_releases/jom/jom_1_1_3.zip
Resolving mirrors.ocf.berkeley.edu... 169.229.226.30
Connecting to mirrors.ocf.berkeley.edu|169.229.226.30|:443... connected.
Unable to establish SSL connection.
Failed in windows_library with error #1.
```

```bash
❯ curl download.qt-project.org/official_releases/jom/jom.zip
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://mirrors.ukfast.co.uk/sites/qt.io/official_releases/jom/jom_1_1_3.zip">here</a>.</p>
</body></html>
```
Since we are ignoring the certificate anyway I'm changing it to use plan http