### PR TITLE
Don't untap homebrew/cask

### DIFF
--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -26,6 +26,7 @@ hash -r
 for t in $(HOMEBREW_NO_AUTO_UPDATE=1 \
           ${BREW_BINARY} tap 2>/dev/null \
           | grep '^[^/]\+/[^/]\+$' \
+          | grep -v '^homebrew/cask$' \
           | grep -v '^homebrew/core$'); do
   ${BREW_BINARY} untap $t
 done


### PR DESCRIPTION
This causes problems for machines that get xquartz from a cask (like t1000).

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui4-install_bottle-homebrew-amd64&build=268)](https://build.osrfoundation.org/job/ignition_gui4-install_bottle-homebrew-amd64/268/) https://build.osrfoundation.org/job/ignition_gui4-install_bottle-homebrew-amd64/268/

~~~
++ /usr/local/bin/brew untap homebrew/cask
Error: Refusing to untap homebrew/cask because it contains the following installed formulae or casks:
xquartz
~~~