### PR TITLE
brew: skip brew doctor checks if sdl is installed

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -153,7 +153,10 @@ echo '# END SECTION'
 
 echo "#BEGIN SECTION: brew doctor analysis"
 brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
-brew doctor
+# if sdl installed, skip brew doctor
+# remove this line when open-scene-graph stops depending on sdl
+# https://github.com/Homebrew/homebrew-core/pull/81101
+brew list | grep '^sdl$' || brew doctor
 echo '# END SECTION'
 
 # CHECK PRE_TESTS_EXECUTION_HOOK AND RUN

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -73,7 +73,10 @@ echo '# END SECTION'
 
 echo "#BEGIN SECTION: brew doctor analysis"
 brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
-brew doctor
+# if sdl installed, skip brew doctor
+# remove this line when open-scene-graph stops depending on sdl
+# https://github.com/Homebrew/homebrew-core/pull/81101
+brew list | grep '^sdl$' || brew doctor
 echo '# END SECTION'
 
 echo "# BEGIN SECTION: re-add group write permissions"


### PR DESCRIPTION
The sdl formula was recently deprecated, which is breaking
out `brew doctor` checks for any formulae that install dartsim,
since sdl is an indirect dependency of dartsim, via open-scene-graph.
For now, skip `brew doctor` checks if sdl is installed.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-pr_any-homebrew-amd64&build=5992)](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-homebrew-amd64/5992/) https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-homebrew-amd64/5992/

~~~
+ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Some installed formulae are deprecated or disabled.
You should find replacements for the following formulae:
  sdl
~~~