### PR TITLE
Fix dashboard to include packages without Source field (i.e ignition-fortress)

### DIFF
--- a/terminal-dashboard/table.bash
+++ b/terminal-dashboard/table.bash
@@ -140,7 +140,11 @@ do
         if [[ $ARCH == "i386" && $VER == "focal" ]]; then
           PKG_VERSION="disabled"
         else
-          PKG_VERSION=$(wget -qO- http://packages.osrfoundation.org/gazebo/${DISTRO}-${PACKAGE_REPO}/dists/${VER}/main/binary-${ARCH}/Packages | grep -1 "Source: ${LIB}" | sed -n 's/^Version: \(.*\)/\1/p' | uniq)
+	  # The Source field is not mandatory and it is probably not present when
+	  # the binary package has the same name than the source package
+          PKG_VERSION=$(wget -qO- http://packages.osrfoundation.org/gazebo/${DISTRO}-${PACKAGE_REPO}/dists/${VER}/main/binary-${ARCH}/Packages | \
+	    grep -1 -m 1 -e "Source: ${LIB}" -e "Package: ${LIB}" | \
+	    sed -n 's/^Version: \(.*\)/\1/p' | uniq)
         fi
 
         PKG_VERSION=${PKG_VERSION%%~*}

--- a/terminal-dashboard/table.bash
+++ b/terminal-dashboard/table.bash
@@ -140,11 +140,11 @@ do
         if [[ $ARCH == "i386" && $VER == "focal" ]]; then
           PKG_VERSION="disabled"
         else
-	  # The Source field is not mandatory and it is probably not present when
-	  # the binary package has the same name than the source package
+          # The Source field is not mandatory and it is probably not present when
+          # the binary package has the same name than the source package
           PKG_VERSION=$(wget -qO- http://packages.osrfoundation.org/gazebo/${DISTRO}-${PACKAGE_REPO}/dists/${VER}/main/binary-${ARCH}/Packages | \
-	    grep -1 -m 1 -e "Source: ${LIB}" -e "Package: ${LIB}" | \
-	    sed -n 's/^Version: \(.*\)/\1/p' | uniq)
+            grep -1 -m 1 -e "Source: ${LIB}" -e "Package: ${LIB}" | \
+            sed -n 's/^Version: \(.*\)/\1/p' | uniq)
         fi
 
         PKG_VERSION=${PKG_VERSION%%~*}


### PR DESCRIPTION
Fixes #505 . The reason because is not working in not really that we are not providing source packages for ignition-$collections but that [is not mandatory to include](https://www.debian.org/doc/debian-policy/ch-controlfields.html#binary-package-control-files-debian-control) a `Source:` clause in .deb packages. My hypothesis is: when there is a single binary package with the same name than the source package, the `Source:` field is omitted. This is the case for our ignition-$collection packages.

The PR is changing the previous `grep`:

`grep -1 "Source: ${LIB}"`

By:

`grep -1 -m 1 -e "Source: ${LIB}" -e "Package: ${LIB}"`

Adding `-m 1` should make grep to stop on the first match (side effect, this can speed up the script). If we don't find the `Source:`field we fallback to look for the `Package:`