### PR TITLE
Inject USER variable inside docker containers

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -427,6 +427,8 @@ RUN adduser \$USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R \$USER:\$USER /home/\$USER
 
+# permit access to USER variable inside docker
+ENV USER ${USER}
 USER $USER
 # Must use sudo where necessary from this point on
 DELIM_DOCKER_USER


### PR DESCRIPTION
Map the USER value to shell variable. Needed for different projects to setup right permissions or other tasks.