### PR TITLE
Explicitly tap homebrew-test-bot

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -53,6 +53,7 @@ echo '# BEGIN SECTION: run test-bot'
 # The test-bot makes a full cleanup of all installed pkgs. Be sure of install back
 # git to keep the slave working
 export HOMEBREW_DEVELOPER=1
+brew tap homebrew/test-bot
 brew tap osrf/simulation
 # replace with 'hub -C $(brew --repo osrf/simulation) pr checkout ${ghprbPullId}'
 # after the following hub issue is resolved:


### PR DESCRIPTION
The logic for auto-tapping has changed recently in https://github.com/Homebrew/brew/pull/10366, so we need to explicitly re-tap it. This should help with https://github.com/osrf/homebrew-simulation/pull/1310