### PR TITLE
abi script: clean build folder between builds

### DIFF
--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -79,6 +79,8 @@ git remote add source_repo ${SRC_REPO}
 git fetch source_repo
 git checkout source_repo/${SRC_BRANCH}
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
+rm -rf $WORKSPACE/build
+mkdir -p $WORKSPACE/build
 cd $WORKSPACE/build
 cmake ${ABI_JOB_CMAKE_PARAMS} \\
   -DBUILD_TESTING=OFF \\


### PR DESCRIPTION
Clean the cmake build folder in between compiling the source and destination branches. In particular, swig doesn't handle file renaming or moving, so it's better to start from a fresh build folder. I think this will fix the failing ABI build in https://github.com/ignitionrobotics/ign-math/pull/216

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_math-abichecker-any_to_any-ubuntu_auto-amd64&build=413)](https://build.osrfoundation.org/job/ignition_math-abichecker-any_to_any-ubuntu_auto-amd64/413/) https://build.osrfoundation.org/job/ignition_math-abichecker-any_to_any-ubuntu_auto-amd64/413/