### PR TITLE
debbuild-base: run wget without --quiet if first call fails

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -59,7 +59,9 @@ if ${NIGHTLY_MODE}; then
     REV=0
   fi
 else
-  wget -O orig_tarball $SOURCE_TARBALL_URI
+  wget --quiet -O orig_tarball $SOURCE_TARBALL_URI || \
+    echo rerunning wget without --quiet since it failed && \
+    wget       -O orig_tarball $SOURCE_TARBALL_URI
   TARBALL_EXT=${SOURCE_TARBALL_URI/*tar./}
   mv orig_tarball $PACKAGE_ALIAS\_$VERSION.orig.tar.\${TARBALL_EXT}
   rm -rf \$REAL_PACKAGE_NAME\-$VERSION

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -59,7 +59,7 @@ if ${NIGHTLY_MODE}; then
     REV=0
   fi
 else
-  wget --quiet -O orig_tarball $SOURCE_TARBALL_URI
+  wget -O orig_tarball $SOURCE_TARBALL_URI
   TARBALL_EXT=${SOURCE_TARBALL_URI/*tar./}
   mv orig_tarball $PACKAGE_ALIAS\_$VERSION.orig.tar.\${TARBALL_EXT}
   rm -rf \$REAL_PACKAGE_NAME\-$VERSION


### PR DESCRIPTION
I've noticed some debbuild jobs failing at the `wget` step, but there is little debugging info because `wget` is called with `--quiet`:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-msgs6-debbuilder&build=244)](https://build.osrfoundation.org/job/ign-msgs6-debbuilder/244/) https://build.osrfoundation.org/job/ign-msgs6-debbuilder/244/

~~~
+ wget --quiet -O orig_tarball https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs6-6.4.0.tar.bz2
Build step 'Execute shell' marked build as failure
~~~

This adds a second invocation of `wget` without `--quiet` if the first one fails:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-msgs6-debbuilder&build=252)](https://build.osrfoundation.org/job/ign-msgs6-debbuilder/252/) https://build.osrfoundation.org/job/ign-msgs6-debbuilder/252/

~~~
+ wget --quiet -O orig_tarball https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs6-6.4.0.tar.bz2
+ echo rerunning wget without --quiet since it failed
rerunning wget without --quiet since it failed
+ wget -O orig_tarball https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs6-6.4.0.tar.bz2
--2021-03-04 17:23:23--  https://osrf-distributions.s3.amazonaws.com/ign-msgs/releases/ignition-msgs6-6.4.0.tar.bz2
Resolving osrf-distributions.s3.amazonaws.com (osrf-distributions.s3.amazonaws.com)... 54.231.49.40
Connecting to osrf-distributions.s3.amazonaws.com (osrf-distributions.s3.amazonaws.com)|54.231.49.40|:443... connected.
ERROR: cannot verify osrf-distributions.s3.amazonaws.com's certificate, issued by ‘CN=DigiCert Baltimore CA-2 G2,OU=www.digicert.com,O=DigiCert Inc,C=US’:
  Unable to locally verify the issuer's authority.
To connect to osrf-distributions.s3.amazonaws.com insecurely, use `--no-check-certificate'.
Build step 'Execute shell' marked build as failure
~~~