### PR TITLE
brew bottles: skip tap syntax

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -61,8 +61,14 @@ pushd $(brew --repo osrf/simulation) && \
   hub pr checkout ${ghprbPullId} && \
   popd
 
+# skip tap syntax for now until we replace :x11
+# do this by invoking with --only-setup and --only-formulae
+brew test-bot --tap=osrf/simulation \
+              --only-setup
+
 brew test-bot --tap=osrf/simulation \
               --fail-fast \
+              --only-formulae \
               --root-url=https://osrf-distributions.s3.amazonaws.com/bottles-simulation
 echo '# END SECTION'
 


### PR DESCRIPTION
:x11 requirements are deprecated (https://github.com/osrf/homebrew-simulation/issues/1227), skip tap syntax checking for now

Our bottle builds are failing the tap syntax check, for example from https://github.com/osrf/homebrew-simulation/pull/1238:

*  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder%2Flabel%3Dosx_mojave&build=139)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_mojave/139/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_mojave/139/console