### PR TITLE
Enable ign-launch5 windows jobs. Add it to Fortress

### DIFF
--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -613,7 +613,7 @@ ignition_software.each { ign_sw ->
 
   // ign-launch only support Windows from ign-launch5
   if (ign_sw == 'launch')
-    supported_branches = [ 'main' ]
+    supported_branches = [ 'ign-launch5', 'main' ]
 
   def ignition_win_ci_any_job = job(ignition_win_ci_any_job_name)
   OSRFWinCompilationAnyGitHub.create(ignition_win_ci_any_job,
@@ -662,8 +662,8 @@ ignition_software.each { ign_sw ->
         if (branch == 'ign-gazebo3' || branch == 'ign-gazebo4')
           disabled()
 
-        // ign-launch still not ported completely to Windows
-        if (ign_sw == 'launch' && branch != 'main')
+        // ign-launch was not ported to windows until 5
+        if (branch == 'ign-launch2' || branch == 'ign-launch3' || branch == 'ign-launch4')
           disabled()
 
         triggers {

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -288,6 +288,7 @@ ignition_collection_jobs =
         'ign_fuel-tools-ign-7-win',
         'ign_gazebo-ign-6-win',
         'ign_gui-ign-6-win',
+        'ign_launch-ign-5-win',
         'ign_physics-ign-5-win',
         'ign_plugin-ign-1-win',
         'ign_rendering-ign-6-win',


### PR DESCRIPTION
Ignition launch was ported to Windows some months ago and enabled for `main` and `-pr-`. This PR enables the version 5 just released and add it to the Fortress collection.

Build is fine: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_launch-ign-5-win&build=1)](https://build.osrfoundation.org/job/ign_launch-ign-5-win/1/)

DSL for ignition: [![Build Status](https://build.osrfoundation.org/job/_dsl_ignition/1204/badge/icon)](https://build.osrfoundation.org/job/_dsl_ignition/1204/)
DSL for collection:  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_ignition_collection&build=403)](https://build.osrfoundation.org/job/_dsl_ignition_collection/403/)

Fixes: https://github.com/ignition-tooling/release-tools/issues/351

