### PR TITLE
Use jenkins user inside docker jobs instead of root

### DIFF
--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,10 +20,10 @@ set -ex
 echo '# BEGIN SECTION: get source package from experimental'
 echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list
 echo "deb-src http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list
-apt-get update
+sudo apt-get update
 mkdir /tmp/work
 cd /tmp/work
-apt-get build-dep -y ${DEB_PACKAGE}
+sudo apt-get build-dep -y ${DEB_PACKAGE}
 apt-get source -t experimental ${DEB_PACKAGE}
 dir=\$(find . -maxdepth 1 -mindepth 1 -type d)
 cd \$dir

--- a/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
+++ b/jenkins-scripts/docker/lib/_generic_linux_compilation_build.sh.bash
@@ -48,7 +48,7 @@ for dep_uppercase in $OSRF_DEPS; do
 cat >> build.sh << DELIM_BUILD_DEPS
     echo "# BEGIN SECTION: building dependency: ${dep} (${dep_branch})"
     echo '# END SECTION'
-    rm -fr $WORKSPACE/$dep
+    sudo rm -fr $WORKSPACE/$dep
 
     if [[ ${dep/ign} == ${dep} ]]; then
       dependency_repo="osrf/${dep}"
@@ -87,7 +87,7 @@ make -j\$(cat $WORKSPACE/make_jobs)
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: installing'
-make install
+sudo make install
 stop_stopwatch COMPILATION
 echo '# END SECTION'
 

--- a/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
+++ b/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
@@ -2,12 +2,12 @@ INSTALL_NVIDIA_DOCKER1="""
 echo '# BEGIN SECTION: install docker (in docker)'
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
-apt-get update
-apt-get install -y docker-ce
+sudo apt-get update
+sudo apt-get install -y docker-ce
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install nvidia-docker1 (in docker)'
-apt-get install -y wget nvidia-340 nvidia-modprobe
+sudo apt-get install -y wget nvidia-340 nvidia-modprobe
 wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
 dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
 echo '# END SECTION'
@@ -17,8 +17,8 @@ INSTALL_NVIDIA_DOCKER2="""
 echo '# BEGIN SECTION: install docker (in docker)'
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
-apt-get update
-# apt-get install -y docker-ce
+sudo apt-get update
+# sudo apt-get install -y docker-ce
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install nvidia-docker2 (in docker)'
@@ -27,13 +27,13 @@ curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \
 distribution=\$(. /etc/os-release;echo \$ID\$VERSION_ID)
 curl -s -L https://nvidia.github.io/nvidia-docker/\$distribution/nvidia-docker.list | \
   tee /etc/apt/sources.list.d/nvidia-docker.list
-apt-get update
-apt-get install -y nvidia-docker2
+sudo apt-get update
+sudo apt-get install -y nvidia-docker2
 # systemctl daemon-reload
 # systemctl restart docker
 echo '# END SECTION'
 """
 
-DOCKER2_CMD="docker run --privileged -e DISPLAY=unix:0 -v /sys:/sys:ro -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/.X11-unix:/tmp/.X11-unix:rw --runtime=nvidia -e DOCKER_FIX= -v /dev/log:/dev/log:ro -v /run/log:/run/log:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro --device /dev/snd --tty --rm"
+DOCKER2_CMD="sudo docker run --privileged -e DISPLAY=unix:0 -v /sys:/sys:ro -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/.X11-unix:/tmp/.X11-unix:rw --runtime=nvidia -e DOCKER_FIX= -v /dev/log:/dev/log:ro -v /run/log:/run/log:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro --device /dev/snd --tty --rm"
 
 DEPENDENCY_PKGS="${DEPENDENCY_PKGS} curl software-properties-common"

--- a/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
+++ b/jenkins-scripts/docker/lib/_install_nvidia_docker.sh
@@ -1,7 +1,7 @@
 INSTALL_NVIDIA_DOCKER1="""
 echo '# BEGIN SECTION: install docker (in docker)'
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
 sudo apt-get update
 sudo apt-get install -y docker-ce
 echo '# END SECTION'
