### PR TITLE
Simplify release.py for ignition releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ Gazebo Classic and Ignition software.
     1. `cd <path to source code>`
     1. Make sure you're in the branch to be released, after the pull request bumping the version has been merged.
     1. Dry-run `release.py` with the appropriate arguments. Some examples:
-        1. New Ignition minor release: `<path to release-tools>/release.py -r 1 ign-physics3 3.1.0 secrettoken --dry-run`
+        1. New Ignition minor release and Gazebo classic release:
+          1. `<path to release-tools>/release.py -r 1 ign-physics3 3.1.0 secrettoken --dry-run`
+          1. `<path to release-tools>/release.py -r 1 gazebo11 11.2.0 secrettoken --dry-run`
         1. Pre-release: `<path to release-tools>/release.py -r 1 ign-physics3 3.0.0~pre1 --upload-to-repo=prerelease secrettoken --dry-run`
-        1. Classic release: `<path to release-tools>/release.py -r 1 gazebo11 11.2.0 secrettoken --dry-run`
     1. If the dry run succeeds, run the same command again, now without `--dry-run`.
 1. Check that:
     * Several `-debbuilder` jobs have been queued in https://build.osrfoundation.org/ and watch those jobs to see if any of them fail.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Gazebo Classic and Ignition software.
     1. `cd <path to source code>`
     1. Make sure you're in the branch to be released, after the pull request bumping the version has been merged.
     1. Dry-run `release.py` with the appropriate arguments. Some examples:
-        1. New Ignition minor release: `<path to release-tools>/release.py -r 1 ign-physics3 3.1.0 --ignition-repo -a ignition-physics3 secrettoken --dry-run`
-        1. Pre-release: `<path to release-tools>/release.py -r 1 ign-physics3 3.0.0~pre1 --ignition-repo -a ignition-physics3 --upload-to-repo=prerelease secrettoken --dry-run`
+        1. New Ignition minor release: `<path to release-tools>/release.py -r 1 ign-physics3 3.1.0 secrettoken --dry-run`
+        1. Pre-release: `<path to release-tools>/release.py -r 1 ign-physics3 3.0.0~pre1 --upload-to-repo=prerelease secrettoken --dry-run`
         1. Classic release: `<path to release-tools>/release.py -r 1 gazebo11 11.2.0 secrettoken --dry-run`
     1. If the dry run succeeds, run the same command again, now without `--dry-run`.
 1. Check that:

--- a/release.py
+++ b/release.py
@@ -138,7 +138,7 @@ def parse_args(argv):
     args = parser.parse_args()
 
     args.package_alias = args.package
-    # If ignition auto is enabled, replace ign- at the begging of the string
+    # If ignition auto is enabled, replace ign- with ignition- at the beginning
     if not args.no_ignition_auto and args.package.startswith('ign-'):
         args.package_alias = args.package.replace('ign-', 'ignition-')
 

--- a/release.py
+++ b/release.py
@@ -137,10 +137,11 @@ def parse_args(argv):
                         help='branch in the source code repository to build the nightly from')
     args = parser.parse_args()
 
-    IGN_AUTO_DETECTED = args.package.startswith('ign-') if not args.no_ignition_auto else False
-    print(IGN_AUTO_DETECTED)
-    if not args.package_alias:
-        args.package_alias = args.package.replace('ign-', 'ignition-') if IGN_AUTO_DETECTED else args.package
+    args.package_alias = args.package
+    # If ignition auto is enabled, replace ign- at the begging of the string
+    if not args.no_ignition_auto and args.package.startswith('ign-'):
+        args.package_alias = args.package.replace('ign-', 'ignition-')
+
     DRY_RUN = args.dry_run
     UPSTREAM = args.upstream
     NO_SRC_FILE = args.no_source_file

--- a/release.py
+++ b/release.py
@@ -30,8 +30,8 @@ RELEASEPY_NO_ARCH_PREFIX = '.releasepy_NO_ARCH_'
 # the release repositories, when needed.
 UBUNTU_DISTROS = []
 
