### PR TITLE
Set USER var from PPID if USER is not present

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -411,6 +411,10 @@ echo '# END SECTION'
 BUILDSH_CCACHE
 fi
 
+# In upstart jobs (Xenial) the USER variable is not set for the jenkins
+# session. Fallback to get the user from processes table
+USER=${USER:-$(ps -o user= -p $PPID)}
+
 cat >> Dockerfile << DELIM_DOCKER_USER
 # Create a user with passwordless sudo
 ARG USERID


### PR DESCRIPTION
Following #494 

In upstart systems (r2d2), the USER variable is not set for Jenkins sessions. The PR sniff the user from the Jenkins process when that happen and USER is empty.

Failing: https://build.osrfoundation.org/job/ignition_gui3-install-pkg-bionic-amd64/366/console
With this branch : [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-ign-gazebo5-bionic-amd64&build=36)](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo5-bionic-amd64/36/)