### PR TITLE
Suppress chdir brew warning during bottle builds

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -38,7 +38,10 @@ echo '# END SECTION'
 echo '# BEGIN SECTION: clean up environment'
 rm -fr ${PKG_DIR} && mkdir -p ${PKG_DIR}
 . ${SCRIPT_LIBDIR}/_homebrew_cleanup.bash
-brew install hub
+# manually exclude a ruby warning that jenkins thinks is from clang
+# https://github.com/osrf/homebrew-simulation/issues/1343
+brew install hub \
+   2>&1 | grep -v 'warning: conflicting chdir during another chdir block'
 echo '# END SECTION'
 
 # set display before building bottle


### PR DESCRIPTION
Similar to #401. Needed to fix bottle build jobs:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder&build=285)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/285/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/285/

There's not an easy way to test this before merging.