### PR TITLE
Keep more package build artifacts.

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
@@ -5,7 +5,7 @@ import javaposse.jobdsl.dsl.Job
 /*
   Implements:
     - cleanup pkgs directory
-    - keep only 10 builds
+    - keep only 200 build logs and 25 build artifacts
     - publish artifacts
 */
 class OSRFLinuxBuildPkgBase
@@ -17,7 +17,7 @@ class OSRFLinuxBuildPkgBase
      job.with
      {
        logRotator {
-         artifactNumToKeep(10)
+         artifactNumToKeep(25)
          numToKeep(200)
        }
 


### PR DESCRIPTION
Package builders were recently updated (#521) to take advantage of an
increased number of jenkins agents and this has surfaced a bug which has
been dormant due to the lack of concurrent jobs.

Ignition Fortress releases currently have 13 platform combinations of
different OS versions and CPU architectures. Which means that with the
previous archiveToKeep value of 10, if the eleventh debbuilder job runs
before the first is copied to the packaging server then the artifacts
will be cleaned up before they can be imported.

The new value of 25 is more than double the current number of target
platforms but is sadly still a constant and not based on the number of
target platforms. I still think it is a more sensible default than 10
given the current situation.

With this change we will have to monitor the impact on the storage
capacity of the Jenkins server where these artifacts are stored.