### PR TITLE
brew formula pr: Insert sha256 line if missing

### DIFF
--- a/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
@@ -69,14 +69,22 @@ else
 fi
 
 echo
-# get stable sha256 and its line number
+# check if stable sha256 is specified
 SHA=`${BREW} ruby -e "puts \"${PACKAGE_ALIAS}\".f.stable.checksum"`
-echo Changing sha256 from
-echo ${SHA} to
-echo ${SOURCE_TARBALL_SHA}
-SHA_LINE=`awk "/${SHA}/ {print FNR}" ${FORMULA_PATH} | head -1`
-echo on line number ${SHA_LINE}
-sed -i -e "${SHA_LINE}c\  sha256 \"${SOURCE_TARBALL_SHA}\"" ${FORMULA_PATH}
+if [ -n "$SHA" ]
+then
+  echo Changing sha256 from
+  echo ${SHA} to
+  echo ${SOURCE_TARBALL_SHA}
+  # identify line number
+  SHA_LINE=`awk "/${SHA}/ {print FNR}" ${FORMULA_PATH} | head -1`
+  echo on line number ${SHA_LINE}
+  sed -i -e "${SHA_LINE}c\  sha256 \"${SOURCE_TARBALL_SHA}\"" ${FORMULA_PATH}
+else
+  # sha256 is not specified, so append a line after URI_LINE
+  echo Appending sha256 ${SOURCE_TARBALL_SHA} after line number ${URI_LINE}
+  sed -i -e "${URI_LINE}a\  sha256 \"${SOURCE_TARBALL_SHA}\"" ${FORMULA_PATH}
+fi
 
 echo
 # revision line if it's nonzero

--- a/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
@@ -81,9 +81,16 @@ then
   echo on line number ${SHA_LINE}
   sed -i -e "${SHA_LINE}c\  sha256 \"${SOURCE_TARBALL_SHA}\"" ${FORMULA_PATH}
 else
-  # sha256 is not specified, so append a line after URI_LINE
-  echo Appending sha256 ${SOURCE_TARBALL_SHA} after line number ${URI_LINE}
-  sed -i -e "${URI_LINE}a\  sha256 \"${SOURCE_TARBALL_SHA}\"" ${FORMULA_PATH}
+  # sha256 is not already specified in this formula
+  echo Appending sha256 ${SOURCE_TARBALL_SHA}
+  if [ -n "${VERSION_LINE}" ]; then
+    echo after line number ${VERSION_LINE}
+    sed -i -e "${VERSION_LINE}a\  sha256 \"${SOURCE_TARBALL_SHA}\"" ${FORMULA_PATH}
+  else
+    # if version is not explicitly specified, append after url
+    echo after line number ${URI_LINE}
+    sed -i -e "${URI_LINE}a\  sha256 \"${SOURCE_TARBALL_SHA}\"" ${FORMULA_PATH}
+  fi
 fi
 
 echo


### PR DESCRIPTION
The homebrew formulae with bumped major versions in fortress use `url` fields that point to the `git` repository rather than a tarball, so they don't have a `sha256` field (see https://github.com/osrf/homebrew-simulation/pull/1481 and https://github.com/osrf/homebrew-simulation/issues/1314). This caused our pull request updater job to fail (the one that is triggered by `release.py`):

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_pull_request_updater&build=957)](https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/957/) https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/957/

I've updated the logic to append a `sha256` field if the formula does not already contain such a field. If the `version` is explicitly specified, the field is appended after `version`; otherwise it is appended after `url`. This fixes the pull request generation:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_pull_request_updater&build=960)](https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/960/) https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/960/
* https://github.com/osrf/homebrew-simulation/pull/1577