### PR TITLE
👩‍🌾 Move SDFormat to ignitionrobotics org

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -52,7 +52,7 @@ class GenericAnyJobGitHub
         configure { project ->
           project  / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' {
               adminlist 'osrf-jenkins j-rivero'
-              orgslist 'osrf'
+              orgslist 'osrf ignitionrobotics'
               allowMembersOfWhitelistedOrgsAsAdmin(true)
               useGitHubHooks(true)
               onlyTriggerPhrase(false)

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -38,7 +38,7 @@ abi_distro.each { distro ->
     abi_job_name = "sdformat-abichecker-any_to_any-ubuntu_auto-${arch}"
     def abi_job = job(abi_job_name)
     OSRFLinuxABIGitHub.create(abi_job)
-    GenericAnyJobGitHub.create(abi_job, 'osrf/sdformat', abi_branches)
+    GenericAnyJobGitHub.create(abi_job, 'ignitionrobotics/sdformat', abi_branches)
     abi_job.with
     {
       steps {
@@ -76,7 +76,7 @@ abi_distro.each { distro ->
     // 1. Create the main ci jobs
     def sdformat_ci_job = job("sdformat-ci-main-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat", "main")
+    OSRFGitHub.create(sdformat_ci_job, "ignitionrobotics/sdformat", "main")
 
     sdformat_ci_job.with
     {
@@ -97,7 +97,7 @@ abi_distro.each { distro ->
 
     // --------------------------------------------------------------
     // 2. Create the any job
-    String sdf_repo = "osrf/sdformat"
+    String sdf_repo = "ignitionrobotics/sdformat"
 
     def sdformat_ci_any_job = job(ci_build_any_job_name_linux)
     OSRFLinuxCompilationAnyGitHub.create(sdformat_ci_any_job, sdf_repo)
@@ -137,7 +137,7 @@ other_supported_distros.each { distro ->
     // ci_main job for the rest of arches / scm@daily
     def sdformat_ci_job = job("sdformat-ci-main-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat", "main")
+    OSRFGitHub.create(sdformat_ci_job, "ignitionrobotics/sdformat", "main")
 
     sdformat_ci_job.with
     {
@@ -169,7 +169,7 @@ sdformat_supported_branches.each { branch ->
       // ci_main job for the rest of arches / scm@daily
       def sdformat_ci_job = job("sdformat-ci-${branch}-${distro}-${arch}")
       OSRFLinuxCompilation.create(sdformat_ci_job)
-      OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat",
+      OSRFGitHub.create(sdformat_ci_job, "ignitionrobotics/sdformat",
                         get_sdformat_branch_name(branch))
       sdformat_ci_job.with
       {
@@ -197,7 +197,7 @@ sdformat_supported_branches.each { branch ->
   experimental_arches.each { arch ->
     def sdformat_ci_job = job("sdformat-ci-main-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
-    OSRFGitHub.create(sdformat_ci_job, "osrf/sdformat", "main")
+    OSRFGitHub.create(sdformat_ci_job, "ignitionrobotics/sdformat", "main")
 
     sdformat_ci_job.with
     {
@@ -288,7 +288,7 @@ all_debbuild_branches.each { branch ->
 String ci_build_any_job_name_brew = "sdformat-ci-pr_any-homebrew-amd64"
 def sdformat_brew_ci_any_job = job(ci_build_any_job_name_brew)
 OSRFBrewCompilationAnyGitHub.create(sdformat_brew_ci_any_job,
-                                    "osrf/sdformat")
+                                    "ignitionrobotics/sdformat")
 sdformat_brew_ci_any_job.with
 {
     steps {
@@ -305,7 +305,7 @@ all_branches = sdformat_supported_branches + 'main'
 all_branches.each { branch ->
   def sdformat_brew_ci_job = job("sdformat-ci-${branch}-homebrew-amd64")
   OSRFBrewCompilation.create(sdformat_brew_ci_job)
-  OSRFGitHub.create(sdformat_brew_ci_job, "osrf/sdformat",
+  OSRFGitHub.create(sdformat_brew_ci_job, "ignitionrobotics/sdformat",
                          get_sdformat_branch_name(branch))
 
   sdformat_brew_ci_job.with
@@ -367,7 +367,7 @@ sdformat_supported_branches.each { branch ->
   String ci_build_any_job_name_win7 = "sdformat-ci-pr_any-windows7-amd64"
   def sdformat_win_ci_any_job = job(ci_build_any_job_name_win7)
   OSRFWinCompilationAnyGitHub.create(sdformat_win_ci_any_job,
-                                "osrf/sdformat")
+                                "ignitionrobotics/sdformat")
   sdformat_win_ci_any_job.with
   {
       steps {
@@ -382,7 +382,7 @@ all_branches = sdformat_supported_branches + 'main'
 all_branches.each { branch ->
   def sdformat_win_ci_job = job("sdformat-ci-${branch}-windows7-amd64")
   OSRFWinCompilation.create(sdformat_win_ci_job)
-  OSRFGitHub.create(sdformat_win_ci_job, "osrf/sdformat",
+  OSRFGitHub.create(sdformat_win_ci_job, "ignitionrobotics/sdformat",
                     get_sdformat_branch_name(branch))
   sdformat_win_ci_job.with
   {


### PR DESCRIPTION
See https://community.gazebosim.org/t/sdformat-moved-to-the-ignition-github-organization/994

I was hoping this wouldn't be necessary and CI would just keep working :confused: 

These are just the minimal changes to get CI running for SDF, there are more bits to change in other places too.

Generated in https://build.osrfoundation.org/job/_dsl_sdformat/1025/

You can see PR builds running, for example: https://github.com/ignitionrobotics/sdformat/pull/608

---

https://github.com/osrf/buildfarmer/issues/207