### PR TITLE
Boost is required to build ign-rendering.

### DIFF
--- a/jenkins-scripts/ign_rendering-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_rendering-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-rendering
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: ogre2 from osrf vcpkg-ports
-set DEPEN_PKGS="dlfcn-win32 cuda freeimage ogre ogre2 gts glib"
+set DEPEN_PKGS="boost dlfcn-win32 cuda freeimage ogre ogre2 gts glib"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-rendering
 set COLCON_AUTO_MAJOR_VERSION=true

--- a/jenkins-scripts/ign_rendering-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_rendering-default-devel-windows-amd64.bat
@@ -5,7 +5,7 @@ set VCS_DIRECTORY=ign-rendering
 set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 :: ogre2 from osrf vcpkg-ports
-set DEPEN_PKGS="boost dlfcn-win32 cuda freeimage ogre ogre2 gts glib"
+set DEPEN_PKGS="boost-core dlfcn-win32 cuda freeimage ogre ogre2 gts glib"
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-rendering
 set COLCON_AUTO_MAJOR_VERSION=true


### PR DESCRIPTION
This is an attempt to resolve the following error as seen on the build
machine Locutus:

```
  Could not find pkg-config information for IgnOGRE.  It was not provided by
  the find-module for the package, nor was it explicitly passed into the call
  to ign_find_package(~).  This is most likely an error in this project's use
  of ign-cmake.
Call Stack (most recent call first):
  CMakeLists.txt:66 (ign_find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
-- Could NOT find Boost (missing: Boost_INCLUDE_DIR)
```