### PR TITLE
👩‍🌾 Fix nightlies, use latest script

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -515,14 +515,6 @@ nightly_scheduler_job.with
                 n=\${n%[0-1]}
               fi
 
-              if [[ "\${n}" == "\${n/ign/ignition}" ]]; then
-                    alias=\${n}
-                    ignitionrepo=""
-              else
-                    alias="\${n/ign/ignition}"
-                    ignitionrepo="--ignition-repo"
-              fi
-
               if [[ "\${n}" != "\${n/cmake/}" ]]; then
                 src_branch="${cmake_branch}"
               elif [[ "\${n}" != "\${n/common/}" ]]; then
@@ -555,8 +547,8 @@ nightly_scheduler_job.with
                 src_branch="main"
               fi
 
-              echo "releasing \${n} (as \${alias}) from branch \${src_branch} \${ignitionrepo}"
-              python3 ./scripts/release.py \${dry_run_str} "\${n}" nightly "\${PASS}" -a \${alias} --extra-osrf-repo prerelease --release-repo-branch main --nightly-src-branch \${src_branch} --upload-to-repo nightly  \${ignitionrepo} > log || echo "MARK_AS_UNSTABLE"
+              echo "releasing \${n} (from branch \${src_branch}"
+              python3 ./scripts/release.py \${dry_run_str} "\${n}" nightly "\${PASS}" --extra-osrf-repo prerelease --release-repo-branch main --nightly-src-branch \${src_branch} --upload-to-repo nightly > log || echo "MARK_AS_UNSTABLE"
               echo " - done"
           done
 


### PR DESCRIPTION
The release script was updated in https://github.com/ignition-tooling/release-tools/pull/393/, but the nightly invocation wasn't, which is making the nightly scheduler unstable:

https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/158/

For example:

```
releasing ign-cmake3 (as ignition-cmake3) from branch main --ignition-repo
usage: release.py [-h] [--dry-run] [-u] [-a PACKAGE_ALIAS]
                  [-b RELEASE_REPO_BRANCH] [-r RELEASE_VERSION]
                  [--no-sanity-checks] [--no-generate-source-file]
                  [--no-ignition-auto] [--upload-to-repo UPLOAD_TO_REPOSITORY]
                  [--extra-osrf-repo EXTRA_REPO]
                  [--nightly-src-branch NIGHTLY_BRANCH]
                  package version jenkins_token
release.py: error: unrecognized arguments: --ignition-repo
MARK_AS_UNSTABLE
 - done
```

---

https://github.com/osrf/buildfarmer/issues/156
