### PR TITLE
Improve Debian tool for ABI transitions

### DIFF
--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,7 +20,7 @@ if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'
 else
   TARGET_DISTRO='experimental'
-  sed -i -e $'s#.*extra_repositories.*#\$extra_repositories = [ \\\'deb http://ftp.us.debian.org/debian experimental main\\\' ];#' /etc/sbuild/sbuild.conf
+  sudo sed -i -e $'s#.*extra_repositories.*#\$extra_repositories = [ \\'deb http://ftp.us.debian.org/debian experimental main\\' ];#' /etc/sbuild/sbuild.conf
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -60,7 +60,7 @@ rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
 export GOPATH=~/gocode
-go get -u github.com/j-rivero/ratt
+go get -u github.com/j-rivero/ratt@[master]
 
 # use new group to run sbuild
 newgrp sbuild << END

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -60,7 +60,8 @@ rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
 export GOPATH=~/gocode
-go get -u -v github.com/j-rivero/ratt@[0.0.1]
+rm -fr ${GOPATH}
+go get -u -v github.com/j-rivero/ratt
 
 # use new group to run sbuild
 newgrp sbuild << END

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -61,9 +61,13 @@ sed -i -e "s:experimental:unstable:g" ${DEB_PACKAGE}_*.changes
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
-export GOPATH=~/gocode
-rm -fr ${GOPATH}
-go get -u -v github.com/j-rivero/ratt
+cd /tmp
+git clone github.com/j-rivero/ratt
+cd ratt
+go mod init local/build
+go mod tidy
+go build
+ls
 
 str_params=''
 if [[ -n '$RATT_INCLUDE' ]]; then
@@ -77,7 +81,7 @@ fi
 # use new group to run sbuild
 newgrp sbuild << END
 echo running ratt under sbuild group
-~/gocode/bin/ratt \${str_params} ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
+./build \${str_params} ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
 END
 cp -a buildlogs ${WORKSPACE}/logs
 echo '# END SECTION'
@@ -85,7 +89,7 @@ DELIM
 
 export LINUX_DISTRO=debian
 export DISTRO=sid
-export DEPENDENCY_PKGS="sbuild quilt devscripts dose-extra"
+export DEPENDENCY_PKGS="sbuild quilt devscripts dose-extra git"
 export USE_DOCKER_IN_DOCKER=true
 
 . "${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash"

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,10 +20,7 @@ if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'
 else
   TARGET_DISTRO='experimental'
-  sudo tee ~/.sbuildrc << EOF
-\$verbose = 1\;
-\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]\;
-EOF
+  echo "\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];" > ~/.sbuildrc
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,7 +20,7 @@ if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'
 else
   TARGET_DISTRO='experimental'
-  echo "\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];" > ~/.sbuildrc
+  echo "\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]\\\;" > ~/.sbuildrc
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,7 +20,6 @@ if ${USE_UNSTABLE}; then
   TARGET_DISTRO='unstable'
 else
  TARGET_DISTRO='experimental'
- EXTRA_SBUILD_CMD="--extra-repository='deb http://ftp.us.debian.org/debian experimental main'"
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'
@@ -38,7 +37,12 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: create chroot'
 sudo sbuild-adduser \${USER}
-sudo sbuild-createchroot unstable \${EXTRA_SBUILD_CMD} /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
+if ${USE_UNSTABLE}; then
+  sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
+else
+  sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian --extra-repository='deb http://ftp.us.debian.org/debian experimental main'
+"
+
 
 echo '# END SECTION'
 

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,6 +20,7 @@ if ${USE_UNSTABLE}; then
   TARGET_DISTRO='unstable'
 else
  TARGET_DISTRO='experimental'
+ EXTRA_SBUILD_CMD="--extra-repository='deb http://ftp.us.debian.org/debian experimental main'"
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'
@@ -37,7 +38,8 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: create chroot'
 sudo sbuild-adduser \${USER}
