### PR TITLE
👩‍🌾 Add ROS Galactic, remove Dashing, Eloquent and Kinetic

### DIFF
--- a/bloom/README.md
+++ b/bloom/README.md
@@ -5,15 +5,15 @@
 1. bloom in the osrf/ repository
 ```bash
    $ BLOOM_RELEASE_REPO_BASE=https://github.com/osrf/ bloom-release --no-pull-request --rosdistro <ros_distro> --track <ros_distro> gazeboX_ros[2]_pkgs
-   
+
    Example
-   $ BLOOM_RELEASE_REPO_BASE=https://github.com/osrf/ bloom-release --no-pull-request --rosdistro dashing --track dashing gazebo11_ros2_pkgs
+   $ BLOOM_RELEASE_REPO_BASE=https://github.com/osrf/ bloom-release --no-pull-request --rosdistro foxy --track foxy gazebo11_ros2_pkgs
 ```
 
 1. Trigger Jenkins jobs with ros_gazebo_pkgs-release.py.bash
 ```bash
    $ ros_gazebo_pkgs-release. <version <release_repo> <ros_distro> <token> 'other arguments used in release.py'*
-   
+
    Example:
-   $ ros_gazebo_pkgs-release.py.bash 3.4.4 https://github.com/osrf/gazebo11_ros2_pkgs-release dashing xxx -r 1 --dry-run
+   $ ros_gazebo_pkgs-release.py.bash 3.4.4 https://github.com/osrf/gazebo11_ros2_pkgs-release foxy xxx -r 1 --dry-run
 ```