-OSRF_REPOS_SUPPORTED="stable prerelease nightly mentor2 haptix-pre"
-OSRF_REPOS_SELF_CONTAINED="mentor2"
+OSRF_REPOS_SUPPORTED = "stable prerelease nightly"
+OSRF_REPOS_SELF_CONTAINED = ""
 
 DRY_RUN = False
 NIGHTLY = False
@@ -443,17 +443,8 @@ def generate_upload_tarball(args):
 
     # use cmake to generate package_source
     generate_package_source(srcdir, builddir)
-
-    # Upload tarball. Do not include versions in tarballs
-    tarball_name = re.sub(r'[0-9]+$','', args.package)
-
-    # Trick to make mentor job project to get proper URLs
-    if args.package == "mentor2":
-        tarball_name = "mentor2"
-
     # For ignition, we use the alias without version numbers as package name
     tarball_name = re.sub(r'[0-9]+$', '', args.package_alias)
-
     tarball_sha, tarball_fname, tarball_path = create_tarball_path(tarball_name, args.version, builddir, args.dry_run)
 
     # If we're releasing under a different name, then rename the tarball (the

--- a/release.py
+++ b/release.py
@@ -38,7 +38,6 @@ NIGHTLY = False
 PRERELEASE = False
 UPSTREAM = False
 NO_SRC_FILE = False
-IGN_REPO = False
 
 IGNORE_DRY_RUN = True
 
@@ -106,7 +105,6 @@ def parse_args(argv):
     global PRERELEASE
     global UPSTREAM
     global NO_SRC_FILE
-    global IGN_REPO
 
     parser = argparse.ArgumentParser(description='Make releases.')
     parser.add_argument('package', help='which package to release')
@@ -129,8 +127,8 @@ def parse_args(argv):
                         help='no-sanity-checks; i.e. skip sanity checks commands')
     parser.add_argument('--no-generate-source-file', dest='no_source_file', action='store_true', default=False,
                         help='Do not generate source file when building')
-    parser.add_argument('--ignition-repo', dest='ignition_repo', action='store_true', default=False,
-                        help='use ignition robotics URL repositories instead of OSRF')
+    parser.add_argument('--no-ignition-auto', dest='no_ignition_auto', action='store_true', default=False,
+                        help='Use package name to create --package-alias if package name starts with ign-')
     parser.add_argument('--upload-to-repo', dest='upload_to_repository', default="stable",
                         help='OSRF repo to upload: stable | prerelease | nightly')
     parser.add_argument('--extra-osrf-repo', dest='extra_repo', default="",
@@ -138,12 +136,14 @@ def parse_args(argv):
     parser.add_argument('--nightly-src-branch', dest='nightly_branch', default="main",
                         help='branch in the source code repository to build the nightly from')
     args = parser.parse_args()
+
+    IGN_AUTO_DETECTED = args.package.startswith('ign-') if not args.no_ignition_auto else False
+    print(IGN_AUTO_DETECTED)
     if not args.package_alias:
-        args.package_alias = args.package
+        args.package_alias = args.package.replace('ign-', 'ignition-') if IGN_AUTO_DETECTED else args.package
     DRY_RUN = args.dry_run
     UPSTREAM = args.upstream
     NO_SRC_FILE = args.no_source_file
-    IGN_REPO = args.ignition_repo
     UPLOAD_REPO = args.upload_to_repository
     if args.upload_to_repository == 'nightly':
         NIGHTLY = True
@@ -451,8 +451,7 @@ def generate_upload_tarball(args):
         tarball_name = "mentor2"
 
     # For ignition, we use the alias without version numbers as package name
-    if IGN_REPO:
-        tarball_name = re.sub(r'[0-9]+$','', args.package_alias)
+    tarball_name = re.sub(r'[0-9]+$', '', args.package_alias)
 
     tarball_sha, tarball_fname, tarball_path = create_tarball_path(tarball_name, args.version, builddir, args.dry_run)
 


### PR DESCRIPTION
The PR removes death code using argument  `--ignition-repo` (there is no release information outside of `ignition-release` if I'm not wrong). It also enable the auto calculation of `package-alias` for anything package starting with `ign-` unless the option `---no-ignition-auto` is enabled (to cover hidden corner cases).

