### PR TITLE
ign-physics CI/debbuilds use large-memory label

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -287,7 +287,12 @@ ignition_software.each { ign_sw ->
       abi_job.with
       {
         if (ign_sw == 'physics')
+        {
           label "huge-memory"
+          // on ARM native nodes in buildfarm we need to restrict to 2 the
+          // compilation threads to avoid OOM killer
+          GLOBAL_SHELL_CMD = GLOBAL_SHELL_CMD + '\nif [[ $(uname -m) == "aarch64" ]]; then export MAKE_JOBS=2; fi'
+        }
 
         steps {
           shell("""\
@@ -325,7 +330,7 @@ ignition_software.each { ign_sw ->
     ignition_ci_any_job.with
     {
       if (ign_sw == 'physics')
-        label "large-memory"
+        label "huge-memory"
 
       steps
       {
@@ -418,7 +423,7 @@ ignition_software.each { ign_sw ->
         ignition_ci_job.with
         {
           if (ign_sw == 'physics')
-            label "large-memory"
+            label "huge-memory"
 
           triggers {
             scm('@daily')

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -324,6 +324,9 @@ ignition_software.each { ign_sw ->
     include_gpu_label_if_needed(ignition_ci_any_job, ign_sw)
     ignition_ci_any_job.with
     {
+      if (ign_sw == 'physics')
+        label "large-memory"
+
       steps
       {
          shell("""\
@@ -414,6 +417,9 @@ ignition_software.each { ign_sw ->
         include_gpu_label_if_needed(ignition_ci_job, ign_sw)
         ignition_ci_job.with
         {
+          if (ign_sw == 'physics')
+            label "large-memory"
+
           triggers {
             scm('@daily')
           }

--- a/release.py
+++ b/release.py
@@ -617,6 +617,8 @@ def go(argv):
                     # Need to use JENKINS_NODE_TAG parameter for large memory nodes
                     # since it runs qemu emulation
                     linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a + '|| large-memory'
+                elif ('ignition-physics' in args.package_alias):
+                    linux_platform_params['JENKINS_NODE_TAG'] = 'large-memory'
 
                 if (NIGHTLY and a == 'i386'):
                     continue


### PR DESCRIPTION
CI failed in https://github.com/ignitionrobotics/ign-physics/pull/294 on a non-`large-memory` machine, and several debbuilds failed as well. Let's require `large-memory` for all ign-physics CI and debbuild jobs.

* ubuntu/bionic amd64: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-physics5-debbuilder&build=375)](https://build.osrfoundation.org/job/ign-physics5-debbuilder/375/) https://build.osrfoundation.org/job/ign-physics5-debbuilder/375/
* ubuntu/focal amd64: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-physics5-debbuilder&build=379)](https://build.osrfoundation.org/job/ign-physics5-debbuilder/379/) https://build.osrfoundation.org/job/ign-physics5-debbuilder/379/