### PR TITLE
WIP: Fix homebrew_pr_bottle_hash_updater

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -6,6 +6,8 @@
 
 restore_brew()
 {
+    sudo apt update
+    sudo apt install libz-dev
     rm -fr /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby
     ${BREW} update-reset
     ${BREW} vendor-install ruby

--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -4,6 +4,13 @@
 # Return:
 # -> TAP_PREFIX
 
+restore_brew()
+{
+    rm -fr /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby
+    ${BREW} update-reset
+    ${BREW} vendor-install ruby
+}
+
 echo '# BEGIN SECTION: check variables'
 if [ -z "${PULL_REQUEST_HEAD_REPO}" ]; then
   echo PULL_REQUEST_HEAD_REPO not specified, setting to osrfbuild
@@ -41,6 +48,12 @@ echo '# END SECTION'
 BREW_PREFIX="/home/linuxbrew/.linuxbrew"
 BREW=${BREW_PREFIX}/bin/brew
 ${BREW} up
+
+pushd $(${BREW} --prefix)/Homebrew/Library 2> /dev/null
+git stash && git clean -d -f
+# Need to test if brew installation is still working (use audit cmake to quick check)
+${BREW} audit cmake || restore_brew
+popd 2> /dev/null
 
 ${BREW} ruby -e "puts 'brew ruby success'"
 


### PR DESCRIPTION
Our homebrew bottle workflow has been broken since the https://build.osrfoundation.org/job/generic-release-homebrew_pr_bottle_hash_updater/ job started failing recently. This job runs at the end after bottles have been built and pushes a commit to the open pull request with the new bottle `sha256` values. Something has been failing when trying to update ruby gems when calling `brew audit`. I copied the `restore_brew()` bash function from [_homebrew_cleanup.bash](https://github.com/ignition-tooling/release-tools/blob/32a0ef7c573dcfec9cc4c2e9f450a7979df9a21b/jenkins-scripts/lib/_homebrew_cleanup.bash#L4) (used on macOS), but that doesn't seem to help, as it complains that `libz` is missing from the base system. I tried a naive approach to install `libz-dev` in 8bd76db but that doesn't work either.

Help me Jose Luis Rivero, you're my only hope.