### PR TITLE
Workaround on S3 AWS cert  for platforms not supporting it

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -59,7 +59,7 @@ if ${NIGHTLY_MODE}; then
     REV=0
   fi
 else
-  wget --quiet -O orig_tarball $SOURCE_TARBALL_URI || \
+  wget --no-check-certificate --quiet -O orig_tarball $SOURCE_TARBALL_URI || \
     echo rerunning wget without --quiet since it failed && \
     wget       -O orig_tarball $SOURCE_TARBALL_URI
   TARBALL_EXT=${SOURCE_TARBALL_URI/*tar./}

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -59,9 +59,13 @@ if ${NIGHTLY_MODE}; then
     REV=0
   fi
 else
-  wget --no-check-certificate --quiet -O orig_tarball $SOURCE_TARBALL_URI || \
+  # Some combinations does not known about AWS certificate from S3
+  if [[ ${LINUX_DISTRO} == debian ]] || [[ ${DISTRO} == 'focal' && ${ARCH} == 'armhf' ]]; then
+     no_check_cert_str = '--no-check-certificate'
+  fi
+  wget \$no_check_cert_str --quiet -O orig_tarball $SOURCE_TARBALL_URI || \
     echo rerunning wget without --quiet since it failed && \
-    wget       -O orig_tarball $SOURCE_TARBALL_URI
+    wget \$no_check_cert_str -O orig_tarball $SOURCE_TARBALL_URI
   TARBALL_EXT=${SOURCE_TARBALL_URI/*tar./}
   mv orig_tarball $PACKAGE_ALIAS\_$VERSION.orig.tar.\${TARBALL_EXT}
   rm -rf \$REAL_PACKAGE_NAME\-$VERSION

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -61,7 +61,7 @@ if ${NIGHTLY_MODE}; then
 else
   # Some combinations does not known about AWS certificate from S3
   if [[ ${LINUX_DISTRO} == debian ]] || [[ ${DISTRO} == 'focal' && ${ARCH} == 'armhf' ]]; then
-     no_check_cert_str = '--no-check-certificate'
+     no_check_cert_str='--no-check-certificate'
   fi
   wget \$no_check_cert_str --quiet -O orig_tarball $SOURCE_TARBALL_URI || \
     echo rerunning wget without --quiet since it failed && \


### PR DESCRIPTION
There are some platforms where the certificate of S3 is not valid, making wget to fail. It happened in several Debian builds and at least in Focal/armhf. The PR ignores the cert only in the given cases, I did not found a way of importing it to the system. 

Tested:
 * Failing [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-plugin-debbuilder&build=611)](https://build.osrfoundation.org/job/ign-plugin-debbuilder/611/)
 * Passing [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-plugin-debbuilder&build=614)](https://build.osrfoundation.org/job/ign-plugin-debbuilder/614/)

Found during the Edifice release #421