### PR TITLE
Make tools/code_check.sh optional

### DIFF
--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -102,7 +102,7 @@ else
   echo "Requested: no test run"
 fi
 
-if $GENERIC_ENABLE_CPPCHECK; then
+if [ $GENERIC_ENABLE_CPPCHECK ] && [ -f tools/code_check.sh ]; then
   echo '# BEGIN SECTION: cppcheck'
   cd $WORKSPACE/${SOFTWARE_DIR}
   if [ ! -f tools/cpplint_to_cppcheckxml.py ]; then


### PR DESCRIPTION
I think we can start retiring that script in favor of `make codecheck` on GitHub actions.

See https://github.com/ignition-tooling/release-tools/issues/446