@@ -9,24 +9,24 @@ echo '# END SECTION'
 echo '# BEGIN SECTION: install nvidia-docker1 (in docker)'
 sudo apt-get install -y wget nvidia-340 nvidia-modprobe
 wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
-dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
+sudo dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
 echo '# END SECTION'
 """
 
 INSTALL_NVIDIA_DOCKER2="""
 echo '# BEGIN SECTION: install docker (in docker)'
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu \$(lsb_release -cs) stable\"
 sudo apt-get update
 # sudo apt-get install -y docker-ce
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install nvidia-docker2 (in docker)'
 curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \
-  apt-key add -
+  sudo apt-key add -
 distribution=\$(. /etc/os-release;echo \$ID\$VERSION_ID)
 curl -s -L https://nvidia.github.io/nvidia-docker/\$distribution/nvidia-docker.list | \
-  tee /etc/apt/sources.list.d/nvidia-docker.list
+  sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 sudo apt-get update
 sudo apt-get install -y nvidia-docker2
 # systemctl daemon-reload

--- a/jenkins-scripts/docker/lib/_ros_setup_buildsh.bash
+++ b/jenkins-scripts/docker/lib/_ros_setup_buildsh.bash
@@ -36,9 +36,9 @@ cat >> build.sh << DELIM_CONFIG
 set -ex
 
 if ${USE_GZ_VERSION_ROSDEP}; then
-  apt-get install -y wget
-  mkdir -p /etc/ros/rosdep/sources.list.d/
-  wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gazebo${GAZEBO_VERSION_FOR_ROS}/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list -O /etc/ros/rosdep/sources.list.d/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list
+  sudo apt-get install -y wget
+  sudo mkdir -p /etc/ros/rosdep/sources.list.d/
+  sudo wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gazebo${GAZEBO_VERSION_FOR_ROS}/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list -O /etc/ros/rosdep/sources.list.d/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list
 fi
 
 if [ `expr length "${ROS_SETUP_PREINSTALL_HOOK} "` -gt 1 ]; then
@@ -49,7 +49,7 @@ fi
 
 echo '# BEGIN SECTION: run rosdep'
 # Step 2: configure and build
-[[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]] && rosdep init
+[[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]] && sudo rosdep init
 # Hack for not failing when github is down
 update_done=false
 seconds_waiting=0
@@ -88,13 +88,13 @@ echo '# END SECTION'
 echo '# BEGIN SECTION install the system dependencies'
 ${CMD_CATKIN_LIST}
 # Update apt repos in case rosdep tries to install Debian packages
