### PR TITLE
ignition_collection.dsl: nightly debbuild in view

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -493,6 +493,12 @@ ignition_collections.each { ign_collection ->
           ignition_collection_jobs["${ign_collection_name}"].each { jobname ->
             name(jobname)
           }
+          if (ign_collection_name == ignition_nightly) {
+            // add nightly debbuild jobs too
+            ignition_collections.find { it.get('name') == ignition_nightly }.get('nightly_jobs').each { job ->
+              name(job.getValue().get('debbuild') + '-debbuilder')
+            }
+          }
       }
 
       columns {


### PR DESCRIPTION
This adds the nightly debbuild jobs to the corresponding Jenkins view:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition_collection&build=379)](https://build.osrfoundation.org/job/_dsl_ignition_collection/379/) https://build.osrfoundation.org/job/_dsl_ignition_collection/379/
* https://build.osrfoundation.org/view/ign-fortress/