### PR TITLE
Use libglvnd to handle GL calls correctly in GPU docker

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -363,6 +363,27 @@ cat >> Dockerfile << DELIM_NVIDIA2_GPU
     ${NVIDIA_VISIBLE_DEVICES:-all}
   ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+# Install libglvnd for OpenGL using nvidia-docker2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        make \
+        automake \
+        autoconf \
+        libtool \
+        pkg-config \
+        python3 \
+        libxext-dev \
+        libx11-dev \
+        x11proto-gl-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
+    git clone -b v1.2.0 https://github.com/NVIDIA/libglvnd.git . && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
+    make install-strip && \
+    find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
+ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}
 DELIM_NVIDIA2_GPU
   fi
  else

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -44,7 +44,7 @@ if $USE_GPU_DOCKER; then
   if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
     case ${NVIDIA_DOCKER_DRIVER} in
       'nvidia-container-toolkit' | 'nvidia-docker2')
-        export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia --gpus all"
+        export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia"
       ;;
       'nvidia-docker')
         export docker_cmd="nvidia-docker"

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -44,7 +44,7 @@ if $USE_GPU_DOCKER; then
   if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
     case ${NVIDIA_DOCKER_DRIVER} in
       'nvidia-container-toolkit' | 'nvidia-docker2')
-        export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia"
+        export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia --gpus all"
       ;;
       'nvidia-docker')
         export docker_cmd="nvidia-docker"

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -43,10 +43,7 @@ if $USE_GPU_DOCKER; then
 
   if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
     case ${NVIDIA_DOCKER_DRIVER} in
-      'nvidia-container-toolkit')
-        export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --gpus all"
-      ;;
-      'nvidia-docker2')
+      'nvidia-container-toolkit' | 'nvidia-docker2')
         export EXTRA_PARAMS_STR="${EXTRA_PARAMS_STR} --runtime=nvidia"
       ;;
       'nvidia-docker')


### PR DESCRIPTION
The `libglvnd` was removed in #392 and seems like some nodes are being failing since them when running the gazebo classic install job (does not seems to happen in ign-rendering CI). The PR installed it again and simplifies the nvidia-docker2 calls.

**Tested in:**

 * drogon [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_gazebo-install-gazebo9_pkg-xenial-amd64&build=3)](https://build.osrfoundation.org/job/_test_gazebo-install-gazebo9_pkg-xenial-amd64/3/)
 * optimus [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_gazebo-install-gazebo9_pkg-xenial-amd64&build=4)](https://build.osrfoundation.org/job/_test_gazebo-install-gazebo9_pkg-xenial-amd64/4/)
 * r2d2 [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_gazebo-install-gazebo9_pkg-xenial-amd64&build=5)](https://build.osrfoundation.org/job/_test_gazebo-install-gazebo9_pkg-xenial-amd64/5/)

