### PR TITLE
gazebo_ros_pkgs.dsl: stop testing gazebo8

### DIFF
--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -17,7 +17,7 @@ Boolean ENABLE_TESTS = true
 Boolean DISABLE_CPPCHECK = false
 
 // version to test more than the official one in each ROS distro
-extra_gazebo_versions = [ 'kinetic'  :  ['8','9'],
+extra_gazebo_versions = [ 'kinetic'  :  ['9'],
                           'melodic'  :  ['11'],
                           'dashing'  :  ['11'],
                           'eloquent' :  ['11']]


### PR DESCRIPTION
gazebo8 is EOL, so disable its use in CI for kinetic.

## Testing

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_gazebo_ros_pkgs&build=713)](https://build.osrfoundation.org/job/_dsl_gazebo_ros_pkgs/713/) https://build.osrfoundation.org/job/_dsl_gazebo_ros_pkgs/713/

~~~
Unreferenced items:
    GeneratedJob{name='ros_gazebo8_pkgs-ci-default_kinetic-xenial-amd64'}
    GeneratedJob{name='ros_gazebo8_pkgs-ci-pr_any_kinetic-xenial-amd64'}
    GeneratedJob{name='ros_gazebo8_pkgs-install_pkg_kinetic-xenial-amd64'}
Disabled items:
    GeneratedJob{name='ros_gazebo8_pkgs-install_pkg_kinetic-xenial-amd64'}
    GeneratedJob{name='ros_gazebo8_pkgs-ci-pr_any_kinetic-xenial-amd64'}
    GeneratedJob{name='ros_gazebo8_pkgs-ci-default_kinetic-xenial-amd64'}
~~~