### PR TITLE
Install openssl on Windows

### DIFF
--- a/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
@@ -5,6 +5,6 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: tinyxml2 from msgs
-set DEPEN_PKGS="libyaml libzip tinyxml2"
+set DEPEN_PKGS="libyaml libzip tinyxml2 openssl curl"
 
 call "%SCRIPT_DIR%/lib/generic-default-devel-windows.bat"

--- a/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gazebo-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-gazebo
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: dlfcn
-set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp ffmpeg freeimage ogre ogre2 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
+set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl openssl jsoncpp ffmpeg freeimage ogre ogre2 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gazebo
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_launch-default-devel-windows-amd64.bat
@@ -4,7 +4,7 @@ set VCS_DIRECTORY=ign-launch
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
-set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl jsoncpp ffmpeg freeimage ogre ogre2 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
+set DEPEN_PKGS="dlfcn-win32 cuda cppzmq curl openssl jsoncpp ffmpeg freeimage ogre ogre2 qt5 qwt gts glib fcl eigen3 ccd assimp libyaml libzip gflags protobuf tinyxml2 zeromq"
 set COLCON_PACKAGE=ignition-launch
 set COLCON_AUTO_MAJOR_VERSION=true
 


### PR DESCRIPTION
I'm improving the windows support on Ign fuel tools, I believe that `openssl` is not installed that's why we are getting this errors on the buildfarm:

```bash
libcurl: (1) Protocol "https" not supported or disabled in libcurl
```

Related with:

 - issue https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
 - PR https://github.com/ignitionrobotics/ign-fuel-tools/pull/178

@j-rivero 

Signed-off-by: Alejandro Hernández <ahcorde@gmail.com>