### PR TITLE
Migrate vcpkg to use --overlay-ports parameter for osrf/vcpkg-ports

### DIFF
--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -21,7 +21,7 @@ update_vcpkg_snapshot_job.with
         job_description = 'RTOOLS_BRANCH: ' +
             build.buildVariableResolver.resolve('RTOOLS_BRANCH') + '<br />' +
             'TARGET_NODE: ' +
-            '<b>' + build.buildvariableresolver.resolve('TARGET_NODE') + '</b>'
+            '<b>' + build.buildVariableResolver.resolve('TARGET_NODE') + '</b>'
         build.setdescription(job_description)
       """.stripIndent())
 

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -17,21 +17,17 @@ update_vcpkg_snapshot_job.with
 
     steps
     {
+      systemGroovyCommand("""\
+        job_description = 'RTOOLS_BRANCH: ' +
+            build.buildVariableResolver.resolve('RTOOLS_BRANCH') + '<br />' +
+            'TARGET_NODE: ' +
+            '<b>' + build.buildvariableresolver.resolve('TARGET_NODE') + '</b>'
+        build.setdescription(job_description)
+      """.stripIndent())
+
       batchFile("""\
             call "%WORKSPACE%/scripts/jenkins-scripts/vcpkg-bootstrap.bat
             """.stripIndent())
-    }
-
-    steps {
-      systemgroovycommand("""\
-          job_description = 
-            'RTOOLS_BRANCH: ' + 
-            build.buildVariableResolver.resolve('RTOOLS_BRANCH') + '<br />' +
-            'TARGET_NODE: ' +
-            '<b>' + build.buildvariableresolver.resolve('TARGET_NODE') + '</b>;'
-        build.setdescription(job_description)
-        """.stripindent()
-      )
     }
 }
 

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -21,6 +21,18 @@ update_vcpkg_snapshot_job.with
             call "%WORKSPACE%/scripts/jenkins-scripts/vcpkg-bootstrap.bat
             """.stripIndent())
     }
+
+    steps {
+      systemgroovycommand("""\
+          job_description = 
+            'RTOOLS_BRANCH: ' + 
+            build.buildVariableResolver.resolve('RTOOLS_BRANCH') + '<br />' +
+            'TARGET_NODE: ' +
+            '<b>' + build.buildvariableresolver.resolve('TARGET_NODE') + '</b>;'
+        build.setdescription(job_description)
+        """.stripindent()
+      )
+    }
 }
 
 

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -22,7 +22,7 @@ update_vcpkg_snapshot_job.with
             build.buildVariableResolver.resolve('RTOOLS_BRANCH') + '<br />' +
             'TARGET_NODE: ' +
             '<b>' + build.buildVariableResolver.resolve('TARGET_NODE') + '</b>'
-        build.setdescription(job_description)
+        build.setDescription(job_description)
       """.stripIndent())
 
       batchFile("""\

--- a/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-gazebo
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: dlfcn
-set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp ffmpeg freeimage ogre qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
+set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp ffmpeg freeimage ogre ogre2 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gazebo
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -5,7 +5,8 @@ set VCS_DIRECTORY=ign-gui
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="qt5 qwt protobuf tinyxml2 freeimage ogre"
+:: ogre2 from vcpkg-ports
+set DEPEN_PKGS="qt5 qwt protobuf tinyxml2 freeimage ogre ogre2"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
@@ -4,7 +4,7 @@ set VCS_DIRECTORY=ign-launch
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="curl jsoncpp qt5 tinyxml2 gflags libyaml libzip"
+set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp ffmpeg freeimage ogre ogre2 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
 set COLCON_PACKAGE=ignition-launch
 set COLCON_AUTO_MAJOR_VERSION=true
 

--- a/jenkins-scripts/ign_rendering-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_rendering-default-devel-windows-amd64.bat
@@ -4,9 +4,8 @@ set SCRIPT_DIR=%~dp0
 set VCS_DIRECTORY=ign-rendering
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
-:: dlfcn
-set DEPEN_PKGS="dlfcn-win32 cuda freeimage ogre gts glib"
-set DEPEN_OSRF_PKGS="ogre2"
+:: ogre2 from osrf vcpkg-ports
+set DEPEN_PKGS="dlfcn-win32 cuda freeimage ogre ogre2 gts glib"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-rendering
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -95,13 +95,6 @@ for %%p in (%DEPEN_PKGS%) do (
   echo # END SECTION
 )
 
-for %%p in (%DEPEN_OSRF_PKGS%) do (
-  call %win_lib% :enable_vcpkg_integration || goto :error
-  echo # BEGIN SECTION: install custom Open Robotics external dependency %%p
-  call %win_lib% :install_osrf_vcpkg_package %%p || goto :error
-  echo # END SECTION
-)
-
 echo # BEGIN SECTION: packages in workspace
 call %win_lib% :list_workspace_pkgs || goto :error
 echo # END SECTION

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -242,7 +242,7 @@ goto :EOF
 set LIB_DIR=%~dp0
 call %LIB_DIR%\windows_env_vars.bat || goto :error
 call %win_lib% :check_vcpkg_snapshot || goto :error
