### PR TITLE
ABI builds: only set ogre2.2 paths if needed

### DIFF
--- a/jenkins-scripts/docker/ignition-abichecker.bash
+++ b/jenkins-scripts/docker/ignition-abichecker.bash
@@ -47,6 +47,19 @@ then
   export NEED_C17_COMPILER=true
 fi
 
+# check if OGRE-2.2 include paths are needed
+if [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gazebo"   && ${IGN_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]] || \
+  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-gui"       && ${IGN_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]] || \
+  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-sensors"   && ${IGN_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]] || \
+  [[ "${ABI_JOB_SOFTWARE_NAME}" = "ign-rendering" && ${IGN_NAME_PREFIX_MAJOR_VERSION} -ge 6 ]]
+then
+  export EXTRA_INCLUDES="""
+ <add_include_paths>
+   /usr/include/OGRE-2.2/Hlms/Common
+ </add_include_paths>
+"""
+fi
+
 # default to use stable repos
 export ABI_JOB_REPOS="stable"
 

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -37,13 +37,6 @@ if [[ "${NEED_C17_COMPILER}" == "true" ]]; then
   ABI_CXX_STANDARD=c++17
 fi
 
-# Needed to compile software using OGRE-2.2. Being used on every build, should not hurt
-EXTRA_INCLUDES="""
- <add_include_paths>
-   /usr/include/OGRE-2.2/Hlms/Common
- </add_include_paths>
-"""
-
 cat > build.sh << DELIM
 #!/bin/bash
 


### PR DESCRIPTION
Fix for builds not using ogre2.2 after #560.

Set the `EXTRA_INCLUDES` variable in `ignition-abichecker.bash` to add ogre2.2 include paths only if a package using `ignition-rendering6`+ is detected.

Test:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-abichecker-any_to_any-ubuntu_auto-amd64&build=655)](https://build.osrfoundation.org/job/ignition_gui-abichecker-any_to_any-ubuntu_auto-amd64/655/) https://build.osrfoundation.org/job/ignition_gui-abichecker-any_to_any-ubuntu_auto-amd64/655/