### PR TITLE
Added qt5-winextras to ign-gui

### DIFF
--- a/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_gui-default-devel-windows-amd64.bat
@@ -6,7 +6,7 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 :: ogre2 from vcpkg-ports
-set DEPEN_PKGS=qt5 qwt protobuf tinyxml2 freeimage ogre ogre22
+set DEPEN_PKGS=qt5 qt5-winextras qwt protobuf tinyxml2 freeimage ogre ogre22
 :: This needs to be migrated to DSL to get multi-major versions correctly
 set COLCON_PACKAGE=ignition-gui
 set COLCON_AUTO_MAJOR_VERSION=true


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

This PR https://github.com/ignitionrobotics/ign-gui/pull/250 requires the package `qt5-winextras` when we use the tool `windeployqt.exe`