### PR TITLE
Only trigger Windows CI for ign-launch main

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -588,9 +588,14 @@ ignition_software.each { ign_sw ->
   }
 
   supported_branches = []
-     // ign-gazebo only support Windows from ign-gazebo5
-     if (ign_sw == 'gazebo')
-       supported_branches = [ 'ign-gazebo5', 'main' ]
+
+  // ign-gazebo only support Windows from ign-gazebo5
+  if (ign_sw == 'gazebo')
+    supported_branches = [ 'ign-gazebo5', 'main' ]
+
+  // ign-launch only support Windows from ign-launch5
+  if (ign_sw == 'launch')
+    supported_branches = [ 'main' ]
 
   def ignition_win_ci_any_job = job(ignition_win_ci_any_job_name)
   OSRFWinCompilationAnyGitHub.create(ignition_win_ci_any_job,


### PR DESCRIPTION
Continuation from https://github.com/ignition-tooling/release-tools/pull/485.

I noticed that Windows CI is being triggered for all `ign-launch` branches. I think this is needed so it's only triggered for `main`. See https://github.com/ignition-tooling/release-tools/pull/453, which was the equivalent for `ign-gazebo`.

(also fixed some indentation)