### PR TITLE
👩‍🌾 Keep last 75 builds instead of 15

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericCompilation.groovy
@@ -5,7 +5,7 @@ import javaposse.jobdsl.dsl.Job
 /*
   Implements:
     - priority 300
-    - keep only 15 builds
+    - keep only 75 builds
     - mail with test results
 */
 class GenericCompilation
@@ -46,7 +46,7 @@ class GenericCompilation
         }
 
         logRotator {
-          numToKeep(15)
+          numToKeep(75)
         }
 
         if (enable_testing)

--- a/jenkins-scripts/dsl/_configs_/OSRFBrewInstall.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewInstall.groovy
@@ -5,7 +5,7 @@ import javaposse.jobdsl.dsl.Job
 /*
   Implements:
     - priority 400
-    - keep only 15 builds
+    - keep only 75 builds
 */
 class OSRFBrewInstall extends OSRFOsXBase
 {
@@ -20,7 +20,7 @@ class OSRFBrewInstall extends OSRFOsXBase
       }
 
       logRotator {
-        numToKeep(15)
+        numToKeep(75)
       }
     }
   }

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxInstall.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxInstall.groovy
@@ -5,7 +5,7 @@ import javaposse.jobdsl.dsl.Job
 /*
   Implements:
     - priority 400
-    - keep only 15 builds
+    - keep only 75 builds
 */
 class OSRFLinuxInstall extends OSRFLinuxBase
 {
@@ -20,7 +20,7 @@ class OSRFLinuxInstall extends OSRFLinuxBase
       }
 
       logRotator {
-        numToKeep(15)
+        numToKeep(75)
       }
     }
   }


### PR DESCRIPTION
There's enough traffic in some jobs that we often lose builds from the same day. Increasing 5x, we can reduce if it starts to take up too much space.