### PR TITLE
brew_release.dsl: build bigsur bottles instead of mojave

### DIFF
--- a/jenkins-scripts/dsl/brew_release.dsl
+++ b/jenkins-scripts/dsl/brew_release.dsl
@@ -4,7 +4,7 @@ import javaposse.jobdsl.dsl.Job
 Globals.default_emails = "jrivero@osrfoundation.org, scpeters@osrfoundation.org"
 
 // first distro in list is used as touchstone
-brew_supported_distros         = [ "catalina", "mojave" ]
+brew_supported_distros         = [ "catalina", "bigsur" ]
 bottle_hash_updater_job_name   = 'generic-release-homebrew_pr_bottle_hash_updater'
 bottle_builder_job_name        = 'generic-release-homebrew_triggered_bottle_builder'
 directory_for_bottles          = 'pkgs'


### PR DESCRIPTION
Mojave will be unsupported by homebrew soon, so stop building these bottles, and build for bigsur instead. We already have one bigsur machine. After this, we can start upgrading Mojave machines to 10.16. Part of https://github.com/ignition-tooling/release-tools/issues/382.