### PR TITLE
Fix ign-utils1 nightly build

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -497,6 +497,7 @@ nightly_scheduler_job.with
   sensors_branch = get_nightly_branch(collection_data, 'sensors')
   sdformat_branch = get_nightly_branch(collection_data, 'sdformat')
   transport_branch = get_nightly_branch(collection_data, 'transport')
+  utils_branch = get_nightly_branch(collection_data, 'utils')
 
   steps {
     shell("""\
@@ -511,12 +512,6 @@ nightly_scheduler_job.with
 
           # redirect to not display the password
           for n in \${NIGHTLY_PACKAGES}; do
-
-              # remove 0 or 1 trailing versions. Use echo + sed to avoid scaping
-              # problems with <<<
-              if [[ \$n != \${n/[0-9]*} ]] && [[ \$(echo \$n | sed -r 's:[a-z-]*[A-Z_]*([0-9]*):\\1:g') -lt 2 ]]; then
-                n=\${n%[0-1]}
-              fi
 
               if [[ "\${n}" != "\${n/cmake/}" ]]; then
                 src_branch="${cmake_branch}"
@@ -546,6 +541,8 @@ nightly_scheduler_job.with
                 src_branch="${sdformat_branch}"
               elif [[ "\${n}" != "\${n/transport/}" ]]; then
                 src_branch="${transport_branch}"
+              elif [[ "\${n}" != "\${n/utils/}" ]]; then
+                src_branch="${utils_branch}"
               else
                 src_branch="main"
               fi

--- a/release.py
+++ b/release.py
@@ -209,7 +209,7 @@ def sanity_package_name(repo_dir, package, package_alias):
             continue
         # Check that first word is the package alias or name
         if line.partition(' ')[0] != expected_name:
-            error("Error in changelog package name or alias: " + line.decode())
+            error("Error in changelog package name or alias: " + line)
 
     cmd = ["find", repo_dir, "-name", "control","-exec","grep","-H","Source:","{}",";"]
     out, err = check_call(cmd, IGNORE_DRY_RUN)


### PR DESCRIPTION
From dry-run test of nightly build scheduler:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-edifice-nightly-scheduler&build=169)](https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/169/) https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/169/

~~~
releasing ign-utils (from branch main
Traceback (most recent call last):
  File "./scripts/release.py", line 615, in <module>
    go(sys.argv)
  File "./scripts/release.py", line 517, in go
    sanity_checks(args, repo_dir)
  File "./scripts/release.py", line 307, in sanity_checks
    sanity_package_name(repo_dir, args.package, args.package_alias)
  File "./scripts/release.py", line 212, in sanity_package_name
    error("Error in changelog package name or alias: " + line.decode())
AttributeError: 'str' object has no attribute 'decode'
MARK_AS_UNSTABLE
 - done
~~~

I've removed the `.decode()` from a line in release.py to remove the error message:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-edifice-nightly-scheduler&build=171)](https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/171/) https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/171/

~~~
releasing ign-utils (from branch main
MARK_AS_UNSTABLE
 - done
~~~

Now after re-running the ignition_collection dsl job:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition_collection&build=328)](https://build.osrfoundation.org/job/_dsl_ignition_collection/328/) https://build.osrfoundation.org/job/_dsl_ignition_collection/328/

It correctly invokes ign-utils1-debbuilder:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-edifice-nightly-scheduler&build=172)](https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/172/) https://build.osrfoundation.org/job/ignition-edifice-nightly-scheduler/172/

~~~
releasing ign-utils1 (from branch main
 - done
~~~