### PR TITLE
Invalidate docker cache to avoid gzdev problems on Fortress

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -100,6 +100,15 @@ abi_job_names = [:]
 
 Globals.extra_emails = "caguero@osrfoundation.org"
 
+// shell command to inject in all bash steps
+GLOBAL_SHELL_CMD=''
+
+// Fortress release needed to invalidate cache to solve problem with bug in
+// gzdev docker installation. Will be disable automatically in 1st May 2021
+today = new Date().format( 'yyyyMMdd' )
+if (today.compareTo('20210501')) {
+  GLOBAL_SHELL_CMD='export INVALIDATE_DOCKER_CACHE=true'
+}
 
 String ci_distro_str = ci_distro[0]
 
@@ -292,6 +301,8 @@ ignition_software.each { ign_sw ->
                   export DISTRO=\$(echo \${image} | sed  's/ubuntu://')
                 fi
 
+                ${GLOBAL_SHELL_CMD}
+
                 export ARCH=${arch}
                 export DEST_BRANCH=\${DEST_BRANCH:-\$ghprbTargetBranch}
                 export SRC_BRANCH=\${SRC_BRANCH:-\$ghprbSourceBranch}
@@ -334,6 +345,8 @@ ignition_software.each { ign_sw ->
                 echo "Bitbucket pipeline.yml detected. Default DISTRO is ${ci_distro}"
                 export DISTRO=\$(echo \${image} | sed  's/ubuntu://')
               fi
+
+              ${GLOBAL_SHELL_CMD}
 
               export ARCH=${arch}
 
@@ -414,6 +427,8 @@ ignition_software.each { ign_sw ->
            shell("""\
                  #!/bin/bash -xe
 
+                 ${GLOBAL_SHELL_CMD}
+
                  export DISTRO=${distro}
                  export ARCH=${arch}
                  export INSTALL_JOB_PKG=${dev_package}
@@ -488,6 +503,7 @@ ignition_software.each { ign_sw ->
             shell("""\
                   #!/bin/bash -xe
 
+                  ${GLOBAL_SHELL_CMD}
                   export DISTRO=${distro}
                   export ARCH=${arch}
                   /bin/bash -xe ./scripts/jenkins-scripts/docker/ign_${ign_sw}-compilation.bash
@@ -515,6 +531,7 @@ all_debbuilders().each { debbuilder_name ->
         shell("""\
               #!/bin/bash -xe
 
+              ${GLOBAL_SHELL_CMD}
               ${extra_str}
               /bin/bash -x ./scripts/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
               """.stripIndent())


### PR DESCRIPTION
This is a workaround for a bug in the way we use gzdev inside docker so changes in its configuration are not propagated to docker images thus fails occur. The PR is a workaround, it adds the `INVALIDATE_DOCKER_CACHE` variable that will make jobs not to use docker images cached. It is doing it in all the ignition linux jobs, not very elegant but my impression that it the workload would be manageable by the buildfarm.

Tested locally:
```bash
release-tools/jenkins-scripts/dsl on  edifice_docker_invalidation [?] ❯ grep INVALIDATE * 
...
ignition_transport-ci-main-xenial-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ignition_transport-ci-pr_any-ubuntu_auto-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ignition_utils-abichecker-any_to_any-ubuntu_auto-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ignition_utils-ci-ign-utils1-bionic-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ignition_utils-ci-ign-utils1-xenial-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ignition_utils-ci-main-bionic-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ignition_utils-ci-main-xenial-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ignition_utils-ci-pr_any-ubuntu_auto-amd64.xml:export INVALIDATE_DOCKER_CACHE=true
ign-launch2-debbuilder.xml:export INVALIDATE_DOCKER_CACHE=true
...
```