### PR TITLE
Remove artifacts from mk-build-deps in new versions

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -156,6 +156,8 @@ echo '# END SECTION'
 echo '# BEGIN SECTION: install build dependencies'
 apt-get update
 mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+# new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
+rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}
 echo '# END SECTION'
 
 if [ -f /usr/bin/rosdep ]; then


### PR DESCRIPTION
New versions of devscripts in Debian Sid left some files in the source code directory making the builds to fail. Just remove them before continuing.

Tested:
 * Fail [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-plugin-debbuilder&build=613)](https://build.osrfoundation.org/job/ign-plugin-debbuilder/613/)
 * Success [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-plugin-debbuilder&build=615)](https://build.osrfoundation.org/job/ign-plugin-debbuilder/615/)

Found during the Edifice release https://github.com/ignition-tooling/release-tools/issues/421