### PR TITLE
Increase max concurrent debbuild jobs to 8.

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -233,6 +233,7 @@ void include_gpu_label_if_needed(Job job, String ign_software_name)
 {
   job.with
   {
+
     ignition_gpu.each { ign_each ->
       if (ign_software_name == ign_each)
       {
@@ -445,6 +446,14 @@ all_debbuilders().each { debbuilder_name ->
   OSRFLinuxBuildPkg.create(build_pkg_job)
   build_pkg_job.with
   {
+
+      concurrentBuild(true)
+
+      throttleConcurrentBuilds {
+        maxPerNode(1)
+        maxTotal(8)
+      }
+
       steps {
         shell("""\
               #!/bin/bash -xe


### PR DESCRIPTION
Recent changes to the OSRF build farm have enabled scaling Linux agents.
With these we can increase the number of workers during release windows in order to build packages more efficiently. In order to take advantage of that we need to increase the concurrent build count. 8 concurrent jobs is both a doubling of the current count (inherited from OSRFUnixBase) and the max count of 4 amd64 and 4 arm64 workers in the scaling groups.