### PR TITLE
brew: add icu4c library path

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -123,6 +123,10 @@ fi
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'gettext' }.empty?"; then
   export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/gettext/lib
 fi
+# if we are using boost, need to add icu4c library path since it is keg-only
+if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'icu4c' }.empty?"; then
+  export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/icu4c/lib
+fi
 
 # if we are using dart@6.10.0 (custom OR port), need to add dartsim library path since it is keg-only
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'dartsim@6.10.0' }.empty?"; then


### PR DESCRIPTION
boost 1.75 is exposing icu4c libraries as transitive dependencies (see https://github.com/osrf/homebrew-simulation/issues/1235). I think this is incorrect, but for now add `/usr/local/opt/icu4c/lib` to the `LIBRARY_PATH`.

Without this fix: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics3-homebrew-amd64&build=9)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics3-homebrew-amd64/9/) https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics3-homebrew-amd64/9/

With this fix: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics3-homebrew-amd64&build=10)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics3-homebrew-amd64/10/) https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics3-homebrew-amd64/10/