### PR TITLE
Fix debbuild names for nightly scheduler

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -21,10 +21,10 @@ ignition_collections = [
     // These are the branches currently targeted at the upcoming collection
     // They're in topological order
     nightly_jobs: [
-          'tools'     : [ debbuild: 'ign-tools1'      , branch: 'ign-tools1' ],
+          'tools'     : [ debbuild: 'ign-tools'       , branch: 'ign-tools1' ],
           'cmake'     : [ debbuild: 'ign-cmake2'      , branch: 'ign-cmake2' ],
           'math'      : [ debbuild: 'ign-math6'       , branch: 'ign-math6' ],
-          'plugin'    : [ debbuild: 'ign-plugin1'     , branch: 'ign-plugin1' ],
+          'plugin'    : [ debbuild: 'ign-plugin'      , branch: 'ign-plugin1' ],
           'utils'     : [ debbuild: 'ign-utils1'      , branch: 'ign-utils1' ],
           'common'    : [ debbuild: 'ign-common4'     , branch: 'ign-common4' ],
           'msgs'      : [ debbuild: 'ign-msgs8'       , branch: 'ign-msgs8' ],


### PR DESCRIPTION
The nightly scheduler build is unstable:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition-fortress-nightly-scheduler&build=212)](https://build.osrfoundation.org/job/ignition-fortress-nightly-scheduler/212/) https://build.osrfoundation.org/job/ignition-fortress-nightly-scheduler/212/

~~~
releasing ign-tools1 (from branch main
MARK_AS_UNSTABLE
 - done
releasing ign-cmake2 (from branch ign-cmake2
 - done
releasing ign-math6 (from branch ign-math6
 - done
releasing ign-plugin1 (from branch ign-plugin1
MARK_AS_UNSTABLE
 - done
~~~

The correct debbuild names don't include the major version:

* https://build.osrfoundation.org/job/ign-plugin-debbuilder/
* https://build.osrfoundation.org/job/ign-tools-debbuilder/