### PR TITLE
Check brew doctor after other tests

### DIFF
--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -45,12 +45,6 @@ echo '# BEGIN SECTION: setup the osrf/simulation tap'
 brew tap osrf/simulation
 echo '# END SECTION'
 
-if [[ -n "${PULL_REQUEST_URL}" ]]; then
-  echo "# BEGIN SECTION: pulling ${PULL_REQUEST_URL}"
-  brew pull ${PULL_REQUEST_URL}
-  echo '# END SECTION'
-fi
-
 echo "# BEGIN SECTION: install ${BOTTLE_NAME}"
 brew install --include-test ${BOTTLE_NAME}
 
@@ -65,11 +59,6 @@ export DISPLAY=$(ps ax \
   | sed -e 's@.*Xquartz @@' -e 's@ .*@@'
 )
 
-echo "#BEGIN SECTION: brew doctor analysis"
-brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
-brew doctor
-echo '# END SECTION'
-
 echo "# BEGIN SECTION: run tests"
 brew linkage --test ${BOTTLE_NAME}
 if ! brew ruby -e "exit '${BOTTLE_NAME}'.f.test_defined?"; then
@@ -80,6 +69,11 @@ else
   brew test ${BOTTLE_NAME}
   brew audit --strict ${BOTTLE_NAME}
 fi
+echo '# END SECTION'
+
+echo "#BEGIN SECTION: brew doctor analysis"
+brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
+brew doctor
 echo '# END SECTION'
 
 echo "# BEGIN SECTION: re-add group write permissions"


### PR DESCRIPTION
The other tests give more informative feedback.

Compare the output from the master branch:

* https://build.osrfoundation.org/view/ign-blueprint/job/ignition_launch1-install_bottle-homebrew-amd64/174/console

~~~
#BEGIN SECTION: brew doctor analysis
+ brew missing
+ brew missing
+ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: You have unlinked kegs in your Cellar.
Leaving kegs unlinked can lead to build-trouble and cause brews that depend on
those kegs to fail to run properly once built. Run `brew link` on these:
  ignition-launch1

Warning: Broken symlinks were found. Remove them with `brew cleanup`:
  /usr/local/opt/ignition-launch1
~~~

with this branch

* https://build.osrfoundation.org/view/ign-blueprint/job/ignition_launch1-install_bottle-homebrew-amd64/175/console

~~~
# BEGIN SECTION: run tests
+ brew linkage --test ignition-launch1
Broken dependencies:
  /usr/local/opt/protobuf/lib/libprotobuf.24.dylib (protobuf)
~~~

`brew doctor` shows a symptom of the problem, but not the actual problem itself, while `brew linkage --test` shows that linkage with protobuf is broken.

Also remove the `brew pull ${PULL_REQUEST_URL}` command, since that functionality has been disabled in homebrew.