### PR TITLE
Add sha1 default branch in -pr- and fix XML configuration for crontab polling

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -30,7 +30,7 @@ class GenericAnyJobGitHub
     {
       parameters
       {
-        stringParam('sha1', '', 'commit or refname to build. To manually use a branch: origin/$branch_name')
+        stringParam('sha1', 'main', 'commit or refname to build. To manually use a branch: origin/$branch_name')
       }
 
       scm

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -59,6 +59,7 @@ class GenericAnyJobGitHub
               permitAll(true)
               // do not remove the cron line otherwise it triggers an error in the log
               spec('')
+              cron('')
               whiteListTargetBranches {
                 supported_branches.each { supported_branch ->
                   'org.jenkinsci.plugins.ghprb.GhprbBranch' {

--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -57,7 +57,8 @@ class GenericAnyJobGitHub
               useGitHubHooks(true)
               onlyTriggerPhrase(false)
               permitAll(true)
-              // do not remove the cron line otherwise it triggers an error in the log
+              // do not remove the cron/spec lines otherwise it triggers an error in the log
+              // both are needed to control the contrab behaviour
               spec('')
               cron('')
               whiteListTargetBranches {


### PR DESCRIPTION
Should workaround https://github.com/ignition-tooling/release-tools/issues/242 in two ways:

* If the [my comment about](https://github.com/ignition-tooling/release-tools/issues/242#issuecomment-746099647) `<spec>` and `<cron>` is correct and there is a miss-configuration in the XML that leads to polling operations, I've verified that with the definition of `<cron>` as empty there is no default value anymore coming to crontab when opening the Jenkins GUI manually.
* I'm adding a default `sha1` value here following instructions of the Jenkins plugin [that explains](https://github.com/jenkinsci/ghprb-plugin):

> If you want to manually build the job, in the job setting check This build is parameterized and add string parameter named sha1 with a default value of master.
