### PR TITLE
vcpkg snapshot support: check and upgrade

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFWinCompilationAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFWinCompilationAnyGitHub.groovy
@@ -14,11 +14,15 @@ class OSRFWinCompilationAnyGitHub
   static void create(Job job,
                      String github_repo,
                      boolean enable_testing  = true,
-                     ArrayList supported_ros_distros = [])
+                     ArrayList supported_branches = [],
+                     boolean enable_github_pr_integration = true)
   {
     OSRFWinCompilation.create(job, enable_testing)
 
     /* Properties from generic any */
-    GenericAnyJobGitHub.create(job, github_repo, supported_ros_distros)
+    GenericAnyJobGitHub.create(job,
+                               github_repo,
+                               supported_branches,
+                               enable_github_pr_integration)
   }
 }

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -9,10 +9,16 @@ def update_vcpkg_snapshot_job = job("_vcpkg_update_snapshot")
 OSRFWinBase.create(update_vcpkg_snapshot_job)
 update_vcpkg_snapshot_job.with
 {
+    parameters {
+        nodeParam('TARGET_NODE') {
+            description('Node to be updated')
+        }
+    }
+
     steps
     {
       batchFile("""\
-            call "./scripts/jenkins-scripts/vcpkg-bootstrap.bat
+            call "%WORKSPACE%/scripts/jenkins-scripts/vcpkg-bootstrap.bat
             """.stripIndent())
     }
 }

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -1,0 +1,41 @@
+import _configs_.*
+import javaposse.jobdsl.dsl.Job
+
+def NO_TESTING = false
+def NO_BRANCHES = []
+def NO_GITHUB_PR_INTEGRATION = false
+
+def update_vcpkg_snapshot_job = job("_vcpkg_update_snapshot")
+OSRFWinBase.create(update_vcpkg_snapshot_job)
+update_vcpkg_snapshot_job.with
+{
+    steps
+    {
+      batchFile("""\
+            call "./scripts/jenkins-scripts/vcpkg-bootstrap.bat
+            """.stripIndent())
+    }
+}
+
+
+def ignition_testing_software = 'gazebo'
+def testing_vcpkg_job = job("_vcpkg_testing_snapshot")
+OSRFWinCompilationAnyGitHub.create(testing_vcpkg_job,
+                                  "ignitionrobotics/ign-${ignition_testing_software}",
+                                  NO_TESTING, NO_BRANCHES, NO_GITHUB_PR_INTEGRATION)
+testing_vcpkg_job.with
+{
+    parameters {
+        stringParam('VCPKG_SNAPSHOT', '','vcpkg tag/release to test')
+    }
+
+    steps
+    {
+      label "win_testing"
+
+      batchFile("""\
+            call "%WORKSPACE%/scripts/jenkins-scripts/vcpkg-bootstrap.bat" || exit /B %errorlevel%
+            call "%WORKSPACE%/scripts/jenkins-scripts/ign_${ignition_testing_software}-default-devel-windows-amd64.bat"
+            """.stripIndent())
+    }
+}

