### PR TITLE
Make debbuilds unstable when a missing component is triggering a warning

### DIFF
--- a/jenkins-scripts/parser_rules/debbuild_missing.parser
+++ b/jenkins-scripts/parser_rules/debbuild_missing.parser
@@ -1,3 +1,3 @@
 warning /^dh_missing: /
 warning /.*binaries-have-file-conflict.*/
-warning /^[[:space:]]*-- Skipping component \[.*\]: Missing dependency.*\./
+warning /^\s*-- Skipping component \[.*\]: Missing dependency.*\./

--- a/jenkins-scripts/parser_rules/debbuild_missing.parser
+++ b/jenkins-scripts/parser_rules/debbuild_missing.parser
@@ -1,2 +1,3 @@
 warning /^dh_missing: /
 warning /.*binaries-have-file-conflict.*/
+warning /.^   -- Skipping component [.*]: Missing dependency.*/

--- a/jenkins-scripts/parser_rules/debbuild_missing.parser
+++ b/jenkins-scripts/parser_rules/debbuild_missing.parser
@@ -1,3 +1,3 @@
 warning /^dh_missing: /
 warning /.*binaries-have-file-conflict.*/
-warning /.^   -- Skipping component [.*]: Missing dependency.*/
+warning /^[[:space:]]*-- Skipping component \[.*\]: Missing dependency.*\./


### PR DESCRIPTION
This should help to identify when we are missing optional dependencies in the packaging jobs by turning unstable the builds.

Tested here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-physics5-debbuilder&build=523)](https://build.osrfoundation.org/job/ign-physics5-debbuilder/523/) with the results of the parser here https://build.osrfoundation.org/job/ign-physics5-debbuilder/523/parsed_console/.

If we merge it now, there would be a good bunch of unstable builds due to different missing packages. The way to solve it would be to inject in the packaging rules files the corresponding `SKIP_$software=True` in the `override_dh_auto_configure` like we are doing for other configurations (i.e: https://github.com/ignition-release/ign-msgs6-release/blob/main/ubuntu/debian/rules#L33-L36).

From the top of my head we would need to patch ign-physics (for DART in Debian) and ign-rendering (for Optix).


