### PR TITLE
👩‍🌾 Windows CI for ign-gazebo5

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -637,9 +637,9 @@ ignition_software.each { ign_sw ->
   }
 
   supported_branches = []
-     // ign-gazebo only support windows on main branch
+     // ign-gazebo only support Windows from ign-gazebo5
      if (ign_sw == 'gazebo')
-       supported_branches = [ 'main' ]
+       supported_branches = [ 'ign-gazebo5', 'main' ]
 
   def ignition_win_ci_any_job = job(ignition_win_ci_any_job_name)
   OSRFWinCompilationAnyGitHub.create(ignition_win_ci_any_job,


### PR DESCRIPTION
Tested with: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition&build=1150)](https://build.osrfoundation.org/job/_dsl_ignition/1150/)

Now I see the `ign-gazebo5` branch whitelisted under the trigger advanced settings here: https://build.osrfoundation.org/job/ign_gazebo-pr-win/configure

---

https://github.com/osrf/buildfarmer/issues/181