### PR TITLE
👩‍🌾 Fix Windows job disable logic

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -685,7 +685,7 @@ ignition_software.each { ign_sw ->
     ignition_win_ci_job.with
     {
         // ign-gazebo only works on Windows from ign-gazebo5
-        if (branch == 'ign-gazebo3' || branch != 'ign-gazebo4')
+        if (branch == 'ign-gazebo3' || branch == 'ign-gazebo4')
           disabled()
 
         // ign-launch still not ported completely to Windows


### PR DESCRIPTION
Fixing a typo from #150 

Test run: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition&build=1147)](https://build.osrfoundation.org/job/_dsl_ignition/1147/)

See how the Windows jobs are enabled now: https://github.com/osrf/buildfarmer/blob/main/Ignition.md

---

https://github.com/osrf/buildfarmer/issues/181