### PR TITLE
🏁 Gazebo 7 & 10 EOL

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -26,8 +26,7 @@ class Globals
                      'rolling'  : ['focal']]
 
    // This should be in sync with archive_library
-   static gz_version_by_rosdistro = [ 'kinetic'  : ['7'] ,
-                                      'melodic'  : ['9'] ,
+   static gz_version_by_rosdistro = [ 'melodic'  : ['9'] ,
                                       'noetic'   : ['11'] ,
                                       'dashing'  : ['9'] ,
                                       'eloquent' : ['9'] ,

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -1,14 +1,13 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
-def gazebo_supported_branches = [ 'gazebo7', 'gazebo9', 'gazebo10', 'gazebo11' ]
+def gazebo_supported_branches = [ 'gazebo9', 'gazebo11' ]
 def gazebo_supported_build_types = [ 'Release', 'Debug', 'Coverage' ]
 // nightly_gazebo_branch is not the branch used to get the code from but
 // the one used to generate the corresponding debbuild job.
-def nightly_gazebo_branch = [ 'gazebo10' ]
+def nightly_gazebo_branch = [ 'gazebo11' ]
 // testing official packages without osrf repo
-def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9',
-                                         'xenial' : 'gazebo7']
+def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9' ]
 
 // Main platform using for quick CI
 def ci_distro_default       = [ 'bionic' ]
@@ -37,7 +36,7 @@ String abi_job_name = ''
 boolean is_watched_by_buildcop(branch, distro = 'xenial', gpu = 'nvidia')
 
 {
-  if (branch == 'master' || branch == 'gazebo7' || branch == 'gazebo9' || branch == 'gazebo10' || branch == 'gazebo11')
+  if (branch == 'master' || branch == 'gazebo9' || branch == 'gazebo11')
     return true
 
   return false
@@ -552,9 +551,6 @@ all_branches.each { branch ->
 
   gazebo_brew_ci_job.with
   {
-      if (("${branch}" == "gazebo7"))
-        disabled()
-
       label osx_label
 
       triggers {
@@ -591,7 +587,7 @@ all_branches.each { branch ->
   }
 
 // 2. default / @ SCM/Daily
-all_branches = gazebo_supported_branches + 'master' - 'gazebo7'
+all_branches = gazebo_supported_branches
 all_branches.each { branch ->
   def gazebo_win_ci_job = job("gazebo-ci-${branch}-windows7-amd64")
   OSRFWinCompilation.create(gazebo_win_ci_job)

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -34,7 +34,7 @@ ignition_branches           = [ 'cmake'      : [ '2' ],
                                 'gazebo'     : [ '3', '4', '5' ],
                                 'gui'        : [ '0', '3', '4', '5' ],
                                 'launch'     : [ '2', '3', '4' ],
-                                'math'       : [ '2', '4', '6' ],
+                                'math'       : [ '4', '6' ],
                                 'msgs'       : [ '1', '5', '6', '7' ],
                                 'physics'    : [ '2', '3', '4' ],
                                 'plugin'     : [ '1' ],
@@ -369,10 +369,6 @@ ignition_software.each { ign_sw ->
   supported_arches.each { arch ->
     supported_install_pkg_branches(ign_sw).each { major_version, supported_distros ->
       supported_distros.each { distro ->
-        // no bionic for math2 or math3
-        if (("${distro}" == "bionic") && (
-            (("${ign_sw}" == "math") && ("${major_version}" == "2"))))
-          return
         // no xenial support for cmake2 and things that use it
         if (("${distro}" == "xenial") && (
             (("${ign_sw}" == "cmake")      && ("${major_version}" == "2")) ||

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -1,7 +1,7 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
-def sdformat_supported_branches = [ 'sdformat4', 'sdformat6' , 'sdformat9', 'sdformat10', 'sdformat11' ]
+def sdformat_supported_branches = [ 'sdformat6' , 'sdformat9', 'sdformat10', 'sdformat11' ]
 def sdformat_gz11_branches = [ 'sdformat9', 'sdformat10', 'sdformat11', 'main' ]
 // nightly and prereleases
 def extra_sdformat_debbuilder = [ 'sdformat12' ]
@@ -357,9 +357,6 @@ all_branches.each { branch ->
       triggers {
         scm('@daily')
       }
-
-      if (branch == 'sdformat4')
-        disabled()
 
       steps {
         batchFile("""\


### PR DESCRIPTION
Gazebo 7 & 10 have reached EOL a while back, and took `ign-math2`, `ign-transport2` and `libsdformat4` with them.

See [announcement](https://community.gazebosim.org/t/gazebo-7-10-officially-end-of-life/799) and [support table](https://github.com/ignitionrobotics/docs/blob/master/tools/versions.md)