-sudo sbuild-createchroot \${TARGET_DISTRO} /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
+sudo sbuild-createchroot unstable \${EXTRA_SBUILD_CMD} /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
+
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -61,13 +61,13 @@ sed -i -e "s:experimental:unstable:g" ${DEB_PACKAGE}_*.changes
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
-cd /tmp
+pushd /tmp 2> /dev/null
 git clone https://github.com/j-rivero/ratt
 cd ratt
 go mod init local/build
 go mod tidy
 go build
-ls
+popd 2> /dev/null
 
 str_params=''
 if [[ -n '$RATT_INCLUDE' ]]; then
@@ -81,7 +81,7 @@ fi
 # use new group to run sbuild
 newgrp sbuild << END
 echo running ratt under sbuild group
-./build \${str_params} ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
+/tmp/ratt/build \${str_params} ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
 END
 cp -a buildlogs ${WORKSPACE}/logs
 echo '# END SECTION'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -26,7 +26,7 @@ else
 EOF
 fi
 
-sudo grep -R GzipIndexes /etc/
+grep -R GzipIndexes /etc/
 
 # DEBUG: what's bad in dose-ceve for ratt
 # dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -21,7 +21,7 @@ if ${USE_UNSTABLE}; then
 else
   TARGET_DISTRO='experimental'
   tee ~/.sbuildrc << EOF
-\\\$verbose = 1\;
+\\\$verbose = 1;
 \\\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];
 EOF
 fi

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -27,7 +27,7 @@ EOF
 fi
 
 # DEBUG: what's bad in dose-ceve for ratt
-dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg
+# dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg
 
 echo '# BEGIN SECTION: get source package from experimental'
 sudo bash -c 'echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list.d/debian-exp.list'
@@ -57,10 +57,15 @@ echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'
 cd ..
 sed -i -e "s:experimental:unstable:g" ${DEB_PACKAGE}_*.changes
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
+
+sudo apt-get install golang-go
+export GOPATH=~/gocode
+go get -u github.com/j-rivero/ratt
+
 # use new group to run sbuild
 newgrp sbuild << END
 echo running ratt under sbuild group
-ratt ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
+~/gocode/bin/ratt ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
 END
 cp -a buildlogs ${WORKSPACE}/logs
 echo '# END SECTION'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -26,6 +26,8 @@ else
 EOF
 fi
 
+sudo grep -R GzipIndexes /etc/
+
 # DEBUG: what's bad in dose-ceve for ratt
 # dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg
 

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -17,9 +17,10 @@ cat > build.sh << DELIM
 set -ex
 
 if ${USE_UNSTABLE}; then
-  TARGET_DISTRO='unstable'
+   TARGET_DISTRO='unstable'
 else
- TARGET_DISTRO='experimental'
+  TARGET_DISTRO='experimental'
+  sed -i -e $'s#.*extra_repositories.*#\$extra_repositories = [ \\\'deb http://ftp.us.debian.org/debian experimental main\\\' ];#' /etc/sbuild/sbuild.conf
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'
@@ -37,11 +38,8 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: create chroot'
 sudo sbuild-adduser \${USER}
-if ${USE_UNSTABLE}; then
-  sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
-else
-  sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian --extra-repository='deb http://ftp.us.debian.org/debian experimental main'
-fi
+# experimental should be handled in sbuild.conf file
+sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -74,7 +74,7 @@ DELIM
 
 export LINUX_DISTRO=debian
 export DISTRO=sid
-export DEPENDENCY_PKGS="ratt sbuild quilt devscripts"
+export DEPENDENCY_PKGS="sbuild quilt devscripts dose-extra"
 export USE_DOCKER_IN_DOCKER=true
 
 . "${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash"

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -58,7 +58,7 @@ cd ..
 sed -i -e "s:experimental:unstable:g" ${DEB_PACKAGE}_*.changes
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
-sudo apt-get install golang-go
+sudo apt-get install -y golang-go
 export GOPATH=~/gocode
 go get -u github.com/j-rivero/ratt
 

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -16,6 +16,11 @@ cat > build.sh << DELIM
 #
 set -ex
 