-apt-get update || (rm -rf /var/lib/apt/lists/* && apt-get update)
-rosdep install --from-paths . \
-               -r             \
-               --ignore-src   \
-               --rosdistro=${ROS_DISTRO} \
-               --default-yes \
-               --as-root apt:false
+sudo apt-get update || (rm -rf /var/lib/apt/lists/* && sudo apt-get update)
+sudo rosdep install --from-paths . \
+		    -r             \
+		    --ignore-src   \
+		    --rosdistro=${ROS_DISTRO} \
+		    --default-yes \
+		    --as-root apt:false
 # Package installation could bring some local_setup.sh files with it
 # need to source it again after installation
 SHELL=/bin/sh . /opt/ros/${ROS_DISTRO}/setup.sh

--- a/jenkins-scripts/docker/lib/_ros_setup_buildsh.bash
+++ b/jenkins-scripts/docker/lib/_ros_setup_buildsh.bash
@@ -89,12 +89,11 @@ echo '# BEGIN SECTION install the system dependencies'
 ${CMD_CATKIN_LIST}
 # Update apt repos in case rosdep tries to install Debian packages
 sudo apt-get update || (rm -rf /var/lib/apt/lists/* && sudo apt-get update)
-sudo rosdep install --from-paths . \
-		    -r             \
-		    --ignore-src   \
-		    --rosdistro=${ROS_DISTRO} \
-		    --default-yes \
-		    --as-root apt:false
+rosdep install --from-paths . \
+               -r             \
+               --ignore-src   \
+               --rosdistro=${ROS_DISTRO} \
+               --default-yes
 # Package installation could bring some local_setup.sh files with it
 # need to source it again after installation
 SHELL=/bin/sh . /opt/ros/${ROS_DISTRO}/setup.sh

--- a/jenkins-scripts/docker/lib/_ros_setup_catkin_make_isolated_buildsh.bash
+++ b/jenkins-scripts/docker/lib/_ros_setup_catkin_make_isolated_buildsh.bash
@@ -18,9 +18,9 @@ cat >> build.sh << DELIM_CONFIG
 set -ex
 
 if ${USE_GZ_VERSION_ROSDEP}; then
-  apt-get install -y wget
-  mkdir -p /etc/ros/rosdep/sources.list.d/
-  wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gazebo${GAZEBO_VERSION_FOR_ROS}/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list -O /etc/ros/rosdep/sources.list.d/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list
+  sudo apt-get install -y wget
+  sudo mkdir -p /etc/ros/rosdep/sources.list.d/
+  sudo wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gazebo${GAZEBO_VERSION_FOR_ROS}/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list -O /etc/ros/rosdep/sources.list.d/00-gazebo${GAZEBO_VERSION_FOR_ROS}.list
 fi
 
 if [ `expr length "${ROS_SETUP_PREINSTALL_HOOK} "` -gt 1 ]; then
@@ -31,7 +31,7 @@ fi
 
 echo '# BEGIN SECTION: run rosdep'
 # Step 2: configure and build
-[[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]] && rosdep init
+[[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]] && sudo rosdep init
 # Hack for not failing when github is down
 update_done=false
 seconds_waiting=0
@@ -68,8 +68,7 @@ echo '# BEGIN SECTION install the system dependencies'
 rosdep install --from-paths . \
                --ignore-src   \
                --rosdistro=${ROS_DISTRO} \
-               --default-yes \
-               --as-root apt:false
+               --default-yes
 echo '# END SECTION'
 
 echo '# BEGIN SECTION compile the catkin workspace'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -221,7 +221,7 @@ fi
 # Hack to avoid problems with dwz symbols starting in Ubuntu Disco if tmp and debugtmp are the
 # same the build fails copying files because they are the same
 if [[ $DISTRO != 'bionic' ]]; then
-  sed -i -e 's:dwz" and:dwz" and (\$tmp ne \$debugtmp) and:' /usr/bin/dh_strip
+  sudo sed -i -e 's:dwz" and:dwz" and (\$tmp ne \$debugtmp) and:' /usr/bin/dh_strip
 fi
 
 echo '# BEGIN SECTION: create deb packages'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -162,9 +162,9 @@ apt-get update
 # buster workaround for dwz. backports repository does not have priority over main
 # explicit the version wanted
 if [ ${DISTRO} = 'buster' ]; then
-  apt-get install -y dwz=0.13-5~bpo10+1
+  sudo apt-get install -y dwz=0.13-5~bpo10+1
 fi
-mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+mk-build-deps -r -i debian/control --tool 'sudo apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 # new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
 rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}
 echo '# END SECTION'
@@ -176,21 +176,21 @@ fi
 if $NEED_C11_COMPILER || $NEED_GCC48_COMPILER; then
 echo '# BEGIN SECTION: install C++11 compiler'
 if [ ${DISTRO} = 'precise' ]; then
-apt-get install -y python-software-propertie software-properties-common || true
-add-apt-repository ppa:ubuntu-toolchain-r/test
-apt-get update
+sudo apt-get install -y python-software-propertie software-properties-common || true
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
 fi
-apt-get install -y gcc-4.8 g++-4.8
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+sudo apt-get install -y gcc-4.8 g++-4.8
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 g++ --version
 echo '# END SECTION'
 fi
 
 if $NEED_C17_COMPILER; then
 echo '# BEGIN SECTION: install C++17 compiler'
-apt-get install -y gcc-8 g++-8
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+sudo apt-get install -y gcc-8 g++-8
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 g++ --version
 echo '# END SECTION'
 fi

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -164,7 +164,7 @@ sudo apt-get update
 if [ ${DISTRO} = 'buster' ]; then
   sudo apt-get install -y dwz=0.13-5~bpo10+1
 fi
-mk-build-deps -r -i debian/control --tool 'sudo apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+sudo mk-build-deps -r -i debian/control --tool 'sudo apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 # new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
 rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}
 echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -158,7 +158,7 @@ cp -a --dereference \${PACKAGE_RELEASE_DIR}/* .
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install build dependencies'
-apt-get update
+sudo apt-get update
 # buster workaround for dwz. backports repository does not have priority over main
 # explicit the version wanted
 if [ ${DISTRO} = 'buster' ]; then

--- a/jenkins-scripts/docker/lib/debbuild-bloom-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-bloom-base.bash
@@ -53,11 +53,11 @@ fi
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install build dependencies'
-mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+sudo mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run rosdep'
-rosdep init
+sudo rosdep init
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: create source package'

--- a/jenkins-scripts/docker/lib/debian-git-repo-base.bash
+++ b/jenkins-scripts/docker/lib/debian-git-repo-base.bash
@@ -59,7 +59,7 @@ fi
 
 echo '# BEGIN SECTION: install build dependencies'
 cat debian/changelog
-mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+sudo mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 echo '# END SECTION'
 
 VERSION=\$(dpkg-parsechangelog  | grep Version | awk '{print \$2}')

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -415,7 +415,9 @@ cat >> Dockerfile << DELIM_DOCKER_USER
 # Create a user with passwordless sudo
 ARG USERID
 ARG USER
-RUN adduser --uid \$USERID --gecos "Developer" --disabled-password \$USER
+ARG GID
+RUN groupadd -g "\$GID" "\$USER";
+RUN adduser --uid \$USERID --gid \$GID --gecos "Developer" --disabled-password \$USER
 RUN adduser \$USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -24,6 +24,7 @@ USERID=$(id -u)
 USER=$(whoami)
 
 sudo docker build ${_DOCKER_BUILD_EXTRA_ARGS} \
+                  --build-arg GID=$(id -g $USER) \
                   --build-arg USERID=$USERID \
                   --build-arg USER=$USER \
                   --tag ${DOCKER_TAG} .

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -6,11 +6,11 @@ export docker_cmd="docker"
 # Do not delete packages from the scripts since some of them can be
 # run twice from the same jenkins job and generate different pkgs
 # If you want to do it, better do it from the DSL jenkins configuration
-sudo mkdir -p ${PACKAGE_DIR}
+mkdir -p ${PACKAGE_DIR}
 
 # This are usually for continous integration jobs
 sudo rm -fr ${WORKSPACE}/build
-sudo mkdir -p ${WORKSPACE}/build
+mkdir -p ${WORKSPACE}/build
 
 [[ -z ${DOCKER_DO_NOT_CACHE} ]] && DOCKER_DO_NOT_CACHE=false
 [[ -z ${USE_DOCKER_IN_DOCKER} ]] && export USE_DOCKER_IN_DOCKER=false
@@ -20,7 +20,12 @@ if $DOCKER_DO_NOT_CACHE; then
   _DOCKER_BUILD_EXTRA_ARGS="--force-rm=true"
 fi
 
+USERID=$(id -u)
+USER=$(whoami)
+
 sudo docker build ${_DOCKER_BUILD_EXTRA_ARGS} \
+                  --build-arg USERID=$USERID \
+                  --build-arg USER=$USER \
                   --tag ${DOCKER_TAG} .
 
 stop_stopwatch CREATE_TESTING_ENVIROMENT

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -90,7 +90,6 @@ sudo ${docker_cmd} run $EXTRA_PARAMS_STR  \
 # Export results out of build directory, to WORKSPACE
 for d in $(find ${WORKSPACE}/build -maxdepth 1 -name '*_results' -type d); do
     sudo mv ${d} ${WORKSPACE}/
-    sudo chown -R jenkins ${WORKSPACE}/*_results
 done
 
 if [[ -z ${KEEP_WORKSPACE} ]]; then
@@ -103,7 +102,4 @@ if [[ -z ${KEEP_WORKSPACE} ]]; then
     for d in $(find ${WORKSPACE} -maxdepth 1 -name '*_results' -type d); do
        sudo mv ${d} ${WORKSPACE}/build/
     done
-
-    [[ -d ${PACKAGE_DIR} ]] && sudo chown -R jenkins ${PACKAGE_DIR}
-    sudo chown jenkins -R ${WORKSPACE}/build/
 fi

--- a/jenkins-scripts/docker/lib/gazebo-base-default.bash
+++ b/jenkins-scripts/docker/lib/gazebo-base-default.bash
@@ -110,7 +110,7 @@ if $DART_COMPILE_FROM_SOURCE; then
       -DCMAKE_INSTALL_PREFIX=/usr
   #make -j${MAKE_JOBS}
   make -j1
-  make install
+  sudo make install
   echo '# END SECTION'
 fi
 DELIM_DART
@@ -178,7 +178,7 @@ if [[ $GAZEBO_MAJOR_VERSION -ge 8 ]]; then
 fi
 
 echo '# BEGIN SECTION: Gazebo installation'
-make install
+sudo make install
 echo '# END SECTION'
 
 # Need to clean up from previous built

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -53,7 +53,6 @@ fi
 
 echo '# BEGIN SECTION: compile and install branch: ${DEST_BRANCH}'
 cp -a $WORKSPACE/${ABI_JOB_SOFTWARE_NAME} /tmp/${ABI_JOB_SOFTWARE_NAME}
-chown -R root:root /tmp/${ABI_JOB_SOFTWARE_NAME}
 cd /tmp/${ABI_JOB_SOFTWARE_NAME}
 git fetch origin 
 git checkout origin/${DEST_BRANCH}
@@ -66,7 +65,7 @@ cmake ${ABI_JOB_CMAKE_PARAMS} \\
   -DCMAKE_INSTALL_PREFIX=/usr/local/destination_branch \\
   /tmp/${ABI_JOB_SOFTWARE_NAME}
 make -j${MAKE_JOBS}
-make install
+sudo make install
 DEST_DIR=\$(find /usr/local/destination_branch/include -name ${ABI_JOB_SOFTWARE_NAME}-* -type d | sed -e 's:.*/::')
 echo '# END SECTION'
 
@@ -85,7 +84,7 @@ cmake ${ABI_JOB_CMAKE_PARAMS} \\
   -DCMAKE_INSTALL_PREFIX=/usr/local/source_branch \\
   /tmp/${ABI_JOB_SOFTWARE_NAME}
 make -j${MAKE_JOBS}
-make install
+sudo make install
 SRC_DIR=\$(find /usr/local/source_branch/include -name ${ABI_JOB_SOFTWARE_NAME}-* -type d | sed -e 's:.*/::')
 echo '# END SECTION'
 

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -94,7 +94,7 @@ cd $WORKSPACE
 rm -fr $WORKSPACE/abi-compliance-checker
 git clone git://github.com/lvc/abi-compliance-checker.git
 cd abi-compliance-checker
-perl Makefile.pl -install --prefix=/usr
+sudo perl Makefile.pl -install --prefix=/usr
 
 mkdir -p $WORKSPACE/abi_checker
 cd $WORKSPACE/abi_checker

--- a/jenkins-scripts/docker/lib/generic-install-base.bash
+++ b/jenkins-scripts/docker/lib/generic-install-base.bash
@@ -23,8 +23,8 @@ fi
 
 if [ `expr length "${INSTALL_JOB_PKG} "` -gt 1 ]; then
 echo "# BEGIN SECTION: try to install package: ${INSTALL_JOB_PKG}"
-apt-get update
-apt-get install -y ${INSTALL_JOB_PKG}
+sudo apt-get update
+sudo apt-get install -y ${INSTALL_JOB_PKG}
 echo '# END SECTION'
 fi
 

--- a/jenkins-scripts/docker/lib/ros_debian-base-linux.bash
+++ b/jenkins-scripts/docker/lib/ros_debian-base-linux.bash
@@ -26,7 +26,7 @@ if [ ${LINUX_DISTRO} = 'debian' ]; then
 
   apt-key adv --keyserver pgp.rediris.es --recv-keys 63DE76AC0B6779BF						       
 fi
-apt-get update
+sudo apt-get update
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install wstool and ros-desktop-full-depends pkg'

--- a/jenkins-scripts/docker/lib/simbody-release-base.bash
+++ b/jenkins-scripts/docker/lib/simbody-release-base.bash
@@ -47,7 +47,7 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: install build dependencies'
 # Build dependencies
-mk-build-deps -i debian/control --tool 'apt-get --yes'
+mk-build-deps -i debian/control --tool 'sudo apt-get --yes'
 rm *build-deps*.deb
 echo '# END SECTION'
 
@@ -105,8 +105,8 @@ RUN echo "HEAD /" | nc \$(cat /tmp/host_ip.txt) 8000 | grep squid-deb-proxy \
 RUN mkdir -p ${WORKSPACE}
 # automatic invalidation of the cache if day is different
 RUN echo "${TODAY_STR}"
-RUN apt-get update
-RUN apt-get install -y fakeroot debootstrap devscripts equivs dh-make ubuntu-dev-tools debhelper wget pkg-kde-tools bash-completion git
+RUN sudo apt-get update
+RUN sudo apt-get install -y fakeroot debootstrap devscripts equivs dh-make ubuntu-dev-tools debhelper wget pkg-kde-tools bash-completion git
 ADD build.sh build.sh
 RUN chmod +x build.sh
 DELIM_DOCKER

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
@@ -31,19 +31,6 @@ class OSRFLinuxBuildPkgBase
 
       publishers
       {
-        postBuildScripts {
-          steps {
-            shell("""\
-              #!/bin/bash -xe
-
-              [[ -d \${WORKSPACE}/pkgs ]] && sudo chown -R jenkins \${WORKSPACE}/pkgs
-              """.stripIndent())
-          }
-
-          onlyIfBuildSucceeds(false)
-          onlyIfBuildFails(false)
-        }
-
         archiveArtifacts('pkgs/*')
       }
     }

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
@@ -31,6 +31,19 @@ class OSRFLinuxBuildPkgBase
 
       publishers
       {
+        postBuildScripts {
+          steps {
+            shell("""\
+              #!/bin/bash -xe
+
+              [[ -d \${WORKSPACE}/pkgs ]] && sudo chown -R jenkins \${WORKSPACE}/pkgs
+              """.stripIndent())
+          }
+
+          onlyIfBuildSucceeds(false)
+          onlyIfBuildFails(false)
+        }
+
         archiveArtifacts('pkgs/*')
       }
     }

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -70,20 +70,6 @@ packages.each { repo_name, pkgs ->
 
       publishers
       {
-        postBuildScripts {
-          steps {
-            shell("""\
-              #!/bin/bash -xe
-
-              [[ -d \${WORKSPACE}/repo ]] && sudo chown -R jenkins \${WORKSPACE}/repo
-              """.stripIndent())
-          }
-
-          onlyIfBuildSucceeds(false)
-          onlyIfBuildFails(false)
-        }
-
-
          // Added the lintian parser
          configure { project ->
            project / publishers << 'hudson.plugins.logparser.LogParserPublisher' {

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -70,6 +70,20 @@ packages.each { repo_name, pkgs ->
 
       publishers
       {
+        postBuildScripts {
+          steps {
+            shell("""\
+              #!/bin/bash -xe
+
+              [[ -d \${WORKSPACE}/repo ]] && sudo chown -R jenkins \${WORKSPACE}/repo
+              """.stripIndent())
+          }
+
+          onlyIfBuildSucceeds(false)
+          onlyIfBuildFails(false)
+        }
+
+
          // Added the lintian parser
          configure { project ->
            project / publishers << 'hudson.plugins.logparser.LogParserPublisher' {

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -126,20 +126,6 @@ gbp_repo_debbuilds.each { software ->
           'string' 'repository_uploader_*'
         }
       }
-
-      postBuildScripts {
-        steps {
-          shell("""\
-                #!/bin/bash -xe
-
-                sudo chown -R jenkins \${WORKSPACE}/repo
-                sudo chown -R jenkins \${WORKSPACE}/pkgs
-                """.stripIndent())
-        }
-
-        onlyIfBuildSucceeds(false)
-        onlyIfBuildFails(false)
-      }
     }
   }
 }

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -126,6 +126,20 @@ gbp_repo_debbuilds.each { software ->
           'string' 'repository_uploader_*'
         }
       }
+
+      postBuildScripts {
+        steps {
+          shell("""\
+                #!/bin/bash -xe
+
+                sudo chown -R jenkins \${WORKSPACE}/repo
+                sudo chown -R jenkins \${WORKSPACE}/pkgs
+                """.stripIndent())
+        }
+
+        onlyIfBuildSucceeds(false)
+        onlyIfBuildFails(false)
+      }
     }
   }
 }

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -132,7 +132,6 @@ gbp_repo_debbuilds.each { software ->
           shell("""\
                 #!/bin/bash -xe
 
-                sudo chown -R jenkins \${WORKSPACE}/repo
                 sudo chown -R jenkins \${WORKSPACE}/pkgs
                 """.stripIndent())
         }

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -48,7 +48,8 @@ BASE_DEPENDENCIES="build-essential \\
                    netcat-openbsd  \\
                    gnupg2          \\
                    net-tools       \\
