### PR TITLE
Cancel any running previous builds from the same PR in -any- jobs

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -76,6 +76,9 @@ class GenericAnyJobGitHub
                     startedStatus 'deploying to build.osrfoundation.org'
                     addTestResults(true)
                   }
+                 'org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate' {
+                    overrideGlobal(false)
+                 }
               }
           }
         }


### PR DESCRIPTION
I [found that there is an option to cancel any previous build](https://github.com/jenkinsci/ghprb-plugin/issues/379) from PRs in the Jenkins plugin that handle github integration with pull requests. 

Tested DSL with Gazebo in: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_gazebo&build=815)](https://build.osrfoundation.org/job/_dsl_gazebo/815/). I've verified that the configuration landed in GUI as expected but did not check that the plugin is indeed working.