### PR TITLE
docker script: chown home folder

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -424,6 +424,7 @@ RUN groupadd -g "\$GID" "\$USER";
 RUN adduser --uid \$USERID --gid \$GID --gecos "Developer" --disabled-password \$USER
 RUN adduser \$USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN chown -R \$USER:\$USER /home/\$USER
 
 USER $USER
 # Must use sudo where necessary from this point on


### PR DESCRIPTION
Follow up to #494, there are some jobs that try to create folders under `$HOME`, but the Ubuntu docker builds seem to lack these permissions. The following two builds for example have many more test failures than normal:

* 549 new test failures [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo9-bionic-amd64-gpu-nvidia&build=5)](https://build.osrfoundation.org/job/gazebo-ci-gazebo9-bionic-amd64-gpu-nvidia/5/) https://build.osrfoundation.org/job/gazebo-ci-gazebo9-bionic-amd64-gpu-nvidia/5/
* 22 new test failures [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-ign-gazebo4-bionic-amd64&build=91)](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo4-bionic-amd64/91/) https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo4-bionic-amd64/91/

testing this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-ign-gazebo4-bionic-amd64&build=94)](https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo4-bionic-amd64/94/) https://build.osrfoundation.org/job/ignition_gazebo-ci-ign-gazebo4-bionic-amd64/94/
