### PR TITLE
ign-tools windows CI: don't major version number

### DIFF
--- a/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
@@ -5,6 +5,6 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 set COLCON_PACKAGE=ignition-tools
-set COLCON_AUTO_MAJOR_VERSION=true
+set COLCON_AUTO_MAJOR_VERSION=false
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"


### PR DESCRIPTION
The ignition-tools cmake package name doesn't include its major version, so disable `COLCON_AUTO_MAJOR_VERSION`. This is a follow-up to #537, since we were unable to test that with an ign-tools PR until after merging.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_tools-pr-win&build=7)](https://build.osrfoundation.org/job/ign_tools-pr-win/7/) https://build.osrfoundation.org/job/ign_tools-pr-win/7/

~~~
# BEGIN SECTION: colcon test for ignition-tools1
[0.561s] [34mcolcon.colcon_core.package_selection[0m [1;30mWARNING[0m [33mignoring unknown package 'ignition-tools1' in --packages-select[0m

Summary: 0 packages finished [0.23s]
# END SECTION
...
# BEGIN SECTION: export testing results
File not found - test_results
0 File(s) copied
Failed with error #4.
~~~