### PR TITLE
Enable ignition-gazebo CI on Windows

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -627,8 +627,8 @@ ignition_software.each { ign_sw ->
                                     enable_testing(ign_sw))
   ignition_win_ci_any_job.with
   {
-     // ign-gazebo/ign-launch still not ported completely to Windows
-     if (ign_sw == 'gazebo' || ign_sw == 'launch')
+     // ign-launch still not ported completely to Windows
+     if (ign_sw == 'launch')
        disabled()
 
       steps {
@@ -663,8 +663,12 @@ ignition_software.each { ign_sw ->
 
     ignition_win_ci_job.with
     {
-        // ign-gazebo/ign-launch still not ported completely to Windows
-        if (ign_sw == 'gazebo' || ign_sw == 'launch')
+        // ign-gazebo only works in main by now (ign-gazebo5)
+        if (ign_sw == 'gazebo' && branch != 'main')
+          disabled()
+
+        // ign-launch still not ported completely to Windows
+        if (ign_sw == 'launch')
           disabled()
 
         triggers {


### PR DESCRIPTION
Together with the merge of https://github.com/ignitionrobotics/ign-gazebo/pull/585 it will enable the Windows CI on ignition-gazebo.
Partially fix https://github.com/ignition-tooling/release-tools/issues/351