### PR TITLE
Do not build nightly packages with prerelease repository enabled

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -642,7 +642,7 @@ nightly_scheduler_job.with
               fi
 
               echo "releasing \${n} (from branch \${src_branch}"
-              python3 ./scripts/release.py \${dry_run_str} "\${n}" nightly "\${PASS}" --extra-osrf-repo prerelease --release-repo-branch main --nightly-src-branch \${src_branch} --upload-to-repo nightly > log || echo "MARK_AS_UNSTABLE"
+              python3 ./scripts/release.py \${dry_run_str} "\${n}" nightly "\${PASS}" --release-repo-branch main --nightly-src-branch \${src_branch} --upload-to-repo nightly > log || echo "MARK_AS_UNSTABLE"
               echo " - done"
           done
 


### PR DESCRIPTION
After https://github.com/ignition-tooling/release-tools/issues/319, we don't need the prerelease repositories when building the nightlies.  This is changing https://github.com/ignitionrobotics/docs/pull/139 (Edifice). 