### PR TITLE
sdformat.dsl: use default label for brew CI

### DIFF
--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -292,10 +292,6 @@ all_branches.each { branch ->
         scm('@daily')
       }
 
-      // special check to modify ci_distro if the branch is part of gz11
-      if (branch in sdformat_gz11_branches)
-        label "osx_" + Globals.get_gz11_mac_distro()
-
       steps {
         shell("""\
               #!/bin/bash -xe


### PR DESCRIPTION
Use default `osx` label for sdformat brew CI jobs. Currently they are using `osx_mojave`, but there are no more machines in the build farm with that label, since they have had OS upgrades:

* https://build.osrfoundation.org/job/sdformat-ci-sdformat11-homebrew-amd64/