### PR TITLE
ignition_collection: fix ign-tools nightly branch

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -592,6 +592,7 @@ nightly_scheduler_job.with
   rendering_branch = get_nightly_branch(collection_data, 'rendering')
   sensors_branch = get_nightly_branch(collection_data, 'sensors')
   sdformat_branch = get_nightly_branch(collection_data, 'sdformat')
+  tools_branch = get_nightly_branch(collection_data, 'tools')
   transport_branch = get_nightly_branch(collection_data, 'transport')
   utils_branch = get_nightly_branch(collection_data, 'utils')
 
@@ -637,6 +638,8 @@ nightly_scheduler_job.with
                 src_branch="${sdformat_branch}"
               elif [[ "\${n}" != "\${n/transport/}" ]]; then
                 src_branch="${transport_branch}"
+              elif [[ "\${n}" != "\${n/tools/}" ]]; then
+                src_branch="${tools_branch}"
               elif [[ "\${n}" != "\${n/utils/}" ]]; then
                 src_branch="${utils_branch}"
               else


### PR DESCRIPTION
The ign-tools nightly build was triggered with the `main` branch instead of `ign-tools1` due to missing logic in the dsl file.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-tools-debbuilder&build=192)](https://build.osrfoundation.org/job/ign-tools-debbuilder/192/) https://build.osrfoundation.org/job/ign-tools-debbuilder/192/