-%VCPKG_CMD% install "%1"
+%VCPKG_CMD% install "%1" --overlay-ports="%VCPKG_OSRF_DIR%"
 goto :EOF
 
 :: ##################################
@@ -276,13 +276,9 @@ if exist %PORT_DIR% (
   rmdir /s /q %PORT_DIR% || goto :error
 )
 
-if NOT exist %VCPKG_OSRF_DIR% (
-  git clone https://github.com/osrf/vcpkg-ports %VCPKG_OSRF_DIR%
-  cd %VCPKG_OSRF_DIR%
-) else (
-  cd %VCPKG_OSRF_DIR%
-  git pull origin master || goto :error
-)
+:: update osrf vcpkg overlay
+cd %VCPKG_OSRF_DIR%
+git pull origin master || goto :error
 
 :: copy port to the official tree
 xcopy %VCPKG_OSRF_DIR%\%PKG% %PORT_DIR% /s /i /e || goto :error

--- a/jenkins-scripts/vcpkg-bootstrap.bat
+++ b/jenkins-scripts/vcpkg-bootstrap.bat
@@ -12,10 +12,12 @@ echo # END SECTION
 
 echo # BEGIN SECTION: Bootstrap vcpkg
 :: Remove previous vcpkg installation
-rd /s /q %VCPKG_DIR%
+rd /s /q %VCPKG_DIR% || goto :error
 
 :: Clone and use the new version of vcpkg
 git clone https://github.com/microsoft/vcpkg %VCPKG_DIR% || goto :error
+git clone https://github.com/osrf/vcpkg-ports %VCPKG_OSRF_DIR% || goto :error
+
 echo "Using SNAPSHOT: %VCPKG_SNAPSHOT%"
 cd %VCPKG_DIR%
 git checkout %VCPKG_SNAPSHOT% || goto :error

--- a/jenkins-scripts/vcpkg-bootstrap.bat
+++ b/jenkins-scripts/vcpkg-bootstrap.bat
@@ -22,23 +22,23 @@ echo "Using SNAPSHOT: %VCPKG_SNAPSHOT%"
 cd %VCPKG_DIR%
 git checkout %VCPKG_SNAPSHOT% || goto :error
 :: Bootstrap vcpkg.exe
-%VCPKG_DIR%\bootstrap-vcpkg.bat -disableMetrics
+%VCPKG_DIR%\bootstrap-vcpkg.bat -disableMetrics || goto :error
 echo # END SECTION
 
 echo # BEGIN SECTION: Custom patches to packages
 :: 1. do not build debug builds to speed up CI
-echo "set(VCPKG_BUILD_TYPE release)" >> %VCPKG_DIR%\triplets\x64-windows.cmake
+echo "set(VCPKG_BUILD_TYPE release)" >> %VCPKG_DIR%\triplets\x64-windows.cmake || goto :error
 :: 2. patch dfcln-win32 to avoid debug filesystem paths
 :: dfcln-win32 assumes that debug build is always there.
 :: remove lines with debug word. portfile is simple enough
 set dfcln_portfile=%VCPKG_DIR%\ports\dfcln-win32\portfile.cmake
 findstr  /v  /i "debug" %dfcln_portfile% > %dfcln_portfile%.new || goto :error
-move %dfcln_portfile%.new %dfcln_portfile%
+move %dfcln_portfile%.new %dfcln_portfile% || goto :error
 :: 3. use lowercase in ogre for releaes
 :: ogre formula relies on checking for Release to install manual-link
 :: replace it to lowercase
 set ogre_portfile=%VCPKG_DIR%\ports\ogre\portfile.cmake
-powershell -Command "(Get-Content %ogre_portfile%) -replace 'Release', 'release' | Out-File -encoding ASCII %ogre_portfile%"
+powershell -Command "(Get-Content %ogre_portfile%) -replace 'Release', 'release' | Out-File -encoding ASCII %ogre_portfile%" || goto :error
 echo # END SECTION
 cd %WORKSPACE%
 goto :EOF


### PR DESCRIPTION
The PR implements the use of [`--overlay-ports` parameter in vcpkg](https://github.com/microsoft/vcpkg/blob/master/docs/specifications/ports-overlay.md) to inject our custom ogre2 port available at https://github.com/osrf/vcpkg-ports . Until now, the package was manually copied to the ports/ directory.

We don't need the variable `DEPEN_OSRF_PKGS` anymore so I moved all ogre2 references to `DEPEN_PKGS`. The PR still update the master branch of the vcpkg-ports on every installation to catch new changes.

The PR includes a bit of Groovy to display the Updated node for https://build.osrfoundation.org/job/_vcpkg_update_snapshot/.

Tested here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_vcpkg_update_snapshot&build=9)](https://build.osrfoundation.org/job/_vcpkg_update_snapshot/9/)
