### PR TITLE
Support for OGRE extra includes in abi checker

### DIFF
--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -37,6 +37,13 @@ if [[ "${NEED_C17_COMPILER}" == "true" ]]; then
   ABI_CXX_STANDARD=c++17
 fi
 
+# Needed to compile software using OGRE-2.2. Being used on every build, should not hurt
+EXTRA_INCLUDES="""
+ <add_include_paths>
+   /usr/include/OGRE-2.2/Hlms/Common
+ </add_include_paths>
+"""
+
 cat > build.sh << DELIM
 #!/bin/bash
 
@@ -109,6 +116,8 @@ cat > pkg.xml << CURRENT_DELIM
    /usr/local/destination_branch/include/\$DEST_DIR
  </headers>
 
+ ${EXTRA_INCLUDES}
+
  <skip_headers>
 CURRENT_DELIM
 
@@ -135,6 +144,8 @@ cat > devel.xml << DEVEL_DELIM
  <headers>
    /usr/local/source_branch/include/\$SRC_DIR
  </headers>
+
+ ${EXTRA_INCLUDES}
 
  <skip_headers>
 DEVEL_DELIM


### PR DESCRIPTION
Fixes https://github.com/ignitionrobotics/ign-rendering/issues/488

The abi-checker in ign-rendering is broken with the following error [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_rendering-abichecker-any_to_any-ubuntu_auto-amd64&build=821)](https://build.osrfoundation.org/job/ignition_rendering-abichecker-any_to_any-ubuntu_auto-amd64/821/):
```
The GCC parameters:
  gcc -fdump-lang-raw -fkeep-inline-functions -c -x c++ -fpermissive -w  -std=c++17 "/tmp/MZxkwdymxg/dump1.h"  -I/usr/local/destination_branch/include/ignition/rendering6 -I/usr/include/OGRE-2.2 -I/usr/include/OGRE -I/usr/include/ignition/utils1 -I/usr/include/ignition/math6 -I/usr/include/ignition/common4 -I/usr/include/OGRE/Paging

In file included from /usr/local/destination_branch/include/ignition/rendering6/ignition/rendering/ogre2/Ogre2Includes.hh:86,
                 from /usr/local/destination_branch/include/ignition/rendering6/ignition/rendering/ogre2/Ogre2Camera.hh:24,
                 from /tmp/MZxkwdymxg/dump1.h:6:
/usr/include/OGRE-2.2/Hlms/Unlit/OgreHlmsUnlit.h:32:10: fatal error: OgreHlmsBufferManager.h: No such file or directory
 #include "OgreHlmsBufferManager.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.```
```

The PR add to all builds the ` -I/usr/include/OGRE-2.2/Hlms/Common`. The change is a bit abusive since everything not depending on rendering should not need it but I think we can life with an extra line in the compilation of the ABI if the benefit is to have to make all software on top to declare it.

Testing:

*  ign-rendering6 vs ign-rendering6 [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_rendering-abichecker-any_to_any-ubuntu_auto-amd64&build=822)](https://build.osrfoundation.org/job/ignition_rendering-abichecker-any_to_any-ubuntu_auto-amd64/822/)

* ign-rendering5 vs ign-rendering6 [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_rendering-abichecker-any_to_any-ubuntu_auto-amd64&build=823)](https://build.osrfoundation.org/job/ignition_rendering-abichecker-any_to_any-ubuntu_auto-amd64/823/)
