### PR TITLE
Snapshot 2020.11 for ignition vcpkg

### DIFF
--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -12,6 +12,6 @@ set VCPKG_CMD=%VCPKG_DIR%\vcpkg.exe
 set VCPKG_CMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%/scripts/buildsystems/vcpkg.cmake
 if NOT DEFINED VCPKG_SNAPSHOT (
   :: see https://github.com/microsoft/vcpkg/releases
-  set VCPKG_SNAPSHOT=2020.01
+  set VCPKG_SNAPSHOT=2020.11
 )
 goto :EOF


### PR DESCRIPTION
Found problems trying to use `2020.01` snapshot and my debugging about what failed when I tested it discovered that I was using `2020.11` for testing instead of `2020.01`. I [tried to backport fixes](https://github.com/osrf/vcpkg-ports/pull/2) for `2020.01` snapshot bug but the thing became not easy and I don't really have a good reason not to use the latest snapshot for vcpkg.
[
I've provisioned](https://build.osrfoundation.org/job/_vcpkg_update_snapshot/28/) the `windows_nuc` agent and run an ign-rendering test: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_vcpkg_migration_ign_rendering-ci-win&build=1)](https://build.osrfoundation.org/job/_test_vcpkg_migration_ign_rendering-ci-win/1/)

The list of external dependencies versions up to ign-rendering:

```
$ ./vcpkg.exe list  | awk '{print $1 " " $2 }'
assimp:x64-windows 5.0.1#3
brotli:x64-windows 1.0.9
bzip2:x64-windows 1.0.8#1
ccd:x64-windows 2.1-4
cppzmq:x64-windows 4.7.1
cuda:x64-windows 10.1#4
curl:x64-windows 7.73.0#1
curl[non-http]:x64-windows Enables
curl[schannel]:x64-windows SSL
curl[ssl]:x64-windows Default
curl[sspi]:x64-windows SSPI
curl[winssl]:x64-windows Legacy
dlfcn-win32:x64-windows 1.1.1-4
double-conversion:x64-windows 3.1.5
egl-registry:x64-windows 2020-02-20
eigen3:x64-windows 3.3.7#7
fcl:x64-windows 0.6.1
ffmpeg:x64-windows 4.3.1#5
ffmpeg[avcodec]:x64-windows Codec
ffmpeg[avdevice]:x64-windows Device
ffmpeg[avfilter]:x64-windows Filter
ffmpeg[avformat]:x64-windows Format
ffmpeg[avresample]:x64-windows Libav
ffmpeg[gpl]:x64-windows allow
ffmpeg[postproc]:x64-windows Postproc
ffmpeg[swresample]:x64-windows Swresample
ffmpeg[swscale]:x64-windows Swscale
freeglut:x64-windows 3.2.1-4
freeimage:x64-windows 3.18.0#17
freetype:x64-windows 2.10.2#4
freetype[bzip2]:x64-windows Support
freetype[png]:x64-windows Support
gettext:x64-windows 0.19-15
gflags:x64-windows 2.2.2-1
glib:x64-windows 2.52.3-14-7
gts:x64-windows 0.7.6-3
harfbuzz:x64-windows 2.7.2
icu:x64-windows 67.1#5
imgui:x64-windows 1.78#3
imgui[freetype]:x64-windows Build
irrlicht:x64-windows 1.8.4-10
jasper:x64-windows 2.0.20
jsoncpp:x64-windows 1.9.4
jxrlib:x64-windows 2019.10.9#2
kubazip:x64-windows 0.1.19
lcms:x64-windows 2.11
libffi:x64-windows 3.3#5
libiconv:x64-windows 1.16#5
libjpeg-turbo:x64-windows 2.0.5
liblzma:x64-windows 5.2.5#1
libpng:x64-windows 1.6.37#12
libpq:x64-windows 12.2#8
libpq[openssl]:x64-windows support
libpq[zlib]:x64-windows Use
libraw:x64-windows 201903-3
libwebp:x64-windows 1.1.0#1
libwebp[nearlossless]:x64-windows Enable
libwebp[simd]:x64-windows Enable
libwebp[unicode]:x64-windows Build
libyaml:x64-windows 0.2.5
libzip:x64-windows 1.7.3
libzip[bzip2]:x64-windows Support
libzip[default-aes]:x64-windows Use
libzip[wincrypto]:x64-windows AES
minizip:x64-windows 1.2.11#7
octomap:x64-windows 1.9.5
ogre2:x64-windows 2.0.9999~2018...
ogre:x64-windows 1.12.9#2
openexr:x64-windows 2.5.0#1
opengl:x64-windows 0.0-7
openjpeg:x64-windows 2.3.1#2
openssl-windows:x64-windows 1.1.1h
openssl:x64-windows 1.1.1g#1
pcre2:x64-windows 10.35#2
pcre:x64-windows 8.44#8
poly2tri:x64-windows 2020-07-21
polyclipping:x64-windows 6.4.2#6
protobuf:x64-windows 3.13.0#2
pugixml:x64-windows 1.10#2
python3:x64-windows 3.8.3#2
qt5-activeqt:x64-windows 5.15.1
qt5-base:x64-windows 5.15.1
qt5-declarative:x64-windows 5.15.1
qt5-imageformats:x64-windows 5.15.1#1
qt5-multimedia:x64-windows 5.15.1
qt5-networkauth:x64-windows 5.15.1
qt5-quickcontrols2:x64-windows 5.15.1
qt5-svg:x64-windows 5.15.1
qt5-tools:x64-windows 5.15.1
qt5:x64-windows 5.15.1
qt5[activeqt]:x64-windows Windows
qt5[declarative]:x64-windows
qt5[essentials]:x64-windows Build
qt5[imageformats]:x64-windows
qt5[multimedia]:x64-windows
qt5[networkauth]:x64-windows
qt5[quickcontrols2]:x64-windows
qt5[svg]:x64-windows
qt5[tools]:x64-windows
qwt:x64-windows 6.1.5
ragel:x64-windows 6.10-3
rapidjson:x64-windows 2020-09-14
sdl2:x64-windows 2.0.12#6
sqlite3:x64-windows 3.33.0
stb:x64-windows 2020-09-14
tiff:x64-windows 4.1.0
tinyxml2:x64-windows 8.0.0-1
utfcpp:x64-windows 3.1.2#1
zeromq:x64-windows 2019-09-20#1
zlib:x64-windows 1.2.11#9
zstd:x64-windows 1.4.4#3
zziplib:x64-windows 0.13.71
```