### PR TITLE
Improve nvidia detection and docker integration

### DIFF
--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -44,7 +44,7 @@ if $USE_GPU_DOCKER; then
   if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
     if $NVIDIA_DOCKER2_NODE; then
       export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} \
-                               --runtime=nvidia"
+	                       --gpus all"
     else
       export docker_cmd="nvidia-docker"
     fi

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -41,12 +41,28 @@ if $USE_GPU_DOCKER; then
                     -v /var/run/docker.sock:/var/run/docker.sock \
                     -v /tmp/.X11-unix:/tmp/.X11-unix:rw"
 
+  # Implementation options (both methods can be coinstalled and runtime compatible)
+  # 1. Native GPU Support:
+  #   - Included with Docker-ce 19.03 or later
+  #   - Package: nvidia-container-toolkit
+  #   - docker param: --gpus all
+  # 2. NVIDIA Container Runtime for Docker:
+  #   - If the nvidia-docker2 package is installed
+  #   - Package: nvidia-docker2
+  #   - docker param: --runtime=nvidia
+  #
+  # Reference: https://docs.nvidia.com/deeplearning/frameworks/user-guide/index.html
   if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
-    if $NVIDIA_DOCKER2_NODE; then
-      export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} \
-	                       --gpus all"
-    else
+    if dpkg -s nvidia-container-toolkit; then
+      export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --gpus all"
+    elif dpkg -s nvidia-docker2; then
+      export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia"
+    elif dpkg -s nvidia-docker; then
       export docker_cmd="nvidia-docker"
+    else
+      echo "No docker-nvidia support was detected but Nvidia car is detected"
+      echo "Probably a problem in provision of the agent"
+      exit 1
     fi
   fi
 fi

--- a/jenkins-scripts/lib/check_graphic_card.bash
+++ b/jenkins-scripts/lib/check_graphic_card.bash
@@ -28,6 +28,16 @@ fi
 # First try to get the display variable
 export_display_variable
 
+# Check for intel
+if [ -n "$(lspci -v | grep "Kernel driver in use: i[0-9][0-9][0-9]")" ]; then
+    export GRAPHIC_CARD_PKG="xserver-xorg-video-intel"
+    export GRAPHIC_CARD_NAME="Intel"
+    export GRAPHIC_CARD_FOUND=true
+    # Need to run properly DRI on intel
+    export EXTRA_PACKAGES="${EXTRA_PACKAGES} libgl1-mesa-dri"
+fi
+
+# If there are two cards in use (intel + other), let nvidia override and be the one selected
 # Check for Nvidia stuff. Using nvidia-docker no installation needed
 if [ -n "$(lspci -v | grep nvidia | head -n 2 | grep "Kernel driver in use: nvidia")" ]; then
     export GRAPHIC_CARD_NAME="Nvidia"
@@ -40,15 +50,6 @@ if [ -n "$(lspci -v | grep "ATI" | grep "VGA")" ]; then
     export GRAPHIC_CARD_PKG=fglrx
     export GRAPHIC_CARD_NAME="ATI"
     export GRAPHIC_CARD_FOUND=true
-fi
-
-# Check for intel
-if [ -n "$(lspci -v | grep "Kernel driver in use: i[0-9][0-9][0-9]")" ]; then
-    export GRAPHIC_CARD_PKG="xserver-xorg-video-intel"
-    export GRAPHIC_CARD_NAME="Intel"
-    export GRAPHIC_CARD_FOUND=true
-    # Need to run properly DRI on intel
-    export EXTRA_PACKAGES="${EXTRA_PACKAGES} libgl1-mesa-dri"
 fi
 
 # Be sure that we have GPU support


### PR DESCRIPTION
The pull request changes two things:

 * Prefer nvidia in nodes with two cards installed. d0eeb3e 
 * Auto select the nvidia/docker integration from current available options 

Testing:
 * r2d2 node (nvidia-docker): [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_rendering-ci-default-bionic-amd64&build=11)](https://build.osrfoundation.org/job/_test_ignition_rendering-ci-default-bionic-amd64/11/)
 * optimus node (nvidia-container-toolkit) [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_rendering-ci-default-bionic-amd64&build=10)](https://build.osrfoundation.org/job/_test_ignition_rendering-ci-default-bionic-amd64/10/)
 * drogon node (nvidia-container-toolkit) [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_rendering-ci-default-bionic-amd64&build=8)](https://build.osrfoundation.org/job/_test_ignition_rendering-ci-default-bionic-amd64/8/). Need to check if the error in 1 test comes from these changes.