### PR TITLE
Add dart-bullet dependency

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -589,20 +589,25 @@ fi
 
 IGN_PHYSICS_DEPENDENCIES="libbenchmark-dev \\
                           dart6-data \\
-                          libdart6-collision-bullet-dev \\
                           libdart6-collision-ode-dev \\
                           libdart6-dev \\
                           libdart6-utils-urdf-dev \\
                           libignition-cmake2-dev \\
-                          libignition-common3-dev \\
                           libignition-math6-dev \\
                           libignition-math6-eigen3-dev \\
                           libignition-plugin-dev"
+if [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 4 ]]; then
+  IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
+                            libdart6-collision-bullet-dev \\
+                            libignition-common4-dev \\
+                            libsdformat11-dev"
 if [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 3 ]]; then
   IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
+                            libignition-common3-dev \\
                             libsdformat10-dev"
 elif [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -eq 2 ]]; then
   IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
+                            libignition-common3-dev \\
                             libsdformat9-dev"
 fi
 IGN_PHYSICS_DART_FROM_PKGS="true"

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -601,7 +601,7 @@ if [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 4 ]]
                             libdart6-collision-bullet-dev \\
                             libignition-common4-dev \\
                             libsdformat11-dev"
-if [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 3 ]]; then
+elif [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 3 ]]; then
   IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
                             libignition-common3-dev \\
                             libsdformat10-dev"

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -589,6 +589,7 @@ fi
 
 IGN_PHYSICS_DEPENDENCIES="libbenchmark-dev \\
                           dart6-data \\
+                          libdart6-collision-bullet-dev \\
                           libdart6-collision-ode-dev \\
                           libdart6-dev \\
                           libdart6-utils-urdf-dev \\


### PR DESCRIPTION
`ign-physics4` deb builds aren't installing the `bullet` component, even though that's listed on `packages.apt`. We should make sure it picks it up from there eventually. For now, I hope this fixes it.

Test run: [![Build Status](https://build.osrfoundation.org/job/ign-physics4-debbuilder/256/badge/icon)](https://build.osrfoundation.org/job/ign-physics4-debbuilder/256/)

Related to https://github.com/ignition-release/ign-physics4-release/pull/7