### PR TITLE
Missing tinyxml2 vcpkg dependencies from ign-msgs

### DIFF
--- a/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
@@ -5,6 +5,6 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: tinyxml2 from msgs
-set DEPEN_PKGS="tinyxml2"
+set DEPEN_PKGS="libyaml libzip tinyxml2"
 
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
@@ -4,4 +4,7 @@ set VCS_DIRECTORY=ign-fuel-tools
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
+:: tinyxml2 from msgs
+set DEPEN_PKGS="tinyxml2"
+
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/ign_msgs-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_msgs-default-devel-windows-amd64.bat
@@ -4,4 +4,6 @@ set VCS_DIRECTORY=ign-msgs
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
+set DEPEN_PKGS="tinyxml2"
+
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/ign_msgs-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_msgs-default-devel-windows-amd64.bat
@@ -4,6 +4,6 @@ set VCS_DIRECTORY=ign-msgs
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="tinyxml2"
+set DEPEN_PKGS="protobuf tinyxml2"
 
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -6,6 +6,8 @@ set VCS_DIRECTORY=sdformat
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
+set DEPEN_PKGS="tinyxml2"
+
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set SDFORMAT_MAJOR_VERSION=%%i
 if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
   call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set VCS_DIRECTORY=sdformat
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="tinyxml2"
+set DEPEN_PKGS="libxml2 tinyxml2"
 
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set SDFORMAT_MAJOR_VERSION=%%i
 if %SDFORMAT_MAJOR_VERSION% GEQ 6 (


### PR DESCRIPTION
Some builds are failing due to missing tinyxml2 dependency defined in ignition libraries coming from msgs. See https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-windows7-amd64/523/.

This PR adds the dependency to missing ones.

Still needs testing but merging should not break anything.
