### PR TITLE
Stop generating jobs for Dashing.

### DIFF
--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -19,7 +19,6 @@ Boolean DISABLE_CPPCHECK = false
 // version to test more than the official one in each ROS distro
 extra_gazebo_versions = [ 'kinetic'  :  ['9'],
                           'melodic'  :  ['11'],
-                          'dashing'  :  ['11'],
                           'eloquent' :  ['11']]
 
 bloom_debbuild_jobs = [ 'gazebo-dev', 'gazebo-msgs', 'gazebo-plugins', 'gazebo-ros', 'gazebo-ros-control', 'gazebo-ros-pkgs' ]


### PR DESCRIPTION
Dashing's support window has ended so we no longer need to regenerate
gazebo_ros_pkgs for it.

Dashing is still referenced in a few scripts, mostly in version and distribution maps. @j-rivero would you prefer that I clean those up or leave them there for now?

```
jenkins-scripts/lib/dependencies_archive.sh
246:      dashing)

bloom/README.md
10:   $ BLOOM_RELEASE_REPO_BASE=https://github.com/osrf/ bloom-release --no-pull-request --rosdistro dashing --track dashing gazebo11_ros2_pkgs
18:   $ ros_gazebo_pkgs-release.py.bash 3.4.4 https://github.com/osrf/gazebo11_ros2_pkgs-release dashing xxx -r 1 --dry-run

bloom/release-bloom.py
18:UBUNTU_DISTROS_IN_ROS2 = {'dashing': ['bionic'],

jenkins-scripts/dsl/_configs_/Globals.groovy
22:                     'dashing'  : ['bionic'] ,
31:                                      'dashing'  : ['9'] ,
111:     return [ 'dashing', 'eloquent', 'foxy', 'rolling' ]
```