### PR TITLE
👩‍🌾 Remove reliance on bitbucket pipelines files

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -293,14 +293,7 @@ ignition_software.each { ign_sw ->
                 wget https://raw.githubusercontent.com/osrf/bash-yaml/master/yaml.sh -O yaml.sh
                 source yaml.sh
 
-                create_variables \${WORKSPACE}/${checkout_subdir}/bitbucket-pipelines.yml
-
                 export DISTRO=${distro}
-
-                if [[ -n \${image} ]]; then
-                  echo "Bitbucket pipeline.yml detected. Default DISTRO is ${distro}"
-                  export DISTRO=\$(echo \${image} | sed  's/ubuntu://')
-                fi
 
                 ${GLOBAL_SHELL_CMD}
 


### PR DESCRIPTION
Closes https://github.com/ignition-tooling/release-tools/issues/203

We used that file to determine the test platform for each version of each library. However:

* Since migrating to GitHub we haven't really been paying attention to that file
* All files are currently pointing to [Bionic](https://github.com/search?q=org%3Aignitionrobotics+image%3A+ubuntu%3Abionic&type=code) and there are none pointing to [Focal](https://github.com/search?q=org%3Aignitionrobotics+image%3A+ubuntu%3Afocal&type=code). But Bionic is the fallback anyway in case that file doesn't exist.

So removing the support for that file, as well as the files themselves, should have no impact on our CI.

I suggest we do that to avoid further confusion, we often get questions about this file.

Whenever we need to target different platforms for each branch, we should open an issue for it and tackle it in a different way.

See this PR that removes the file and CI still passes: https://github.com/ignitionrobotics/ign-fuel-tools/pull/196

---

https://github.com/osrf/buildfarmer/issues/224