--- a/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
@@ -4,4 +4,6 @@ set VCS_DIRECTORY=ign-common
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
+set DEPEN_PKGS="ffmpeg"
+
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-gazebo
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: dlfcn
-set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp freeimage ogre qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
+set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp ffmpeg freeimage ogre qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gazebo
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-gazebo
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: dlfcn
-set DEPEN_PKGS="dlfcn-win32 cuda curl jsoncpp freeimage ogre gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2"
+set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp freeimage ogre qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gazebo
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -10,5 +10,8 @@ if exist D:\vcpkg (
 set VCPKG_OSRF_DIR=%VCPKG_DIR%\osrf_vcpkg_ports
 set VCPKG_CMD=%VCPKG_DIR%\vcpkg.exe
 set VCPKG_CMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%/scripts/buildsystems/vcpkg.cmake
-
+if NOT DEFINED VCPKG_SNAPSHOT (
+  :: see https://github.com/microsoft/vcpkg/releases
+  set VCPKG_SNAPSHOT=2020.01
+)
 goto :EOF

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -226,11 +226,22 @@ echo # END SECTION
 goto :EOF
 
 :: ##################################
+:check_vcpkg_snapshot
+setlocal EnableDelayedExpansion
+for /f %%i in ('git -C %VCPKG_DIR% describe --tags HEAD') do set VCPKG_HEAD=%%i
+echo "VCPKG_HEAD is %VCPKG_HEAD%"
+if NOT %VCPKG_HEAD% == %VCPKG_SNAPSHOT% (
+  echo The vpckg directory is not using the expected snapshot %VCPKG_SNAPSHOT%
+  goto :error
+)
+goto :EOF
+
+:: ##################################
 :install_vcpkg_package
 :: arg1: package to install
 set LIB_DIR=%~dp0
 call %LIB_DIR%\windows_env_vars.bat || goto :error
-
+call %win_lib% :check_vcpkg_snapshot || goto :error
 %VCPKG_CMD% install "%1"
 goto :EOF
 

--- a/jenkins-scripts/vcpkg-bootstrap.bat
+++ b/jenkins-scripts/vcpkg-bootstrap.bat
@@ -1,0 +1,32 @@
+echo on
+ 
+set SCRIPT_DIR=%~dp0
+set PLATFORM_TO_BUILD=amd64
+
+set win_lib=%SCRIPT_DIR%\lib\windows_library.bat
+
+:: Call vcvarsall and all the friends
+echo # BEGIN SECTION: configure the MSVC compiler
+call %win_lib% :configure_msvc2019_compiler
+echo # END SECTION
+
+echo # BEGIN SECTION: Bootstrap vcpkg
+:: Remove previous vcpkg installation
+rd /s /q %VCPKG_DIR%
+
+:: Clone and use the new version of vcpkg
+git clone https://github.com/microsoft/vcpkg %VCPKG_DIR% || goto :error
+echo "Using SNAPSHOT: %VCPKG_SNAPSHOT%"
+cd %VCPKG_DIR%
+git checkout %VCPKG_SNAPSHOT% || goto :error
+:: Bootstrap vcpkg.exe
+%VCPKG_DIR%\bootstrap-vcpkg.bat -disableMetrics
+echo # END SECTION
+cd %WORKSPACE%
+goto :EOF
+
+:: ##################################
+:error - error routine
+::
+echo Failed in with error #%errorlevel%.
+exit /B %errorlevel%


### PR DESCRIPTION
This should close https://github.com/ignition-tooling/release-tools/issues/340 (also help in https://github.com/ignitionrobotics/ign-common/issues/122). The idea is to define a which snapshot of vcpkg we are using (it matches with its github releases), use it statically until we find a reason to upgrade. To help with the upgrade, this PR creates two jobs:
 *  ` _vcpkg_testing_snapshot`: uses a special label `wintesting` to run the upgrade of the snapshot together with trying to build `ign-gazebo` (which should exercise most of the ignition software given its dependency chain).
 * `_vcpkg_update_snapshot`: the job has a parameter to inject a node name to run the upgrade of vcpkg (beware, takes long time). Instead of making it to run in all nodes in parallel I decided to go with the selected node option (b30102f ) to keep the buildfarm going while we are upgrading.

The job also includes some missing dependencies in ign-gazebo, 12c7648

Testing:
 * DSL generation: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_core&build=740)](https://build.osrfoundation.org/job/_dsl_core/740/)
 * Testing job [upgrading vcpkg snapshot](https://build.osrfoundation.org/job/_vcpkg_testing_snapshot/50/consoleFull#console-section-4)
 * Testing job [trying to build ign-gazebo  ](https://build.osrfoundation.org/job/_vcpkg_testing_snapshot/53/consoleFull#console-section-8)
 * Testing [ffmpeg installed job](https://build.osrfoundation.org/job/_vcpkg_testing_snapshot/54/console). igniion-gazebo is failing because a protobuf problem but igntion-common was able to be built with av support. 

Note: we need to upgrade nodes before merging. Otherwise they will fail in the check of the right snapshot being used.  