### PR TITLE
Snapshot 2021.05.12 for ignition vcpkg

### DIFF
--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -15,6 +15,6 @@ set VCPKG_CMD=%VCPKG_DIR%\vcpkg.exe
 set VCPKG_CMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%/scripts/buildsystems/vcpkg.cmake
 if NOT DEFINED VCPKG_SNAPSHOT (
   :: see https://github.com/microsoft/vcpkg/releases
-  set VCPKG_SNAPSHOT=2020.11
+  set VCPKG_SNAPSHOT=2021.05.12
 )
 goto :EOF


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

This PR is related with this https://github.com/ignition-tooling/release-tools/pull/488

https://github.com/ignitionrobotics/ign-gui/pull/250 requires to install `mesa[gles2]`. These two packages are not available in the configured vcpkg tag `2020.11`. We should use a newer version `2021.05.12`.