### PR TITLE
Migrate ABI checker default platform from Xenial to Bionic

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -68,7 +68,7 @@ class Globals
 
    static ArrayList get_abi_distro()
    {
-     return [ 'xenial' ]
+     return [ 'bionic' ]
    }
 
    static ArrayList get_ci_gpu()


### PR DESCRIPTION
Following https://github.com/ignition-tooling/release-tools/pull/462#discussion_r632179850 .

A testing run for Gazebo9 (currently broken abi checker on Xenial) after changing DISTRO value manually to bionic:
[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-abichecker-any_to_any-ubuntu_auto-amd64&build=884)](https://build.osrfoundation.org/job/gazebo-abichecker-any_to_any-ubuntu_auto-amd64/884/)
