### PR TITLE
Declare protobuf dependency on fuel-tools for Windows

### DIFF
--- a/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_fuel-tools-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set IGN_CLEAN_WORKSPACE=true
 
 :: tinyxml2 from msgs
 
-set DEPEN_PKGS="libyaml libzip tinyxml2 openssl curl"
+set DEPEN_PKGS="libyaml libzip tinyxml2 openssl protobuf curl"
 set COLCON_PACKAGE=ignition-fuel_tools
 set COLCON_AUTO_MAJOR_VERSION=true
 


### PR DESCRIPTION
Failing here: https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-windows7-amd64/649/consoleFull#-102647437aa60f765-a60a-427d-900c-dc128ab22287

This PR: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-pr_any-windows7-amd64&build=651)](https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-windows7-amd64/651/)