### PR TITLE
Ogre 2.2 debbuilder. Fixing forks debbuilders

### DIFF
--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -9,7 +9,9 @@ release_repo_debbuilds = [ 'opensplice' ]
 
 // List of repositories that host branches compatible with gbp (git build
 // package) method used by debian
-gbp_repo_debbuilds = [ 'ogre-2.1', 'lark-parser' ]
+gbp_repo_debbuilds = [ 'lark-parser',
+                       'ogre-2.1',
+                       'ogre-2.2' ]
 
 release_repo_debbuilds.each { software ->
   // --------------------------------------------------------------

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -61,7 +61,7 @@ gbp_repo_debbuilds.each { software ->
     scm {
       git {
         remote {
-          github("osrf/${software}-release", 'https')
+          github("ignition-forks/${software}-release", 'https')
           branch('${BRANCH}')
         }
 


### PR DESCRIPTION
The PR adds the ogre2.2 debbuilder, test here https://build.osrfoundation.org/job/ogre-2.2-debbuilder/.

Also moves the current debbuilder under the fork organization.