### PR TITLE
bump_dependency.bash: improve homebrew support

### DIFF
--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -418,9 +418,11 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   # remove bottle - TODO: this is only needed for new formulae
   sed -i -e "/bottle do/,/end/d" $FORMULA
   # URL from release to commit - TODO: remove manual step
-  sed -i "s@url.*@url \"$URL\"@g" $FORMULA
+  sed -i "s@^  url.*@  url \"$URL\"@g" $FORMULA
   # SHA - TODO: remove manual step
   sed -i "s/sha256.*/sha256 \"$SHA\"/g" $FORMULA
+  # revision - remove if present
+  sed -i "/^  revision.*/d" $FORMULA
   # version
   sed -i "/ version /d" $FORMULA
   sed -i "/url.*/a \ \ version\ \"${PREV_VER}.999.999~0~`date +"%Y%m%d"`~${SOURCE_COMMIT:0:6}\"" $FORMULA

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -325,7 +325,7 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   startFromCleanBranch ${BUMP_BRANCH} main
 
   # Check if main branch of that library is the correct version
-  PROJECT_NAME="${LIB//-/_}${VER}"
+  PROJECT_NAME="${LIB_}${VER}"
   PROJECT_NAME="${PROJECT_NAME/ign_/ignition-}"
   PROJECT="project.*(${PROJECT_NAME}"
   if ! grep -q ${PROJECT} "CMakeLists.txt"; then

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -311,9 +311,6 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   PREV_VER="$((${VER}-1))"
   LIB_UPPER=`echo ${LIB#"ign-"} | tr a-z A-Z`
   ORG=${IGN_ORG}
-  if [ "$LIB" = "sdformat" ]; then
-    ORG=${OSRF_ORG}
-  fi
   BUMP_BRANCH="bump_${COLLECTION}_${LIB}${VER}"
 
   echo -e "${BLUE_BG}Processing [${LIB}]${DEFAULT_BG}"
@@ -417,6 +414,7 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   sed -i "s ${LIB}${PREV_VER} main g" $FORMULA
   # class IgnitionLibN
   sed -i -E "s/((class Ignition.*))${PREV_VER}/\1${VER}/g" $FORMULA
+  sed -i -E "s/((class Sdformat))${PREV_VER}/\1${VER}/g" $FORMULA
   # remove bottle - TODO: this is only needed for new formulae
   sed -i -e "/bottle do/,/end/d" $FORMULA
   # URL from release to commit - TODO: remove manual step

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -19,10 +19,10 @@
 # Requires the 'gh' CLI to be installed.
 #
 # Usage:
-# $ ./bump_dependency.bash <collection> <library>;<library> <version>;<version> <issue_number> <prev_collection> <docs_branch>
+# $ ./bump_dependency.bash <collection> <library>;<library> <version>;<version> <issue_number> <prev_collection> [<docs_branch>]
 #
 # For example, to bump to `ign-rendering6` and all its dependencies, as well as
-# `sdf12` and its dependencies on fortress:
+# `sdf12` and its dependencies on fortress using the default `master` branch for `docs`:
 #
 # ./bump_dependency.bash fortress "ign-rendering;sdformat" "6;12" 428 edifice "chapulina/fortress"
 #

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -57,6 +57,9 @@ VERSION_INPUT=${3}
 ISSUE_NUMBER=${4}
 PREV_COLLECTION=${5}
 DOCS_BRANCH=${6}
+if [[ -z "${DOCS_BRANCH}" ]]; then
+  DOCS_BRANCH=master
+fi
 
 COMMIT_MSG="Bumps in ${COLLECTION}"
 PR_TEXT="See https://github.com/${TOOLING_ORG}/release-tools/issues/${ISSUE_NUMBER}"

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -22,9 +22,11 @@
 # $ ./bump_dependency.bash <collection> <library>;<library> <version>;<version> <issue_number> <prev_collection> [<docs_branch>]
 #
 # For example, to bump to `ign-rendering6` and all its dependencies, as well as
-# `sdf12` and its dependencies on fortress using the default `master` branch for `docs`:
+# `sdf12` and its dependencies on fortress using the `chapulina/fortress` branch for `docs`:
 #
 # ./bump_dependency.bash fortress "ign-rendering;sdformat" "6;12" 428 edifice "chapulina/fortress"
+#
+# The `docs_branch` parameter is optional and defaults to `master` if not specified.
 #
 # The script clones all the necessary repositories under /tmp/bump_dependency.
 #

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -385,17 +385,20 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   cd ${TEMP_DIR}/homebrew-simulation
   startFromCleanBranch bump_${COLLECTION}_${LIB} master
 
-  FORMULA="Formula/${LIB/ign/ignition}${VER}.rb"
+  # expand ign-* to ignition-*
+  FORMULA_BASE=${LIB/ign/ignition}
+  # construct path with major version suffix
+  FORMULA="Formula/${FORMULA_BASE}${VER}.rb"
   if [ ! -f "$FORMULA" ]; then
     echo -e "${GREEN}${LIB}: Creating ${FORMULA}${DEFAULT}"
 
-    git rm Aliases/${LIB/ign/ignition}${VER}
+    git rm Aliases/${FORMULA_BASE}${VER}
 
     # Collection
     if ! [[ $VER == ?(-)+([0-9]) ]] ; then
       cp Formula/ignition-${PREV_COLLECTION}.rb $FORMULA
     else
-      cp Formula/${LIB/ign/ignition}${PREV_VER}.rb $FORMULA
+      cp Formula/${FORMULA_BASE}${PREV_VER}.rb $FORMULA
     fi
 
     git add $FORMULA


### PR DESCRIPTION
There were several issues with the auto-generated homebrew formulae in the `bump_dependency.bash` script.

* The major version number in the ign-collection formula was negative (see https://github.com/osrf/homebrew-simulation/pull/1422/commits/509abd322c131e2e31b92a8dc15d101c8fc4eb3f)
* The url replacing logic would replace every url in the file, including the PyYAML url
* It did not remove `revision` numbers
* It was using source commits in the URLs instead of building from the `main` branch, as decided in https://github.com/osrf/homebrew-simulation/pull/1481
* It didn't handle SDFormat properly in a few places

I've used this to open the homebrew-simulation pull requests for https://github.com/ignition-tooling/release-tools/issues/545