### PR TITLE
Add additional dependencies for ignition-tooling components.

### DIFF
--- a/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
@@ -4,6 +4,6 @@ set VCS_DIRECTORY=ign-common
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="ffmpeg"
+set DEPEN_PKGS="ffmpeg freeimage gts tinyxml2"
 
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"


### PR DESCRIPTION
This change is being made based on the comments in
https://github.com/ignition-tooling/release-tools/pull/347/files#r529115468
and the failure of several jobs to find tinyxml2 on the windows_nuc
agent.