### PR TITLE
👩‍🌾 Suppress Homebrew Ruby warnings

### DIFF
--- a/jenkins-scripts/lib/_homebrew_base_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_base_setup.bash
@@ -17,4 +17,7 @@ fi
 git -C $(${BREW_BINARY} --repo) fsck
 export HOMEBREW_UPDATE_TO_TAG=1
 ${BREW_BINARY} update
-${BREW_BINARY} install ${BREW_BASE_DEPENDCIES}
+# manually exclude a ruby warning that jenkins thinks is from clang
+# https://github.com/osrf/homebrew-simulation/issues/1343
+${BREW_BINARY} install ${BREW_BASE_DEPENDCIES} \
+   2>&1 | grep -v 'warning: conflicting chdir during another chdir block'

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -9,6 +9,9 @@ fi
 
 export HOMEBREW_MAKE_JOBS=${MAKE_JOBS}
 
+# Suppress warnings from upstream
+export HOMEBREW_RUBY_WARNINGS="-W0"
+
 # Get project name as first argument to this script
 PROJECT=$1 # project will have the major version included (ex gazebo2)
 PROJECT_ARGS=${2}

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -9,9 +9,6 @@ fi
 
 export HOMEBREW_MAKE_JOBS=${MAKE_JOBS}
 
-# Suppress warnings from upstream
-export HOMEBREW_RUBY_WARNINGS="-W0"
-
 # Get project name as first argument to this script
 PROJECT=$1 # project will have the major version included (ex gazebo2)
 PROJECT_ARGS=${2}


### PR DESCRIPTION
Fixes https://github.com/osrf/homebrew-simulation/issues/1343

We usually disable warnings coming from upstream libraries, so I think it makes sense to suppress warnings from upstream tooling as well.

---

https://github.com/osrf/buildfarmer/issues/161