### PR TITLE
Workaround Buster dwz problem by using backports version

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -159,6 +159,11 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: install build dependencies'
 apt-get update
+# buster workaround for dwz. backports repository does not have priority over main
+# explicit the version wanted
+if [[ DISTRO == 'buster']]; then
+  apt-get install -y dwz=0.13-5~bpo10+1
+fi
 mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 # new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
 rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -161,7 +161,7 @@ echo '# BEGIN SECTION: install build dependencies'
 apt-get update
 # buster workaround for dwz. backports repository does not have priority over main
 # explicit the version wanted
-if [[ DISTRO == 'buster']]; then
+if [[ ${DISTRO} = 'buster']]; then
   apt-get install -y dwz=0.13-5~bpo10+1
 fi
 mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -161,7 +161,7 @@ echo '# BEGIN SECTION: install build dependencies'
 apt-get update
 # buster workaround for dwz. backports repository does not have priority over main
 # explicit the version wanted
-if [[ ${DISTRO} = 'buster']]; then
+if [ ${DISTRO} = 'buster' ]; then
   apt-get install -y dwz=0.13-5~bpo10+1
 fi
 mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -68,6 +68,7 @@ case ${LINUX_DISTRO} in
     export DEPENDENCY_PKGS="locales ${DEPENDENCY_PKGS}"
     ;;
   'debian')
+    SOURCE_LIST_URL="http://ftp.us.debian.org/debian"
     # debian does not ship locales by default
     export DEPENDENCY_PKGS="locales ${DEPENDENCY_PKGS}"
     ;;
@@ -140,8 +141,7 @@ fi
 if [[ ${LINUX_DISTRO} == 'debian' ]]; then
 cat >> Dockerfile << DELIM_DEBIAN_APT
   RUN sed -i -e 's:httpredir:ftp.us:g' /etc/apt/sources.list
-  RUN echo "deb-src http://ftp.us.debian.org/debian ${DISTRO} main" \\
-                                                         >> /etc/apt/sources.list
+  RUN echo "deb-src ${SOURCE_LIST_URL} ${DISTRO} main" >> /etc/apt/sources.list
 DELIM_DEBIAN_APT
 fi
 

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -168,6 +168,14 @@ RUN echo "deb ${SOURCE_LIST_URL} ${DISTRO} restricted universe" \\
 DELIM_DOCKER_I386_APT
 fi
 
+# Workaround for: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=932019
+if [[ ${DISTRO} == 'buster' ]]; then
+cat >> Dockerfile << DELIM_BUSTER_DWZ
+RUN echo "deb ${SOURCE_LIST_URL} ${DISTRO}-backports main" \\
+                                                       >> /etc/apt/sources.list
+DELIM_BUSTER_DWZ
+fi
+
 # Workaround for: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1325142
 if [[ ${ARCH} == 'i386' ]]; then
 cat >> Dockerfile << DELIM_DOCKER_PAM_BUG


### PR DESCRIPTION
Upstream bug fixed in newer versions available in backports repo.
Close: https://github.com/ignition-release/gazebo11-release/issues/7

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo11-debbuilder&build=69)](https://build.osrfoundation.org/job/gazebo11-debbuilder/69/)