### PR TITLE
Remove warning configuration from homebrew bottle builder

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
@@ -11,7 +11,7 @@ import javaposse.jobdsl.dsl.Job
 */
 class OSRFBrewCompilation extends OSRFOsXBase
 {
-  static void create(Job job, enable_testing = true)
+  static void create(Job job, enable_testing = true, enable_warnings = true)
   {
     OSRFOsXBase.create(job)
 
@@ -26,39 +26,41 @@ class OSRFBrewCompilation extends OSRFOsXBase
                     'Pull request URL (osrf/homebrew-simulation) pointing to a pull request.')
       }
 
-      publishers
-      {
-        configure { project ->
-          project / publishers / 'io.jenkins.plugins.analysis.core.steps.IssuesRecorder' {
-            analysisTools {
-              'io.jenkins.plugins.analysis.warnings.Clang' {
-                id()
-                name()
-                pattern()
-                reportEncoding()
-                skipSymbolicLinks(false)
+      if (enable_warnings) {
+        publishers
+        {
+          configure { project ->
+            project / publishers / 'io.jenkins.plugins.analysis.core.steps.IssuesRecorder' {
+              analysisTools {
+                'io.jenkins.plugins.analysis.warnings.Clang' {
+                  id()
+                  name()
+                  pattern()
+                  reportEncoding()
+                  skipSymbolicLinks(false)
+                }
               }
-            }
 
-            sourceCodeEncoding()
-            ignoreQualityGate(false)
-            ignoreFailedBuilds(true)
-            referenceJobName()
-            healthy(0)
-            unhealthy(0)
-            minimumSeverity {
-              name('LOW')
-            }
-            filters { }
-            isEnabledForFailure(false)
-            isAggregatingResults(false)
-            isBlameDisabled(false)
+              sourceCodeEncoding()
+              ignoreQualityGate(false)
+              ignoreFailedBuilds(true)
+              referenceJobName()
+              healthy(0)
+              unhealthy(0)
+              minimumSeverity {
+                name('LOW')
+              }
+              filters { }
+              isEnabledForFailure(false)
+              isAggregatingResults(false)
+              isBlameDisabled(false)
 
-            qualityGates {
-              'io.jenkins.plugins.analysis.core.util.QualityGate' {
-                threshold(1)
-                type('TOTAL')
-                status('WARNING')
+              qualityGates {
+                'io.jenkins.plugins.analysis.core.util.QualityGate' {
+                  threshold(1)
+                  type('TOTAL')
+                  status('WARNING')
+                }
               }
             }
           }

--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -10,8 +10,7 @@ bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_buil
 directory_for_bottles          = 'pkgs'
 
 def DISABLE_TESTS = false
-def NO_SUPPORTED_BRANCHES = []
-def DISABLE_GITHUB_INTEGRATION = false
+def DISABLE_WARNINGS = false
 
 /*
   release.py
@@ -121,12 +120,7 @@ release_job.with
 // -------------------------------------------------------------------
 // 2. BREW bottle creation MATRIX job from pullrequest
 def bottle_job_builder = matrixJob(bottle_builder_job_name)
-// set enable_github_pr_integration flag to false so we can customize trigger behavior
-OSRFBrewCompilationAnyGitHub.create(bottle_job_builder,
-                                    "osrf/homebrew-simulation",
-                                    DISABLE_TESTS,
-                                    NO_SUPPORTED_BRANCHES,
-                                    DISABLE_GITHUB_INTEGRATION)
+OSRFBrewCompilation.create(bottle_job_builder, DISABLE_TESTS, DISABLE_WARNINGS)
 GenericRemoteToken.create(bottle_job_builder)
 
 bottle_job_builder.with


### PR DESCRIPTION
Made a quick draft on the change that should allow disable warnings configuration in brew bottle builder, issue #407. Seems to me like we are not using any of the GitHub configurations in the GitHubAny class so I removed it and use the BrewCompilation adding the option of disabling warnings. We are also losing the github checkout but it is my impression that is not being really used by the scripts.

I just run a quick diff on the XML generated with the new and the old DSL:

```diff
--- generic-release-homebrew_triggered_bottle_builder.xml	2021-03-03 16:13:59.332425202 +0100
+++ /tmp/generic-release-homebrew_triggered_bottle_builder.xml	2021-03-03 16:05:30.930462814 +0100
@@ -19,6 +19,11 @@
                     <defaultValue></defaultValue>
                     <description>Pull request URL (osrf/homebrew-simulation) pointing to a pull request.</description>
                 </hudson.model.StringParameterDefinition>
+                <hudson.model.StringParameterDefinition>
+                    <name>sha1</name>
+                    <defaultValue>main</defaultValue>
+                    <description>commit or refname to build. To manually use a branch: origin/$branch_name</description>
+                </hudson.model.StringParameterDefinition>
             </parameterDefinitions>
         </hudson.model.ParametersDefinitionProperty>
         <hudson.plugins.throttleconcurrents.ThrottleJobProperty>
@@ -32,6 +37,9 @@
             <useJobPriority>true</useJobPriority>
             <priority>300</priority>
         </jenkins.advancedqueue.priority.strategy.PriorityJobProperty>
+        <com.coravy.hudson.plugins.github.GithubProjectProperty>
+            <projectUrl>https://github.com/osrf/homebrew-simulation/</projectUrl>
+        </com.coravy.hudson.plugins.github.GithubProjectProperty>
         <jenkins.advancedqueue.priority.strategy.PriorityJobProperty>
             <useJobPriority>true</useJobPriority>
             <priority>100</priority>
@@ -42,7 +50,6 @@
             </projectNameList>
         </hudson.plugins.copyartifact.CopyArtifactPermissionProperty>
     </properties>
-    <scm class='hudson.scm.NullSCM'></scm>
     <canRoam>false</canRoam>
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
@@ -176,8 +183,9 @@
                 </hudson.plugins.emailext.plugins.trigger.FixedTrigger>
             </configuredTriggers>
             <contentType>default</contentType>
-            <defaultSubject>$DEFAULT_SUBJECT</defaultSubject>
-            <defaultContent>$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
+            <defaultSubject>$PROJECT_NAME - Branch: $GIT_BRANCH (#$BUILD_NUMBER) - $BUILD_STATUS!</defaultSubject>
+            <defaultContent>$JOB_DESCRIPTION 
+$PROJECT_NAME - Build # $BUILD_NUMBER - $BUILD_STATUS:
 
 ${BUILD_FAILURE_ANALYZER, includeTitle=true, includeIndications=true, useHtmlFormat=false}
 
@@ -253,6 +261,37 @@
             <saveOutput>false</saveOutput>
             <disabled>false</disabled>
         </hudson.plugins.emailext.ExtendedEmailPublisher>
+        <io.jenkins.plugins.analysis.core.steps.IssuesRecorder>
+            <analysisTools>
+                <io.jenkins.plugins.analysis.warnings.Clang>
+                    <id></id>
+                    <name></name>
+                    <pattern></pattern>
+                    <reportEncoding></reportEncoding>
+                    <skipSymbolicLinks>false</skipSymbolicLinks>
+                </io.jenkins.plugins.analysis.warnings.Clang>
+            </analysisTools>
+            <sourceCodeEncoding></sourceCodeEncoding>
+            <ignoreQualityGate>false</ignoreQualityGate>
+            <ignoreFailedBuilds>true</ignoreFailedBuilds>
+            <referenceJobName></referenceJobName>
+            <healthy>0</healthy>
+            <unhealthy>0</unhealthy>
+            <minimumSeverity>
+                <name>LOW</name>
+            </minimumSeverity>
+            <filters></filters>
+            <isEnabledForFailure>false</isEnabledForFailure>
+            <isAggregatingResults>false</isAggregatingResults>
+            <isBlameDisabled>false</isBlameDisabled>
+            <qualityGates>
+                <io.jenkins.plugins.analysis.core.util.QualityGate>
+                    <threshold>1</threshold>
+                    <type>TOTAL</type>
+                    <status>WARNING</status>
+                </io.jenkins.plugins.analysis.core.util.QualityGate>
+            </qualityGates>
+        </io.jenkins.plugins.analysis.core.steps.IssuesRecorder>
         <hudson.tasks.ArtifactArchiver>
             <artifacts>pkgs/*</artifacts>
             <allowEmptyArchive>true</allowEmptyArchive>
@@ -328,5 +367,29 @@
         <artifactDaysToKeep>-1</artifactDaysToKeep>
         <artifactNumToKeep>10</artifactNumToKeep>
     </logRotator>
+    <scm class='hudson.plugins.git.GitSCM'>
+        <userRemoteConfigs>
+            <hudson.plugins.git.UserRemoteConfig>
+                <refspec>+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*</refspec>
+                <url>https://github.com/osrf/homebrew-simulation.git</url>
+            </hudson.plugins.git.UserRemoteConfig>
+        </userRemoteConfigs>
+        <branches>
+            <hudson.plugins.git.BranchSpec>
+                <name>${sha1}</name>
+            </hudson.plugins.git.BranchSpec>
+        </branches>
+        <configVersion>2</configVersion>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+        <gitTool>Default</gitTool>
+        <extensions>
+            <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+                <relativeTargetDir>homebrew-simulation</relativeTargetDir>
+            </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+        </extensions>
+        <browser class='hudson.plugins.git.browser.GithubWeb'>
+            <url>https://github.com/osrf/homebrew-simulation/</url>
+        </browser>
+    </scm>
     <authToken></authToken>
 </matrix-project>
```
It needs testing in the buildfarm.