### PR TITLE
Call brew list with --formula

### DIFF
--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -15,7 +15,7 @@ export HOMEBREW_UPDATE_TO_TAG=1
 ${BREW_BINARY} up || { restore_brew && ${BREW_BINARY} up ; }
 
 # Clear all installed homebrew packages, links, taps, and kegs
-BREW_LIST=$(${BREW_BINARY} list)
+BREW_LIST=$(${BREW_BINARY} list --formula)
 if [[ -n "${BREW_LIST}" ]]; then
   ${BREW_BINARY} remove --force --ignore-dependencies ${BREW_LIST}
 fi


### PR DESCRIPTION
It's now required for non-interactive calls to brew list.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_transport9-install_bottle-homebrew-amd64&build=55)](https://build.osrfoundation.org/job/ignition_transport9-install_bottle-homebrew-amd64/55/) https://build.osrfoundation.org/job/ignition_transport9-install_bottle-homebrew-amd64/55/

~~~
+++ /usr/local/bin/brew list
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
~~~