### PR TITLE
Auto detect nvidia support

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -120,11 +120,6 @@ if [ -z ${ENABLE_ROS} ]; then
   ENABLE_ROS=false
 fi
 
-# By default nodes are in nvidia-docker1
-if [ -z ${NVIDIA_DOCKER2_NODE} ]; then
-  NVIDIA_DOCKER2_NODE=false
-fi
-
 # Transition for 4.8 -> 4.9 makes some optimization in the linking
 # which can break some software. Use it as a workaround in this case
 if [ -z ${NEED_GCC48_COMPILER} ]; then

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -363,30 +363,6 @@ cat >> Dockerfile << DELIM_NVIDIA2_GPU
     ${NVIDIA_VISIBLE_DEVICES:-all}
   ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
-
-  # Install libglvnd for OpenGL using nvidia-docker2
-  RUN apt-get update && apt-get install -y --no-install-recommends \
-	git \
-	ca-certificates \
-	make \
-	automake \
-	autoconf \
-	libtool \
-	pkg-config \
-	python3 \
-	libxext-dev \
-	libx11-dev \
-	x11proto-gl-dev && \
-    rm -rf /var/lib/apt/lists/*
-
-  RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
-    git clone -b v1.2.0 https://github.com/NVIDIA/libglvnd.git . && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
-    make install-strip && \
-    find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
-
-  ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 DELIM_NVIDIA2_GPU
   fi
  else

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -347,7 +347,7 @@ fi
 
 if $USE_GPU_DOCKER; then
  if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
-   if $NVIDIA_DOCKER2_NODE; then
+   if [[ ${NVIDIA_DOCKER_DRIVER} == 'nvidia-docker2' ]]; then
    # NVIDIA is using nvidia_docker2 integration
    cat >> Dockerfile << DELIM_NVIDIA2_GPU
 # nvidia-container-runtime

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -347,48 +347,48 @@ fi
 
 if $USE_GPU_DOCKER; then
  if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
-   if [[ ${NVIDIA_DOCKER_DRIVER} == 'nvidia-docker2' ]]; then
-   # NVIDIA is using nvidia_docker2 integration
-   cat >> Dockerfile << DELIM_NVIDIA2_GPU
-# nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES \
+   if [[ ${NVIDIA_DOCKER_DRIVER} == 'nvidia-docker' ]]; then
+# NVIDIA-DOCKER1
+cat >> Dockerfile << DELIM_NVIDIA_GPU
+  # nvidia-container-runtime
+  LABEL com.nvidia.volumes.needed="nvidia_driver"
+  ENV PATH /usr/local/nvidia/bin:\${PATH}
+  ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\${LD_LIBRARY_PATH}
+DELIM_NVIDIA_GPU
+   else
+# NVIDIA is using nvidia_docker2 integration
+cat >> Dockerfile << DELIM_NVIDIA2_GPU
+  # nvidia-container-runtime
+  ENV NVIDIA_VISIBLE_DEVICES \
     ${NVIDIA_VISIBLE_DEVICES:-all}
-ENV NVIDIA_DRIVER_CAPABILITIES \
+  ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
 
-# Install libglvnd for OpenGL using nvidia-docker2
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        git \
-        ca-certificates \
-        make \
-        automake \
-        autoconf \
-        libtool \
-        pkg-config \
-        python3 \
-        libxext-dev \
-        libx11-dev \
-        x11proto-gl-dev && \
+  # Install libglvnd for OpenGL using nvidia-docker2
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+	git \
+	ca-certificates \
+	make \
+	automake \
+	autoconf \
+	libtool \
+	pkg-config \
+	python3 \
+	libxext-dev \
+	libx11-dev \
+	x11proto-gl-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
+  RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
     git clone -b v1.2.0 https://github.com/NVIDIA/libglvnd.git . && \
     ./autogen.sh && \
     ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
     make install-strip && \
     find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
 
-ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+  ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 DELIM_NVIDIA2_GPU
-   else
-   # NVIDIA-DOCKER1
-   cat >> Dockerfile << DELIM_NVIDIA_GPU
-# nvidia-container-runtime
-LABEL com.nvidia.volumes.needed="nvidia_driver"
-ENV PATH /usr/local/nvidia/bin:\${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\${LD_LIBRARY_PATH}
-DELIM_NVIDIA_GPU
-   fi
+  fi
  else
   # No NVIDIA cards needs to have the same X stack than the host
   cat >> Dockerfile << DELIM_DISPLAY

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -53,8 +53,8 @@ if $USE_GPU_DOCKER; then
         export docker_cmd="nvidia-docker"
       ;;
       *)
-        echo "No docker-nvidia support was detected but Nvidia car is detected"
-        echo "Probably a problem in provision of the agent"
+        echo "No docker-nvidia support was detected but an Nvidia card is detected"
+        echo "Probably a problem in the provisioning of the agent"
         exit 1
     esac
   fi

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -41,29 +41,22 @@ if $USE_GPU_DOCKER; then
                     -v /var/run/docker.sock:/var/run/docker.sock \
                     -v /tmp/.X11-unix:/tmp/.X11-unix:rw"
 
-  # Implementation options (both methods can be coinstalled and runtime compatible)
-  # 1. Native GPU Support:
-  #   - Included with Docker-ce 19.03 or later
-  #   - Package: nvidia-container-toolkit
-  #   - docker param: --gpus all
-  # 2. NVIDIA Container Runtime for Docker:
-  #   - If the nvidia-docker2 package is installed
-  #   - Package: nvidia-docker2
-  #   - docker param: --runtime=nvidia
-  #
-  # Reference: https://docs.nvidia.com/deeplearning/frameworks/user-guide/index.html
   if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
-    if dpkg -s nvidia-container-toolkit; then
-      export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --gpus all"
-    elif dpkg -s nvidia-docker2; then
-      export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia"
-    elif dpkg -s nvidia-docker; then
-      export docker_cmd="nvidia-docker"
-    else
-      echo "No docker-nvidia support was detected but Nvidia car is detected"
-      echo "Probably a problem in provision of the agent"
-      exit 1
-    fi
+    case ${NVIDIA_DOCKER_DRIVER} in
+      'nvidia-container-toolkit')
+        export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --gpus all"
+      ;;
+      'nvidia-docker2')
+        export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia"
+      ;;
+      'nvidia-docker')
+        export docker_cmd="nvidia-docker"
+      ;;
+      *)
+        echo "No docker-nvidia support was detected but Nvidia car is detected"
+        echo "Probably a problem in provision of the agent"
+        exit 1
+    esac
   fi
 fi
 


### PR DESCRIPTION
This should fix the problems on current optimus introduced in #386, since `nvidia-toolkit-container` does not install `ENV NVIDIA_VISIBLE_DEVICES` variables needed to expose gpus into the container.

Other improvements:
 * Remove the need for `NVIDIA_DOCKER2_NODE` in nodes configuration. Autodetected from packages installed.
 * Remove the `libglvnd` installation. Testing seems not to need it.

Testing:
 * Optimus [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_rendering-ci-default-bionic-amd64&build=22)](https://build.osrfoundation.org/job/_test_ignition_rendering-ci-default-bionic-amd64/22/)
 * Drogon (one failing, flaky) [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_rendering-ci-default-bionic-amd64&build=23)](https://build.osrfoundation.org/job/_test_ignition_rendering-ci-default-bionic-amd64/23/)
 * Maria (no gpu) [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_rendering-ci-default-bionic-amd64&build=24)](https://build.osrfoundation.org/job/_test_ignition_rendering-ci-default-bionic-amd64/24/)
 * r2d2 [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_ignition_rendering-ci-default-bionic-amd64&build=25)](https://build.osrfoundation.org/job/_test_ignition_rendering-ci-default-bionic-amd64/25/)