--- a/bloom/release-bloom.py
+++ b/bloom/release-bloom.py
@@ -18,6 +18,7 @@ UBUNTU_DISTROS_IN_ROS = {'kinetic': ['xenial'],
 UBUNTU_DISTROS_IN_ROS2 = {'dashing': ['bionic'],
                           'eloquent': ['bionic'],
                           'foxy': ['focal'],
+                          'galactic': ['focal'],
                           'rolling': ['focal']}
 DRY_RUN = False
 

--- a/bloom/release-bloom.py
+++ b/bloom/release-bloom.py
@@ -12,12 +12,9 @@ JOB_NAME_PATTERN = '%s-bloom-debbuilder'
 
 UBUNTU_ARCHS = ['amd64']
 # not releasing for precise by default
-UBUNTU_DISTROS_IN_ROS = {'kinetic': ['xenial'],
-                         'melodic': ['bionic'],
+UBUNTU_DISTROS_IN_ROS = {'melodic': ['bionic'],
                          'noetic': ['focal']}
-UBUNTU_DISTROS_IN_ROS2 = {'dashing': ['bionic'],
-                          'eloquent': ['bionic'],
-                          'foxy': ['focal'],
+UBUNTU_DISTROS_IN_ROS2 = {'foxy': ['focal'],
                           'galactic': ['focal'],
                           'rolling': ['focal']}
 DRY_RUN = False

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -84,7 +84,7 @@ if [ -z ${DISTRO} ]; then
 fi
 
 if [ -z ${ROS_DISTRO} ]; then
-  ROS_DISTRO=kinetic
+  ROS_DISTRO=melodic
 fi
 
 if [ -z "${ROS2}" ]; then

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -16,11 +16,8 @@ class Globals
    static gpu_by_distro  = [ xenial  : [ 'nvidia' ] ,
                              bionic  : [ 'nvidia' ]]
 
-   static ros_ci = [ 'kinetic'  : ['xenial'] ,
-                     'melodic'  : ['bionic'] ,
+   static ros_ci = [ 'melodic'  : ['bionic'] ,
                      'noetic'   : ['focal'] ,
-                     'dashing'  : ['bionic'] ,
-                     'eloquent' : ['bionic'] ,
                      'foxy'     : ['focal'] ,
                      'galactic' : ['focal'] ,
                      'rolling'  : ['focal']]
@@ -28,8 +25,6 @@ class Globals
    // This should be in sync with archive_library
    static gz_version_by_rosdistro = [ 'melodic'  : ['9'] ,
                                       'noetic'   : ['11'] ,
-                                      'dashing'  : ['9'] ,
-                                      'eloquent' : ['9'] ,
                                       'foxy'     : ['11'] ,
                                       'galactic' : ['11'] ,
                                       'rolling'  : ['11']]
@@ -103,16 +98,16 @@ class Globals
 
    static ArrayList get_ros_suported_distros()
    {
-     return [ 'kinetic', 'melodic', 'noetic' ]
+     return [ 'melodic', 'noetic' ]
    }
 
    static ArrayList get_ros2_suported_distros()
    {
-     return [ 'dashing', 'eloquent', 'foxy', 'galactic', 'rolling' ]
+     return [ 'foxy', 'galactic', 'rolling' ]
    }
 
    static String get_ros2_development_distro() {
-     return 'galactic'
+     return 'rolling'
    }
 
    static String get_gz11_ubuntu_distro()

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -108,7 +108,7 @@ class Globals
 
    static ArrayList get_ros2_suported_distros()
    {
-     return [ 'dashing', 'eloquent', 'foxy', 'rolling' ]
+     return [ 'dashing', 'eloquent', 'foxy', 'galactic', 'rolling' ]
    }
 
    static String get_ros2_development_distro() {

--- a/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
+++ b/jenkins-scripts/dsl/gazebo_ros_pkgs.dsl
@@ -17,9 +17,7 @@ Boolean ENABLE_TESTS = true
 Boolean DISABLE_CPPCHECK = false
 
 // version to test more than the official one in each ROS distro
-extra_gazebo_versions = [ 'kinetic'  :  ['9'],
-                          'melodic'  :  ['11'],
-                          'eloquent' :  ['11']]
+extra_gazebo_versions = [ 'melodic'  :  ['11']]
 
 bloom_debbuild_jobs = [ 'gazebo-dev', 'gazebo-msgs', 'gazebo-plugins', 'gazebo-ros', 'gazebo-ros-control', 'gazebo-ros-pkgs' ]
 

--- a/jenkins-scripts/dsl/ros1_ign_bridge.dsl
+++ b/jenkins-scripts/dsl/ros1_ign_bridge.dsl
@@ -40,7 +40,7 @@ bridge_packages.each { pkg ->
         stringParam("LINUX_DISTRO", 'ubuntu', "Linux distribution to build packages for")
         stringParam("DISTRO", "xenial", "Linux release inside LINUX_DISTRO to build packages for")
         stringParam("ARCH", "amd64", "Architecture to build packages for")
-        stringParam('ROS_DISTRO', 'kinetic','ROS DISTRO to build pakcages for')
+        stringParam('ROS_DISTRO', 'noetic','ROS DISTRO to build pakcages for')
         stringParam("UPLOAD_TO_REPO", 'stable', "OSRF repo name to upload the package to")
         stringParam('UPSTREAM_RELEASE_REPO', 'https://github.com/ignition-release/ros1_ign_bridge-release', 'Release repository url')
     }

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -233,9 +233,6 @@ else
   # default versions for every ROS distribution
   if [[ -z ${GAZEBO_VERSION_FOR_ROS} ]]; then
     case ${ROS_DISTRO} in
-      kinetic)
-        GAZEBO_VERSION_FOR_ROS="7"
-      ;;
       melodic)
         GAZEBO_VERSION_FOR_ROS="9"
       ;;
@@ -243,12 +240,6 @@ else
         GAZEBO_VERSION_FOR_ROS="11"
       ;;
       # ROS 2
-      dashing)
-        GAZEBO_VERSION_FOR_ROS="9"
-      ;;
-      eloquent)
-        GAZEBO_VERSION_FOR_ROS="9"
-      ;;
       foxy)
         GAZEBO_VERSION_FOR_ROS="11"
       ;;
@@ -344,12 +335,6 @@ else
                                   ros-${ROS_DISTRO}-transmission-interface  \\
                                   ros-${ROS_DISTRO}-urdf                    \\
                                   ros-${ROS_DISTRO}-xacro"
-
-    if [[ ${ROS_DISTRO} == 'kinetic' ]]; then
-       ROS_GAZEBO_PKGS_DEPENDENCIES="${ROS_GAZEBO_PKGS_DEPENDENCIES} \\
-                                     ros-${ROS_DISTRO}-ros-base \\
-                                     ros-${ROS_DISTRO}-pcl-ros"
-    fi
 
     ROS_GAZEBO_PKGS_EXAMPLE_DEPS="ros-${ROS_DISTRO}-xacro \\
                                  ${ROS_GAZEBO_PKGS_EXAMPLE_DEPS}"


### PR DESCRIPTION
Galactic was just missing in a couple of places.

Dashing, Eloquent and Kinetic are EOL.

Dashing removal started in #471.

Kinetic is also being removed in #462, but that PR may take a bit more massaging for Xenial, so I added just those changes here. Hopefully this makes it easier to review.

---

https://github.com/osrf/buildfarmer/issues/207