+if ${USE_UNSTABLE}; then
+  TARGET_DISTRO='unstable'
+else
+ TARGET_DISTRO='experimental'
+fi
 
 echo '# BEGIN SECTION: get source package from experimental'
 sudo bash -c 'echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list.d/debian-exp.list'
@@ -30,15 +35,14 @@ cd \$dir
 debuild --no-sign
 echo '# END SECTION'
 
-echo '# BEGIN SECTION: create experimental chroot'
+echo '# BEGIN SECTION: create chroot'
 sudo sbuild-adduser \${USER}
-sudo sbuild-createchroot unstable /srv/chroot/exp-amd64-sbuild http://deb.debian.org/debian
+sudo sbuild-createchroot \${TARGET_DISTRO} /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'
 cd ..
-# need to configure unstable in the change file, not all packages are in experimental
-sed -i -e 's:experimental:unstable:g' ${DEB_PACKAGE}_*.changes
+sed -i -e "s:experimental:\${TARGET_DISTRO}:g" ${DEB_PACKAGE}_*.changes
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 # use new group to run sbuild
 newgrp sbuild << END

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -60,7 +60,7 @@ rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
 export GOPATH=~/gocode
-go get -u -v github.com/j-rivero/ratt
+go get -u -v github.com/j-rivero/ratt@[0.0.1]
 
 # use new group to run sbuild
 newgrp sbuild << END

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,7 +20,10 @@ if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'
 else
   TARGET_DISTRO='experimental'
-  echo "\\\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];" > ~/.sbuildrc
+  tee ~/.sbuildrc << EOF
+\\\$verbose = 1\;
+\\\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]\;
+EOF
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'
@@ -39,7 +42,12 @@ echo '# END SECTION'
 echo '# BEGIN SECTION: create chroot'
 sudo sbuild-adduser \${USER}
 # experimental should be handled in sbuild.conf file
-sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
+if $USE_UNSTABLE; then
+  sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
+else
+  sudo sbuild-createchroot --extra-repository='deb http://ftp.us.debian.org/debian experimental main' unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
+fi
+
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -26,6 +26,9 @@ else
 EOF
 fi
 
+# DEBUG: what's bad in dose-ceve for ratt
+dose-ceve --verbose --deb-native-arch=amd64 -T debsrc -r libconsole-bridge0.4 -G pkg
+
 echo '# BEGIN SECTION: get source package from experimental'
 sudo bash -c 'echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list.d/debian-exp.list'
 sudo bash -c 'echo "deb-src http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list.d/debian-exp.list'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -26,7 +26,10 @@ else
 EOF
 fi
 
