### PR TITLE
Use colcon + vcpkg for sdformat10 and newer

### DIFF
--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -15,7 +15,7 @@ if %SDFORMAT_MAJOR_VERSION% GEQ 10 (
   set COLCON_PACKAGE=sdformat
   set COLCON_AUTO_MAJOR_VERSION=true
   call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"
-else if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
+) else if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
   call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"
 ) else (
   call "%SCRIPT_DIR%/lib/sdformat-base-windows.bat"

--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -9,7 +9,13 @@ set IGN_CLEAN_WORKSPACE=true
 set DEPEN_PKGS="libxml2 tinyxml2"
 
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set SDFORMAT_MAJOR_VERSION=%%i
-if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
+
+if %SDFORMAT_MAJOR_VERSION% GEQ 10 (
+  :: This needs to be migrated to DSL to get multi-major versions correctly
+  set COLCON_PACKAGE=sdformat
+  set COLCON_AUTO_MAJOR_VERSION=true
+  call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"
+else if %SDFORMAT_MAJOR_VERSION% GEQ 6 (
   call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"
 ) else (
   call "%SCRIPT_DIR%/lib/sdformat-base-windows.bat"

--- a/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/sdformat-default-devel-windows-amd64.bat
@@ -11,7 +11,6 @@ set DEPEN_PKGS="libxml2 tinyxml2"
 for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set SDFORMAT_MAJOR_VERSION=%%i
 
 if %SDFORMAT_MAJOR_VERSION% GEQ 10 (
-  :: This needs to be migrated to DSL to get multi-major versions correctly
   set COLCON_PACKAGE=sdformat
   set COLCON_AUTO_MAJOR_VERSION=true
   call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"


### PR DESCRIPTION
We still have some scripts that relies on the old behaviour of using tarballs + configure.bat files. Here I'm enabling colcon + vcpkg to sdformat10 and above. This should fix the problem with tinyxml2.

Tested here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat10-windows7-amd64&build=21)](https://build.osrfoundation.org/job/sdformat-ci-sdformat10-windows7-amd64/21/)

The failing tests can come from the fact of compiling ign-tools support (in gazebodistro file) that was previously ignored.

//cc @scpeters @azeey