### PR TITLE
Use more precise regex to detect running gzserver

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -149,7 +149,7 @@ if ${ENABLE_ROS}; then
   export ROS_IP=127.0.0.1
 fi
 
-if [[ -n `ps aux | grep gzserver | grep -v grep` ]]; then
+if [[ -n `ps aux | grep '[ /]gzserver' | grep -v grep | grep -v 'gzserver[^ ]'` ]]; then
     echo "There is a gzserver already running on the machine. Stopping"
     exit -1
 fi


### PR DESCRIPTION
There are some false positives of running gzservers from lingering
processes like: 'tee /tmp/ign/logs/gzserver_stdout.log'
This increases the precision of the regular expressions used to
detect running gzserver processes.

There is currently such a false-positive process running on drogon, so I have marked it offline:

* https://build.osrfoundation.org/computer/linux-aws_drogon.nv.xenial/