### PR TITLE
Declare ENABLE_ROS in bloom-debbuild

### DIFF
--- a/jenkins-scripts/docker/bloom-debbuild.bash
+++ b/jenkins-scripts/docker/bloom-debbuild.bash
@@ -19,4 +19,5 @@ if [[ -z ${ROS_DISTRO} ]]; then
   exit 1
 fi
 
+export ENABLE_ROS=true
 . ${SCRIPT_DIR}/lib/debbuild-bloom-base.bash


### PR DESCRIPTION
Missing variable to get right the python version inside bloom:

Before: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros-ign-gazebo-bloom-debbuilder&build=12)](https://build.osrfoundation.org/job/ros-ign-gazebo-bloom-debbuilder/12/)

After: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros-ign-gazebo-bloom-debbuilder&build=14)](https://build.osrfoundation.org/job/ros-ign-gazebo-bloom-debbuilder/14/)