### PR TITLE
Allow ARM jobs to run on native arm hosts.

### DIFF
--- a/release.py
+++ b/release.py
@@ -616,7 +616,7 @@ def go(argv):
                         continue
                     # Need to use JENKINS_NODE_TAG parameter for large memory nodes
                     # since it runs qemu emulation
-                    linux_platform_params['JENKINS_NODE_TAG'] = 'large-memory'
+                    linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a + '|| large-memory'
 
                 if (NIGHTLY and a == 'i386'):
                     continue


### PR DESCRIPTION
Update the label expression for ARM releases to allow them to run on
hosts with the `linux-arm64` or `linux-armhf` labels respectively in
addition to hosts with the `large-memory` label.

Example ARM host: https://build.osrfoundation.org/computer/linux-ip-172-30-1-225.focal-00fdeb8a/