### PR TITLE
Migrate fuel tools windows build to colcon

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -74,7 +74,8 @@ ignition_prerelease_pkgs    = [ 'placeholder' : [
                               ]
 // packages using colcon for windows compilation while migrating all them to
 // this solution
-ignition_colcon_win         = [ 'gazebo',
+ignition_colcon_win         = [ 'fuel-tools',
+                                'gazebo',
                                 'gui',
                                 'launch',
                                 'physics',

--- a/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_cmake-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-cmake
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_common-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-common
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-fuel-tools
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
@@ -6,5 +6,7 @@ set IGN_CLEAN_WORKSPACE=true
 
 :: tinyxml2 from msgs
 set DEPEN_PKGS="libyaml libzip tinyxml2"
+set COLCON_PACKAGE=ignition-gazebo
+set COLCON_AUTO_MAJOR_VERSION=true
 
-call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"
+call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set IGN_CLEAN_WORKSPACE=true
 
 :: tinyxml2 from msgs
 set DEPEN_PKGS="libyaml libzip tinyxml2"
-set COLCON_PACKAGE=ignition-gazebo
+set COLCON_PACKAGE=ignition-fuel_tools
 set COLCON_AUTO_MAJOR_VERSION=true
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/ign_math-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_math-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-math
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/ign_msgs-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_msgs-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-msgs
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/ign_plugin-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_plugin-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-plugin
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/ign_rndf-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_rndf-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-rndf
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
@@ -1,4 +1,4 @@
-set SCRIPT_DIR="%~dp0"
+set SCRIPT_DIR=%~dp0
 
 set VCS_DIRECTORY=ign-tools
 set PLATFORM_TO_BUILD=x86_amd64

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -28,6 +28,9 @@ set LOCAL_WS_BUILD=%WORKSPACE%\build
 @if "%ENABLE_TESTS%" == "" set ENABLE_TESTS=TRUE
 @if "%COLCON_AUTO_MAJOR_VERSION%" == "" set COLCON_AUTO_MAJOR_VERSION=false
 
+python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" 
+type "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"
+
 setlocal ENABLEDELAYEDEXPANSION
 if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
    for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -28,9 +28,6 @@ set LOCAL_WS_BUILD=%WORKSPACE%\build
 @if "%ENABLE_TESTS%" == "" set ENABLE_TESTS=TRUE
 @if "%COLCON_AUTO_MAJOR_VERSION%" == "" set COLCON_AUTO_MAJOR_VERSION=false
 
-python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" 
-type "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"
-
 setlocal ENABLEDELAYEDEXPANSION
 if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
    for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i


### PR DESCRIPTION
:farmer:  To solve the failing of ci windows on main I just moved the build to colcon (part of #412) 

Before: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-main-windows7-amd64&build=19)](https://build.osrfoundation.org/job/ignition_fuel-tools-ci-main-windows7-amd64/19/)

After: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-main-windows7-amd64&build=20)](https://build.osrfoundation.org/job/ignition_fuel-tools-ci-main-windows7-amd64/20/)

The PR includes a fix for all SCRIPT_DIR variables, Windows does not like quotes.
