### PR TITLE
one-line gazebo.sh: use homebrew/cask/xquartz

### DIFF
--- a/one-line-installations/gazebo.sh
+++ b/one-line-installations/gazebo.sh
@@ -291,10 +291,12 @@ do_install() {
 			  fi
 
 			  if ! pkgutil --pkg-info org.macosforge.xquartz.pkg; then
-				echo "Installing XQuartz:"
-				brew install homebrew/cask/xquartz
-				echo "XQuartz installation complete."
-				echo
+				if ! pkgutil --pkg-info org.xquartz.X11; then
+				  echo "Installing XQuartz:"
+				  brew install homebrew/cask/xquartz
+				  echo "XQuartz installation complete."
+				  echo
+				fi
 			  fi
 
 			  brew tap osrf/simulation

--- a/one-line-installations/gazebo.sh
+++ b/one-line-installations/gazebo.sh
@@ -292,7 +292,7 @@ do_install() {
 
 			  if ! pkgutil --pkg-info org.macosforge.xquartz.pkg; then
 				echo "Installing XQuartz:"
-				brew install Caskroom/cask/xquartz
+				brew install homebrew/cask/xquartz
 				echo "XQuartz installation complete."
 				echo
 			  fi


### PR DESCRIPTION
The caskroom tap is deprecated, so use `homebrew/cask/xquartz` instead. Also check for two different pkg names with `pkgutil`, as the homebrew cask uses a different name. This fix will allow us to bring t1000 back online:

* https://build.osrfoundation.org/computer/mac-t1000.catalina/