### PR TITLE
Added libpython3-dev as a dependency of ign-math

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -410,6 +410,7 @@ fi
 #
 
 IGN_MATH_DEPENDENCIES="libeigen3-dev \\
+                       libpython3-dev \\
                        ruby-dev \\
                        swig \\
                        libignition-cmake-dev \\


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

Related to https://github.com/ignitionrobotics/ign-math/pull/216. `libpython3-dev` is not installed. This PR adds the dependecy to build the Ignition math Python interfaces.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_math-ci-pr_any-ubuntu_auto-amd64&build=581)](https://build.osrfoundation.org/job/ignition_math-ci-pr_any-ubuntu_auto-amd64/581/)

