### PR TITLE
Ignition Utils will be version 1 on Edifice

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -64,7 +64,7 @@ ignition_debbuild = ignition_software + [ 'cmake3',
                                           'sensors5',
                                           'tools2',
                                           'transport10',
-                                          'utils']
+                                          'utils1']
 // DESC: exclude ignition from generate any install testing job
 ignition_no_pkg_yet         = [  ]
 // DESC: major versions that has a package in the prerelease repo. Should

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -42,7 +42,7 @@ ignition_branches           = [ 'cmake'      : [ '2' ],
                                 'sensors'    : [ '3', '4' ],
                                 'tools'      : [ '1' ],
                                 'transport'  : [ '2', '4', '8', '9' ],
-                                'utils'      : [ '0' ]]
+                                'utils'      : [ '1' ]]
 // DESC: prerelease branches are managed as any other supported branches for
 // special cases different to major branches: get compilation CI on the branch
 // physics/sensors don't need to be included since they use main for gz11
@@ -64,7 +64,7 @@ ignition_debbuild = ignition_software + [ 'cmake3',
                                           'sensors5',
                                           'tools2',
                                           'transport10',
-                                          'utils0']
+                                          'utils']
 // DESC: exclude ignition from generate any install testing job
 ignition_no_pkg_yet         = [  ]
 // DESC: major versions that has a package in the prerelease repo. Should

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -33,7 +33,7 @@ ignition_collections = [
           'sensors'   : [ debbuild: 'ign-sensors5'    , branch: 'main' ],
           'tools'     : [ debbuild: 'ign-tools2'      , branch: 'main' ],
           'transport' : [ debbuild: 'ign-transport10' , branch: 'main' ],
-          'utils'     : [ debbuild: 'ign-utils0'      , branch: 'main' ],
+          'utils'     : [ debbuild: 'ign-utils'       , branch: 'main' ],
     ],
   ],
 ]

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -33,7 +33,7 @@ ignition_collections = [
           'sensors'   : [ debbuild: 'ign-sensors5'    , branch: 'main' ],
           'tools'     : [ debbuild: 'ign-tools2'      , branch: 'main' ],
           'transport' : [ debbuild: 'ign-transport10' , branch: 'main' ],
-          'utils'     : [ debbuild: 'ign-utils'       , branch: 'main' ],
+          'utils'     : [ debbuild: 'ign-utils1'       , branch: 'main' ],
     ],
   ],
 ]

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -33,7 +33,7 @@ ignition_collections = [
           'sensors'   : [ debbuild: 'ign-sensors5'    , branch: 'main' ],
           'tools'     : [ debbuild: 'ign-tools2'      , branch: 'main' ],
           'transport' : [ debbuild: 'ign-transport10' , branch: 'main' ],
-          'utils'     : [ debbuild: 'ign-utils1'       , branch: 'main' ],
+          'utils'     : [ debbuild: 'ign-utils1'      , branch: 'main' ],
     ],
   ],
 ]


### PR DESCRIPTION
We always have the dilemma with version 1 of whether to omit the 1 or not. I'm just following the `ign-plugin` pattern and omitting 1... Hey, maybe we'll never need a version 2 :wink: 