### PR TITLE
sdformat.dsl: fix some main branch CI

### DIFF
--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -76,7 +76,7 @@ abi_distro.each { distro ->
     // 1. Create the main ci jobs
     def sdformat_ci_job = job("sdformat-ci-main-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat")
+    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat", "main")
 
     sdformat_ci_job.with
     {
@@ -137,7 +137,7 @@ other_supported_distros.each { distro ->
     // ci_main job for the rest of arches / scm@daily
     def sdformat_ci_job = job("sdformat-ci-main-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat")
+    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat", "main")
 
     sdformat_ci_job.with
     {
@@ -197,7 +197,7 @@ sdformat_supported_branches.each { branch ->
   experimental_arches.each { arch ->
     def sdformat_ci_job = job("sdformat-ci-main-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat")
+    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat", "main")
 
     sdformat_ci_job.with
     {


### PR DESCRIPTION
The OSRFGitHub.create() function takes an optional branch name parameter that defaults to "master". We now need to explicitly pass "main" in these places.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-main-bionic-amd64&build=1)](https://build.osrfoundation.org/job/sdformat-ci-main-bionic-amd64/1/) https://build.osrfoundation.org/job/sdformat-ci-main-bionic-amd64/1/

~~~
Fetching upstream changes from https://github.com/osrf/sdformat.git
 > git fetch --tags --progress https://github.com/osrf/sdformat.git +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git rev-parse origin/master^{commit} # timeout=10
 > git rev-parse master^{commit} # timeout=10
ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.
~~~