+sudo rm /var/lib/apt/lists/*.lz4
 sudo sed -i -e 's:GzipIndexes "true":GzipIndexes "false":g' /etc/apt/apt.conf.d/*
+sudo apt-get update
+sudo ls -las /var/lib/apt/lists/*
 
 # DEBUG: what's bad in dose-ceve for ratt
 # dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -60,7 +60,7 @@ rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
 export GOPATH=~/gocode
-go get -u github.com/j-rivero/ratt@[master]
+go get -u -v github.com/j-rivero/ratt@[master]
 
 # use new group to run sbuild
 newgrp sbuild << END

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -31,9 +31,6 @@ sudo sed -i -e 's:GzipIndexes "true":GzipIndexes "false":g' /etc/apt/apt.conf.d/
 sudo apt-get update
 sudo ls -las /var/lib/apt/lists/*
 
-# DEBUG: what's bad in dose-ceve for ratt
-# dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg
-
 echo '# BEGIN SECTION: get source package from experimental'
 sudo bash -c 'echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list.d/debian-exp.list'
 sudo bash -c 'echo "deb-src http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list.d/debian-exp.list'
@@ -68,10 +65,19 @@ export GOPATH=~/gocode
 rm -fr ${GOPATH}
 go get -u -v github.com/j-rivero/ratt
 
+str_params=''
+if [[ -n '$RATT_INCLUDE' ]]; then
+  str_params="--include '${RATT_INCLUDE}'"
+fi
+
+if [[ -n '$RATT_EXCLUDE' ]]; then
+  str_params="\${str_params} --exclude '${RATT_EXCLUDE}'"
+fi
+
 # use new group to run sbuild
 newgrp sbuild << END
 echo running ratt under sbuild group
-~/gocode/bin/ratt ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
+~/gocode/bin/ratt \${str_params} ${DEB_PACKAGE}_*.changes* || echo MARK_AS_UNSTABLE
 END
 cp -a buildlogs ${WORKSPACE}/logs
 echo '# END SECTION'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -60,7 +60,7 @@ rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
 export GOPATH=~/gocode
-go get -u -v github.com/j-rivero/ratt@[master]
+go get -u -v github.com/j-rivero/ratt
 
 # use new group to run sbuild
 newgrp sbuild << END

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,7 +20,7 @@ if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'
 else
   TARGET_DISTRO='experimental'
-  echo "\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]\\\;" > ~/.sbuildrc
+  echo "\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];" > ~/.sbuildrc
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -27,7 +27,7 @@ EOF
 fi
 
 # DEBUG: what's bad in dose-ceve for ratt
-dose-ceve --verbose --deb-native-arch=amd64 -T debsrc -r libconsole-bridge0.4 -G pkg
+dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg
 
 echo '# BEGIN SECTION: get source package from experimental'
 sudo bash -c 'echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list.d/debian-exp.list'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,7 +20,7 @@ if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'
 else
   TARGET_DISTRO='experimental'
-  echo "\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];" > ~/.sbuildrc
+  echo "\\\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];" > ~/.sbuildrc
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -41,9 +41,7 @@ if ${USE_UNSTABLE}; then
   sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian
 else
   sudo sbuild-createchroot unstable /srv/chroot/test-amd64-sbuild http://deb.debian.org/debian --extra-repository='deb http://ftp.us.debian.org/debian experimental main'
-"
-
-
+fi
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -88,7 +88,11 @@ echo '# END SECTION'
 DELIM
 
 export LINUX_DISTRO=debian
-export DISTRO=sid
+if $USE_UNSTABLE; then
+  export DISTRO=sid
+else
+  export DISTRO=experimental
+fi
 export DEPENDENCY_PKGS="sbuild quilt devscripts dose-extra git"
 export USE_DOCKER_IN_DOCKER=true
 

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -57,7 +57,9 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'
 cd ..
-sed -i -e "s:experimental:unstable:g" ${DEB_PACKAGE}_*.changes
+if $USE_UNSTABLE; then
+  sed -i -e "s:experimental:unstable:g" ${DEB_PACKAGE}_*.changes
+fi
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -62,7 +62,7 @@ rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
 sudo apt-get install -y golang-go
 cd /tmp
-git clone github.com/j-rivero/ratt
+git clone https://github.com/j-rivero/ratt
 cd ratt
 go mod init local/build
 go mod tidy

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -22,7 +22,7 @@ else
   TARGET_DISTRO='experimental'
   tee ~/.sbuildrc << EOF
 \\\$verbose = 1\;
-\\\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]\;
+\\\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ];
 EOF
 fi
 

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -46,7 +46,7 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: run ratt for ${DEB_PACKAGE}'
 cd ..
-sed -i -e "s:experimental:\${TARGET_DISTRO}:g" ${DEB_PACKAGE}_*.changes
+sed -i -e "s:experimental:unstable:g" ${DEB_PACKAGE}_*.changes
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 # use new group to run sbuild
 newgrp sbuild << END

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -20,7 +20,10 @@ if ${USE_UNSTABLE}; then
    TARGET_DISTRO='unstable'
 else
   TARGET_DISTRO='experimental'
-  sudo sed -i -e $'s#.*extra_repositories.*#\$extra_repositories = [ \\'deb http://ftp.us.debian.org/debian experimental main\\' ];#' /etc/sbuild/sbuild.conf
+  sudo tee ~/.sbuildrc << EOF
+\$verbose = 1;
+\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]; 
+EOF
 fi
 
 echo '# BEGIN SECTION: get source package from experimental'

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -26,7 +26,8 @@ else
 EOF
 fi
 
-grep -R GzipIndexes /etc/
+sudo sed -i -e 's:GzipIndexes "true":GzipIndexes "false":g' /etc/apt/apt.conf.d/*
+sudo grep -R GzipIndexes /etc/
 
 # DEBUG: what's bad in dose-ceve for ratt
 # dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -27,7 +27,6 @@ EOF
 fi
 
 sudo sed -i -e 's:GzipIndexes "true":GzipIndexes "false":g' /etc/apt/apt.conf.d/*
-sudo grep -R GzipIndexes /etc/
 
 # DEBUG: what's bad in dose-ceve for ratt
 # dose-ceve --verbose --deb-native-arch=amd64 -t debsrc -r libconsole-bridge0.4 -G pkg

--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -21,8 +21,8 @@ if ${USE_UNSTABLE}; then
 else
   TARGET_DISTRO='experimental'
   sudo tee ~/.sbuildrc << EOF
-\$verbose = 1;
-\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]; 
+\$verbose = 1\;
+\$extra_repositories = [ 'deb http://ftp.us.debian.org/debian experimental main' ]\;
 EOF
 fi
 

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -427,6 +427,8 @@ RUN adduser \$USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R \$USER:\$USER /home/\$USER
 
+# permit access to USER variable inside docker
+ENV USER ${USER}
 USER $USER
 # Must use sudo where necessary from this point on
 DELIM_DOCKER_USER

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -97,9 +97,9 @@ ratt_pkg_job.with
                  'package to run ratt against (check lib transition)')
      booleanParam('USE_UNSTABLE', true,
                  'use unstable instead of experimental to test packages')
-     stringParam('RATT_INCLUDE'.''
+     stringParam('RATT_INCLUDE','',
                  'Regexp for package inclusion: ^(hwloc|fltk1.3|starpu)$. See https://github.com/j-rivero/ratt/blob/master/README.md')
-     stringParam('RATT_EXCLUDE'.''
+     stringParam('RATT_EXCLUDE','',
                  'Regexp for package exclusion: ^(gcc-9|gcc-8)$. See https://github.com/j-rivero/ratt/blob/master/README.md')
   }
 

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -95,6 +95,8 @@ ratt_pkg_job.with
   {
      stringParam('DEB_PACKAGE','master',
                  'package to run ratt against (check lib transition)')
+     booleanParam('USE_UNSTABLE', true,
+                 'use unstable instead of experimental to test packages')
   }
 
   logRotator {

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -97,6 +97,10 @@ ratt_pkg_job.with
                  'package to run ratt against (check lib transition)')
      booleanParam('USE_UNSTABLE', true,
                  'use unstable instead of experimental to test packages')
+     stringParam('RATT_INCLUDE'.''
+                 'Regexp for package inclusion: ^(hwloc|fltk1.3|starpu)$. See https://github.com/j-rivero/ratt/blob/master/README.md')
+     stringParam('RATT_EXCLUDE'.''
+                 'Regexp for package exclusion: ^(gcc-9|gcc-8)$. See https://github.com/j-rivero/ratt/blob/master/README.md')
   }
 
   logRotator {


### PR DESCRIPTION
ratt is used in Debian for ABI transition. To help with maintenance work in Debian, I've improved the tool to handle experimental/unstable and include Exclude/Include values in packages.

Tested here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=debian-ratt-builder&build=110)](https://build.osrfoundation.org/job/debian-ratt-builder/110/)