### PR TITLE
Don't build dependencies from source on CI, use nightlies

### DIFF
--- a/jenkins-scripts/docker/ign_common-compilation.bash
+++ b/jenkins-scripts/docker/ign_common-compilation.bash
@@ -32,12 +32,6 @@ if [[ ${IGN_COMMON_MAJOR_VERSION} -ge 3 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
-if [[ ${IGN_COMMON_MAJOR_VERSION} -eq 4 ]]; then
-  export BUILD_IGN_UTILS=true
-  export IGN_UTILS_MAJOR_VERSION=1
-  export IGN_UTILS_BRANCH=main
-fi
-
 export GZDEV_PROJECT_NAME="ignition-common${IGN_COMMON_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
+++ b/jenkins-scripts/docker/ign_fuel-tools-compilation.bash
@@ -29,12 +29,6 @@ if ! [[ ${IGN_FUEL_TOOLS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
-if [[ ${IGN_FUEL_TOOLS_MAJOR_VERSION} -eq 6 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=7
-  export IGN_MSGS_BRANCH=main
-fi
-
 export GZDEV_PROJECT_NAME="ignition-fuel-tools${IGN_FUEL_TOOLS_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_gazebo-compilation.bash
+++ b/jenkins-scripts/docker/ign_gazebo-compilation.bash
@@ -31,43 +31,6 @@ fi
 export NEED_C17_COMPILER=true
 export GPU_SUPPORT_NEEDED=true
 
-if [[ ${IGN_GAZEBO_MAJOR_VERSION} -eq 5 ]]; then
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=5
-  export IGN_RENDERING_BRANCH=main
-
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=5
-  export IGN_GUI_BRANCH=main
-
-  export BUILD_IGN_SENSORS=true
-  export IGN_SENSORS_MAJOR_VERSION=5
-  export IGN_SENSORS_BRANCH=main
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=7
-  export IGN_MSGS_BRANCH=main
-
-  export BUILD_IGN_FUEL_TOOLS=true
-  export IGN_FUEL_TOOLS_MAJOR_VERSION=6
-  export IGN_FUEL_TOOLS_BRANCH=main
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=10
-  export IGN_TRANSPORT_BRANCH=main
-
-  export BUILD_SDFORMAT=true
-  export SDFORMAT_MAJOR_VERSION=11
-  export SDFORMAT_BRANCH=master
-
-  export BUILD_IGN_PHYSICS=true
-  export IGN_PHYSICS_MAJOR_VERSION=4
-  export IGN_PHYSICS_BRANCH=main
-
-  export BUILD_IGN_UTILS=true
-  export IGN_UTILS_MAJOR_VERSION=1
-  export IGN_UTILS_BRANCH=main
-fi
 export GZDEV_PROJECT_NAME="ignition-gazebo${IGN_GAZEBO_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_gui-compilation.bash
+++ b/jenkins-scripts/docker/ign_gui-compilation.bash
@@ -33,19 +33,6 @@ if [[ ${IGN_GUI_MAJOR_VERSION} -ge 1 ]]; then
 fi
 
 export GPU_SUPPORT_NEEDED=true
-if [[ ${IGN_GUI_MAJOR_VERSION} -eq 5 ]]; then
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=5
-  export IGN_RENDERING_BRANCH=main
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=7
-  export IGN_MSGS_BRANCH=main
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=10
-  export IGN_TRANSPORT_BRANCH=main
-fi
 export GZDEV_PROJECT_NAME="ignition-gui${IGN_GUI_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_launch-compilation.bash
+++ b/jenkins-scripts/docker/ign_launch-compilation.bash
@@ -29,44 +29,6 @@ if ! [[ ${IGN_LAUNCH_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
 fi
 
 export NEED_C17_COMPILER=true
-
-if [[ ${IGN_LAUNCH_MAJOR_VERSION} -eq 4 ]]; then
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=5
-  export IGN_RENDERING_BRANCH=main
-
-  export BUILD_IGN_GAZEBO=true
-  export IGN_GAZEBO_MAJOR_VERSION=5
-  export IGN_GAZEBO_BRANCH=main
-
-  export BUILD_IGN_GUI=true
-  export IGN_GUI_MAJOR_VERSION=5
-  export IGN_GUI_BRANCH=main
-
-  export BUILD_IGN_SENSORS=true
-  export IGN_SENSORS_MAJOR_VERSION=5
-  export IGN_SENSORS_BRANCH=main
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=7
-  export IGN_MSGS_BRANCH=main
-
-  export BUILD_IGN_FUEL_TOOLS=true
-  export IGN_FUEL_TOOLS_MAJOR_VERSION=6
-  export IGN_FUEL_TOOLS_BRANCH=main
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=10
-  export IGN_TRANSPORT_BRANCH=main
-
-  export BUILD_SDFORMAT=true
-  export SDFORMAT_MAJOR_VERSION=11
-  export SDFORMAT_BRANCH=master
-
-  export BUILD_IGN_PHYSICS=true
-  export IGN_PHYSICS_MAJOR_VERSION=4
-  export IGN_PHYSICS_BRANCH=main
-fi
 export GZDEV_PROJECT_NAME="ignition-launch${IGN_LAUNCH_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_physics-compilation.bash
+++ b/jenkins-scripts/docker/ign_physics-compilation.bash
@@ -29,13 +29,6 @@ if ! [[ ${IGN_PHYSICS_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
 fi
 
 export NEED_C17_COMPILER=true
-
-if [[ ${IGN_PHYSICS_MAJOR_VERSION} -eq 4 ]]; then
-  export BUILD_SDFORMAT=true
-  export SDFORMAT_MAJOR_VERSION=11
-  export SDFORMAT_BRANCH=master
-fi
-
 export GZDEV_PROJECT_NAME="ignition-physics${IGN_PHYSICS_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_sensors-compilation.bash
+++ b/jenkins-scripts/docker/ign_sensors-compilation.bash
@@ -31,23 +31,6 @@ fi
 export NEED_C17_COMPILER=true
 
 export GPU_SUPPORT_NEEDED=true
-if [[ ${IGN_SENSORS_MAJOR_VERSION} -eq 5 ]]; then
-  export BUILD_IGN_RENDERING=true
-  export IGN_RENDERING_MAJOR_VERSION=5
-  export IGN_RENDERING_BRANCH=main
-
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=7
-  export IGN_MSGS_BRANCH=main
-
-  export BUILD_IGN_TRANSPORT=true
-  export IGN_TRANSPORT_MAJOR_VERSION=10
-  export IGN_TRANSPORT_BRANCH=main
-
-  export BUILD_SDFORMAT=true
-  export SDFORMAT_MAJOR_VERSION=11
-  export SDFORMAT_BRANCH=master
-fi
 export GZDEV_PROJECT_NAME="ignition-sensors${IGN_SENSORS_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/jenkins-scripts/docker/ign_transport-compilation.bash
+++ b/jenkins-scripts/docker/ign_transport-compilation.bash
@@ -32,12 +32,6 @@ if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -ge 6 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
-if [[ ${IGN_TRANSPORT_MAJOR_VERSION} -eq 10 ]]; then
-  export BUILD_IGN_MSGS=true
-  export IGN_MSGS_MAJOR_VERSION=7
-  export IGN_MSGS_BRANCH=main
-fi
-
 export GZDEV_PROJECT_NAME="ignition-transport${IGN_TRANSPORT_MAJOR_VERSION}"
 
 . "${SCRIPT_DIR}/lib/generic-building-base.bash"

--- a/jenkins-scripts/docker/sdformat-compilation.bash
+++ b/jenkins-scripts/docker/sdformat-compilation.bash
@@ -26,12 +26,6 @@ if [[ ${SDFORMAT_MAJOR_VERSION} -ge 8 ]]; then
   export NEED_C17_COMPILER=true
 fi
 
-if [[ ${SDFORMAT_MAJOR_VERSION} -ge 11 ]]; then
-  export BUILD_IGN_UTILS=true
-  export IGN_UTILS_MAJOR_VERSION=1
-  export IGN_UTILS_BRANCH=main
-fi
-
 export GZDEV_PROJECT_NAME="sdformat${SDFORMAT_MAJOR_VERSION}"
 
 # master and major branches compilations


### PR DESCRIPTION
Ubuntu CI is already installing dependencies from nightlies, so we don't need to build them from source too.

This should save lots of CI time.

If this gets in, I'll decline #379 and update #333