### PR TITLE
ignition.dsl: cleanup logic for xenial support

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -376,26 +376,19 @@ ignition_software.each { ign_sw ->
         // no xenial support for cmake2 and things that use it
         if (("${distro}" == "xenial") && (
             (("${ign_sw}" == "cmake")      && ("${major_version}" == "2")) ||
-            (("${ign_sw}" == "common")     && ("${major_version}" == "3")) ||
-            (("${ign_sw}" == "fuel-tools") &&
-              (("${major_version}" == "3") || ("${major_version}" == "4") ||
-               ("${major_version}" == "5"))) ||
+            (("${ign_sw}" == "common")     && ("${major_version}" != "1")) ||
+            (("${ign_sw}" == "fuel-tools") && ("${major_version}" != "1")) ||
              ("${ign_sw}" == "gazebo")     ||
              ("${ign_sw}" == "gui")        ||
              ("${ign_sw}" == "launch")     ||
             (("${ign_sw}" == "math")       && ("${major_version}" == "6")) ||
-            (("${ign_sw}" == "msgs")       &&
-              (("${major_version}" == "2") || ("${major_version}" == "3") ||
-               ("${major_version}" == "4") || ("${major_version}" == "5") ||
-               ("${major_version}" == "6"))) ||
+            (("${ign_sw}" == "msgs")       && ("${major_version}" != "1")) ||
              ("${ign_sw}" == "physics")    ||
              ("${ign_sw}" == "plugin")     ||
              ("${ign_sw}" == "rendering")  ||
              ("${ign_sw}" == "sensors")    ||
-            (("${ign_sw}" == "transport")  &&
-              (("${major_version}" == "6") || ("${major_version}" == "7") ||
-               ("${major_version}" == "8") || ("${major_version}" == "9")))) ||
-             ("${ign_sw}" == "utils"))
+            (("${ign_sw}" == "transport")  && ("${major_version}" != "4")) ||
+             ("${ign_sw}" == "utils")))
           return
 
         extra_repos_str=""
@@ -466,37 +459,21 @@ ignition_software.each { ign_sw ->
           if (("${distro}" == "xenial") && (
               ("${ign_sw}" == "cmake" && "${branch}" == "ign-cmake2") ||
               ("${ign_sw}" == "cmake" && "${branch}" == "main") ||
-              ("${ign_sw}" == "common" && "${branch}" == "main") ||
-              ("${ign_sw}" == "common" && "${branch}" == "ign-common3") ||
+              ("${ign_sw}" == "common" && "${branch}" != "ign-common1") ||
               ("${ign_sw}" == "fuel-tools" && "${branch}" != "ign-fuel-tools1") ||
               ("${ign_sw}" == "gazebo") ||
               ("${ign_sw}" == "gui") ||
               ("${ign_sw}" == "launch") ||
               ("${ign_sw}" == "math" && "${branch}" == "ign-math6") ||
               ("${ign_sw}" == "math" && "${branch}" == "main") ||
-              ("${ign_sw}" == "msgs" && "${branch}" == "ign-msgs2") ||
-              ("${ign_sw}" == "msgs" && "${branch}" == "ign-msgs3") ||
-              ("${ign_sw}" == "msgs" && "${branch}" == "ign-msgs4") ||
-              ("${ign_sw}" == "msgs" && "${branch}" == "ign-msgs5") ||
-              ("${ign_sw}" == "msgs" && "${branch}" == "ign-msgs6") ||
-              ("${ign_sw}" == "msgs" && "${branch}" == "ign-msgs7") ||
-              ("${ign_sw}" == "msgs" && "${branch}" == "main") ||
+              ("${ign_sw}" == "msgs" && "${branch}" != "ign-msgs1") ||
               ("${ign_sw}" == "physics") ||
-              ("${ign_sw}" == "plugin" && "${branch}" != "ign-plugin0") ||
-              ("${ign_sw}" == "rendering" && "${branch}" != "ign-rendering0") ||
+              ("${ign_sw}" == "plugin") ||
+              ("${ign_sw}" == "rendering") ||
               ("${ign_sw}" == "sensors") ||
               ("${ign_sw}" == "tools") ||
-              ("${ign_sw}" == "transport" && "${branch}" == "ign-transport6") ||
-              ("${ign_sw}" == "transport" && "${branch}" == "ign-transport7") ||
-              ("${ign_sw}" == "transport" && "${branch}" == "ign-transport8") ||
-              ("${ign_sw}" == "transport" && "${branch}" == "ign-transport9") ||
-              ("${ign_sw}" == "transport" && "${branch}" == "ign-transport10") ||
-              ("${ign_sw}" == "transport" && "${branch}" == "main") ||
+              ("${ign_sw}" == "transport" && "${branch}" != "ign-transport4") ||
               ("${ign_sw}" == "utils")))
-            disabled()
-
-          // gz11 branches don't work on xenial
-          if (("${branch}" == "gz11") && ("${distro}" == "xenial"))
             disabled()
 
           steps {


### PR DESCRIPTION
Clean up the logic for disabling jobs that don't work on xenial. Some of the recently added jobs are not properly disabled on xenial:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_common4-install-pkg-xenial-amd64&build=6)](https://build.osrfoundation.org/job/ignition_common4-install-pkg-xenial-amd64/6/) https://build.osrfoundation.org/job/ignition_common4-install-pkg-xenial-amd64/6/

Testing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition&build=1143)](https://build.osrfoundation.org/job/_dsl_ignition/1143/) https://build.osrfoundation.org/job/_dsl_ignition/1143/

~~~
Added items:
    GeneratedJob{name='ignition_utils-install-pkg-bionic-amd64'}
...
Unreferenced items:
    GeneratedJob{name='ignition_common4-install-pkg-xenial-amd64'}
    GeneratedJob{name='ignition_fuel-tools6-install-pkg-xenial-amd64'}
    GeneratedJob{name='ignition_msgs7-install-pkg-xenial-amd64'}
    GeneratedJob{name='ignition_transport10-install-pkg-xenial-amd64'}
Disabled items:
    GeneratedJob{name='ignition_transport10-install-pkg-xenial-amd64'}
    GeneratedJob{name='ignition_common4-install-pkg-xenial-amd64'}
    GeneratedJob{name='ignition_msgs7-install-pkg-xenial-amd64'}
    GeneratedJob{name='ignition_fuel-tools6-install-pkg-xenial-amd64'}
~~~