-                   locales"
+                   locales         \\
+                   sudo"
 
 BREW_BASE_DEPENDCIES="git cmake"
 


### PR DESCRIPTION
I have noticed some times when Jenkins fails to clear a workspace for a job. After investigating the machines over ssh, I have noticed the remaining folders contain files owned by `root`. This is caused by our use of the `root` user in the docker-based Ubuntu CI jobs. To avoid using the `root` user, this pull request creates a user in the Dockerfile that matches the current user, and switch to this user before using commands that touch the workspace folders.

I have tested with the following job:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-main-bionic-i386&build=14)](https://build.osrfoundation.org/job/sdformat-ci-main-bionic-i386/14/) https://build.osrfoundation.org/job/sdformat-ci-main-bionic-i386/14/

In order for this job to pass, I had to manually call `sudo chown -R jenkins:jenkins` on both the build machine's workspace folder and on the shared `/srv/ccache` folder. To merge this; I recommend taking all the Linux nodes of build.osrfoundation.org offline, then sanitizing the workspace and `/srv/ccache` folders of each Linux node, then bringing them back online.

**edit**
commands to run on migration:
```bash
sudo find /var/lib/jenkins/workspace -user root -exec chown jenkins {} \;
# chown symbolic links too
sudo find /var/lib/jenkins/workspace -user root -exec chown -h jenkins {} \;
sudo chown jenkins -R /srv/ccache
```