### PR TITLE
Update ROS apt setup after expired keys

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -215,18 +215,14 @@ RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main ${DISTRO} main
                                                  /etc/apt/sources.list.d/ros2-latest.list
 RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > \\
                                                  /etc/apt/sources.list.d/ros2-testing.list
-# Backup command for https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
-RUN curl http://repo.ros2.org/repos.key | apt-key add - || \\
-    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 DELIM_ROS_REPO
   else
 cat >> Dockerfile << DELIM_ROS_REPO
 # Note that ROS uses ubuntu hardcoded in the paths of repositories
 RUN echo "deb http://packages.ros.org/${ROS_REPO_NAME}/ubuntu ${DISTRO} main" > \\
                                                 /etc/apt/sources.list.d/ros.list
-# Backup command for https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654 || \\
-    curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654
 DELIM_ROS_REPO
 # Need ros stable for the cases of ros-testing
 if [[ ${ROS_REPO_NAME} != "ros" ]]; then

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -215,14 +215,18 @@ RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main ${DISTRO} main
                                                  /etc/apt/sources.list.d/ros2-latest.list
 RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > \\
                                                  /etc/apt/sources.list.d/ros2-testing.list
-RUN curl http://repo.ros2.org/repos.key | apt-key add -
+# Backup command for https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
+RUN curl http://repo.ros2.org/repos.key | apt-key add - || \\
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 DELIM_ROS_REPO
   else
 cat >> Dockerfile << DELIM_ROS_REPO
 # Note that ROS uses ubuntu hardcoded in the paths of repositories
 RUN echo "deb http://packages.ros.org/${ROS_REPO_NAME}/ubuntu ${DISTRO} main" > \\
                                                 /etc/apt/sources.list.d/ros.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+# Backup command for https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654 || \\
+    curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 DELIM_ROS_REPO
 # Need ros stable for the cases of ros-testing
 if [[ ${ROS_REPO_NAME} != "ros" ]]; then

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -211,9 +211,9 @@ ENV RTI_NC_LICENSE_ACCEPTED=yes
 RUN apt-get ${APT_PARAMS} update \\
     && apt-get install -y curl \\
     && rm -rf /var/lib/apt/lists/*
-RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg http://repo.ros2.org/ubuntu/main ${DISTRO} main" > \\
+RUN echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://repo.ros2.org/ubuntu/main ${DISTRO} main" > \\
          /etc/apt/sources.list.d/ros2-latest.list
-RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > \\ 
+RUN echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > \\ 
         /etc/apt/sources.list.d/ros2-testing.list
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 DELIM_ROS_REPO

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -211,10 +211,10 @@ ENV RTI_NC_LICENSE_ACCEPTED=yes
 RUN apt-get ${APT_PARAMS} update \\
     && apt-get install -y curl \\
     && rm -rf /var/lib/apt/lists/*
-RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg \\
-          http://repo.ros2.org/ubuntu/main ${DISTRO} main" > /etc/apt/sources.list.d/ros2-latest.list
-RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg \\
-          http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > /etc/apt/sources.list.d/ros2-testing.list
+RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg http://repo.ros2.org/ubuntu/main ${DISTRO} main" > \\
+         /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > \\ 
+        /etc/apt/sources.list.d/ros2-testing.list
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 DELIM_ROS_REPO
   else

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -211,10 +211,10 @@ ENV RTI_NC_LICENSE_ACCEPTED=yes
 RUN apt-get ${APT_PARAMS} update \\
     && apt-get install -y curl \\
     && rm -rf /var/lib/apt/lists/*
-RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main ${DISTRO} main" > \\
-                                                 /etc/apt/sources.list.d/ros2-latest.list
-RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > \\
-                                                 /etc/apt/sources.list.d/ros2-testing.list
+RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg \\
+          http://repo.ros2.org/ubuntu/main ${DISTRO} main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb [arch=amd64,arm64] signed-by=/usr/share/keyrings/ros-archive-keyring.gpg \\
+          http://repo.ros2.org/ubuntu/testing ${DISTRO} main" > /etc/apt/sources.list.d/ros2-testing.list
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 DELIM_ROS_REPO
   else


### PR DESCRIPTION
The PR should work to fix the incident with the [expired ROS keys](https://docs.google.com/document/d/1ze0h6bmEwJfE0Xb2Nw9vuy20mselG08nGQLcqM1ui0U/edit). It is invalidating the current docker cache in the nodes by modifying the docker commands before the first apt-get update is in place.

Tested:

 * ROS1: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros_gazebo_pkgs-install_pkg_stable_ros_melodic-bionic-amd64&build=929)](https://build.osrfoundation.org/view/all/job/ros_gazebo_pkgs-install_pkg_stable_ros_melodic-bionic-amd64/929/)
 * ROS2: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros2_gazebo_pkgs-install_pkg_stable_ros_eloquent-bionic-amd64&build=274)](https://build.osrfoundation.org/view/all/job/ros2_gazebo_pkgs-install_pkg_stable_ros_eloquent-bionic-amd64/274/)