### PR TITLE
DSL: do not fail if Linux jobs don't have Dockefile

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBase.groovy
@@ -23,6 +23,10 @@ class OSRFLinuxBase
           archiveArtifacts {
             pattern('Dockerfile')
             pattern('build.sh')
+            // there are no guarantees that a job using OSRFLinuxBase generate
+            // these files (i.e: testing job). Do not fail if they are not
+            // present
+            allowEmpty(true)
         }
       }
     }


### PR DESCRIPTION
Previously a simple generated job failed with [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_job_from_dsl&build=9)](https://build.osrfoundation.org/job/_test_job_from_dsl/9/)  

```
ERROR: Step ?Archive the artifacts? failed: No artifacts found that match the file pattern "Dockerfile,build.sh". Configuration error?
```

Fixed if run with this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_job_from_dsl&build=10)](https://build.osrfoundation.org/job/_test_job_from_dsl/10/)