### PR TITLE
Right frontend debian

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -12,6 +12,11 @@ fi
 
 [[ -z $USE_GPU_DOCKER ]] && export USE_GPU_DOCKER=false
 
+# Workaround while docker cache is propagated after the change of
+# ENV DEBIAN_FRONTEND to ARG DEBIAN_FRONTEND in our dockerfiles
+# This probably can be removed in Oct 2021
+export DEBIAN_FRONTEND=noninteractive
+
 # Check disk space and if low:
 #  *  Containers that exited more than 5 days ago are removed.
 #  *  Images that don't belong to any remaining container after that are removed

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -12,11 +12,6 @@ fi
 
 [[ -z $USE_GPU_DOCKER ]] && export USE_GPU_DOCKER=false
 
-# Workaround while docker cache is propagated after the change of
-# ENV DEBIAN_FRONTEND to ARG DEBIAN_FRONTEND in our dockerfiles
-# This probably can be removed in Oct 2021
-export DEBIAN_FRONTEND=noninteractive
-
 # Check disk space and if low:
 #  *  Containers that exited more than 5 days ago are removed.
 #  *  Images that don't belong to any remaining container after that are removed

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -164,7 +164,7 @@ sudo apt-get update
 if [ ${DISTRO} = 'buster' ]; then
   sudo apt-get install -y dwz=0.13-5~bpo10+1
 fi
-sudo mk-build-deps -r -i debian/control --tool 'sudo apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+sudo mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 # new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
 rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}
 echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -164,7 +164,7 @@ sudo apt-get update
 if [ ${DISTRO} = 'buster' ]; then
   sudo apt-get install -y dwz=0.13-5~bpo10+1
 fi
-sudo mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+sudo mk-build-deps -r -i debian/control --tool 'DEBIAN_FRONTEND=noninteractive apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 # new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
 rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}
 echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -164,7 +164,7 @@ sudo apt-get update
 if [ ${DISTRO} = 'buster' ]; then
   sudo apt-get install -y dwz=0.13-5~bpo10+1
 fi
-sudo mk-build-deps -r -i debian/control --tool 'DEBIAN_FRONTEND=noninteractive apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+sudo DEBIAN_FRONTEND=noninteractive mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
 # new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
 rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}
 echo '# END SECTION'

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -119,6 +119,7 @@ MAINTAINER Jose Luis Rivero <jrivero@osrfoundation.org>
 ENV LANG C
 ENV LC_ALL C
 ARG DEBIAN_FRONTEND=noninteractive
+RUN echo 'export DEBIAN_FRONTEND=noninteractive' >> /root/.bashrc
 ENV DEBFULLNAME "OSRF Jenkins"
 ENV DEBEMAIL "build@osrfoundation.org"
 DELIM_DOCKER

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -118,7 +118,7 @@ MAINTAINER Jose Luis Rivero <jrivero@osrfoundation.org>
 # setup environment
 ENV LANG C
 ENV LC_ALL C
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 ENV DEBFULLNAME "OSRF Jenkins"
 ENV DEBEMAIL "build@osrfoundation.org"
 DELIM_DOCKER


### PR DESCRIPTION
After #494 some problems appear with interactive apt-get installation. I have not detected yet what is exactly the root cause of the problems since not all builds are affected. I'm pretty sure that problems are related to the use of sudo and the change on environments context.

The PR changes:
 * `ENV DEBIAN_FRONTEND noninteractive` is not doing its job after changing to non root accounts in docker. Seems like this configuration is not recommended so I've move it to use ARG https://github.com/moby/moby/pull/4035 . This seems insufficient to fix problems.
* Inject the `DEBIAN_FRONTEND` var inside `/root/.bashrc`. This did not fix the problem.
* Inject the variable directly in the debbuild-base line of installing packages. This fixed the problem although we can find other places were the problem happens again.

Failing: <a href='https://build.osrfoundation.org/job/sdformat12-debbuilder/269/'><img src='https://build.osrfoundation.org/buildStatus/icon?job=sdformat12-debbuilder&build=269'></a>
Fixed: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat12-debbuilder&build=276)](https://build.osrfoundation.org/job/sdformat12-debbuilder/276/)