### PR TITLE
Default to Focal for CI

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -108,14 +108,4 @@ class Globals
    static String get_ros2_development_distro() {
      return 'rolling'
    }
-
-   static String get_gz11_ubuntu_distro()
-   {
-     return 'bionic'
-   }
-
-   static String get_gz11_mac_distro()
-   {
-     return 'mojave'
-   }
 }

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -57,12 +57,12 @@ class Globals
    // Main CI platform
    static ArrayList get_ci_distro()
    {
-    return [ 'bionic' ]
+    return [ 'focal' ]
    }
 
    static ArrayList get_abi_distro()
    {
-     return [ 'bionic' ]
+     return [ 'focal' ]
    }
 
    static ArrayList get_ci_gpu()
@@ -72,7 +72,7 @@ class Globals
 
    static ArrayList get_other_supported_distros()
    {
-     return [ 'bionic' ]
+     return [ 'focal' ]
    }
 
    static ArrayList get_supported_arches()

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -72,7 +72,7 @@ class Globals
 
    static ArrayList get_other_supported_distros()
    {
-     return [ 'focal' ]
+     return [  ]
    }
 
    static ArrayList get_supported_arches()

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -3,9 +3,6 @@ import javaposse.jobdsl.dsl.Job
 
 def gazebo_supported_branches = [ 'gazebo9', 'gazebo11' ]
 def gazebo_supported_build_types = [ 'Release', 'Debug', 'Coverage' ]
-// nightly_gazebo_branch is not the branch used to get the code from but
-// the one used to generate the corresponding debbuild job.
-def nightly_gazebo_branch = [ 'gazebo11' ]
 // testing official packages without osrf repo
 def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9',
                                          'focal'  : 'gazebo9',
@@ -460,7 +457,7 @@ ubuntu_official_packages_distros.each { distro, branch ->
 // --------------------------------------------------------------
 // DEBBUILD: linux package builder
 
-all_debbuild_branches = gazebo_supported_branches + nightly_gazebo_branch
+all_debbuild_branches = gazebo_supported_branches
 all_debbuild_branches.each { branch ->
   def build_pkg_job = job("${branch}-debbuilder")
   OSRFLinuxBuildPkg.create(build_pkg_job)

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -8,7 +8,6 @@ def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9',
                                          'focal'  : 'gazebo9',
                                          'jammy'  : 'gazebo11']
 // Main platform using for quick CI
-def ci_distro_default       = [ 'bionic' ]
 def ci_distro               = Globals.get_ci_distro()
 def ci_gpu                  = Globals.get_ci_gpu()
 def abi_distro              = Globals.get_abi_distro()
@@ -23,7 +22,6 @@ def all_supported_gpus      = Globals.get_all_supported_gpus()
 def DISABLE_TESTS = false
 def DISABLE_GITHUB_INTEGRATION = false
 
-String ci_distro_default_str = ci_distro_default[0]
 String ci_distro_str = ci_distro[0]
 String ci_gpu_str = ci_gpu[0]
 String ci_build_any_job_name_linux = "gazebo-ci-pr_any-ubuntu_auto-amd64-gpu-${ci_gpu_str}"
@@ -139,11 +137,7 @@ ci_distro.each { distro ->
 
       // --------------------------------------------------------------
       // 2. Create the master ci jobs
-      def gazebo_ci_job = job("gazebo-ci-master-${ci_distro_default_str}-${arch}-gpu-${gpu}")
-      if (is_watched_by_buildcop('master', ci_distro_default_str, gpu))
-      {
-        Globals.extra_emails = Globals.build_cop_email
-      }
+      def gazebo_ci_job = job("gazebo-ci-master-${distro}-${arch}-gpu-${gpu}")
       OSRFLinuxCompilation.create(gazebo_ci_job)
       OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo")
 
@@ -159,7 +153,7 @@ ci_distro.each { distro ->
           shell("""\
                 #!/bin/bash -xe
 
-                export DISTRO=${ci_distro_default_str}
+                export DISTRO=${distro}
                 export ARCH=${arch}
                 export GPU_SUPPORT_NEEDED=true
                 /bin/bash -xe ./scripts/jenkins-scripts/docker/gazebo-compilation.bash
@@ -257,10 +251,6 @@ ci_distro.each { distro ->
 // BRANCHES CI JOB @ SCM/DAILY
 gazebo_supported_branches.each { branch ->
   distros = ci_distro
-  if (branch == 'gazebo11')
-  {
-    distros = ci_distro_default
-  }
   distros.each { distro ->
     supported_arches.each { arch ->
       ci_gpu.each { gpu ->
@@ -301,7 +291,7 @@ gazebo_supported_branches.each { branch ->
 } // end of branch
 
 // EXPERIMENTAL ARCHES @ SCM/WEEKLY
-ci_distro_default.each { distro ->
+ci_distro.each { distro ->
   experimental_arches.each { arch ->
     def gazebo_ci_job = job("gazebo-ci-master-${distro}-${arch}-gpu-none")
     OSRFLinuxCompilation.create(gazebo_ci_job)
@@ -330,7 +320,7 @@ ci_distro_default.each { distro ->
 }
 
 // COVERAGE TYPE @ SCM/DAILY
-ci_distro_default.each { distro ->
+ci_distro.each { distro ->
   supported_arches.each { arch ->
     ci_gpu.each { gpu ->
       def gazebo_ci_job = job("gazebo-ci-coverage-${distro}-${arch}-gpu-${gpu}")
@@ -365,7 +355,7 @@ ci_distro_default.each { distro ->
 }
 
 // BUILD TYPES CI JOBS @ SCM/DAILY
-ci_distro_default.each { distro ->
+ci_distro.each { distro ->
   supported_arches.each { arch ->
     gazebo_supported_build_types.each { build_type ->
       def gazebo_ci_job = job("gazebo-ci_BT${build_type}-master-${distro}-${arch}-gpu-none")
@@ -427,10 +417,6 @@ all_supported_distros.each { distro ->
 // INSTALL LINUX -DEV PACKAGES ALL PLATFORMS @ CRON/DAILY
 gazebo_supported_branches.each { branch ->
   distros = ci_distro
-  if (branch == 'gazebo11')
-  {
-    distros = ci_distro_default
-  }
   distros.each { distro ->
     supported_arches.each { arch ->
       // --------------------------------------------------------------

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -8,7 +8,8 @@ def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9',
                                          'focal'  : 'gazebo9',
                                          'jammy'  : 'gazebo11']
 // Main platform using for quick CI
-def ci_distro               = Globals.get_ci_distro()
+// Using bionic until https://github.com/osrf/gazebo/issues/3151 is fixed
+def ci_distro               = [ 'bionic' ]
 def ci_gpu                  = Globals.get_ci_gpu()
 def abi_distro              = Globals.get_abi_distro()
 // Other supported platform to be checked but no for quick

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -7,8 +7,9 @@ def gazebo_supported_build_types = [ 'Release', 'Debug', 'Coverage' ]
 // the one used to generate the corresponding debbuild job.
 def nightly_gazebo_branch = [ 'gazebo11' ]
 // testing official packages without osrf repo
-def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9' ]
-
+def ubuntu_official_packages_distros = [ 'bionic' : 'gazebo9',
+                                         'focal'  : 'gazebo9',
+                                         'jammy'  : 'gazebo11']
 // Main platform using for quick CI
 def ci_distro_default       = [ 'bionic' ]
 def ci_distro               = Globals.get_ci_distro()

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -135,39 +135,13 @@ ci_distro.each { distro ->
          }
       }
 
-      // --------------------------------------------------------------
-      // 2. Create the master ci jobs
-      def gazebo_ci_job = job("gazebo-ci-master-${distro}-${arch}-gpu-${gpu}")
-      OSRFLinuxCompilation.create(gazebo_ci_job)
-      OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo")
-
-      gazebo_ci_job.with
-      {
-        label "gpu-reliable && large-memory"
-
-        triggers {
-          scm('*/5 * * * *')
-        }
-
-        steps {
-          shell("""\
-                #!/bin/bash -xe
-
-                export DISTRO=${distro}
-                export ARCH=${arch}
-                export GPU_SUPPORT_NEEDED=true
-                /bin/bash -xe ./scripts/jenkins-scripts/docker/gazebo-compilation.bash
-                """.stripIndent())
-        }
-      }
-
       // reset build cop email in global list of mails
       Globals.extra_emails = ''
     } // end of gpu
   } // end of arch
 } // end of distro
 
-// OTHER CI SUPPORTED JOBS (master branch) @ SCM/DAILY
+// OTHER CI SUPPORTED JOBS (gazebo11 branch) @ SCM/DAILY
 other_supported_distros.each { distro ->
   supported_arches.each { arch ->
 
@@ -177,8 +151,8 @@ other_supported_distros.each { distro ->
       gpus = [ 'none' ]
 
     gpus.each { gpu ->
-      // ci_master job for the rest of arches / scm@daily
-      def gazebo_ci_job = job("gazebo-ci-master-${distro}-${arch}-gpu-${gpu}")
+      // gazebo11 job for the rest of arches / scm@daily
+      def gazebo_ci_job = job("gazebo-ci-gazebo11-${distro}-${arch}-gpu-${gpu}")
       OSRFLinuxCompilation.create(gazebo_ci_job)
       OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo")
 
@@ -293,9 +267,9 @@ gazebo_supported_branches.each { branch ->
 // EXPERIMENTAL ARCHES @ SCM/WEEKLY
 ci_distro.each { distro ->
   experimental_arches.each { arch ->
-    def gazebo_ci_job = job("gazebo-ci-master-${distro}-${arch}-gpu-none")
+    def gazebo_ci_job = job("gazebo-ci-gazebo11-${distro}-${arch}-gpu-none")
     OSRFLinuxCompilation.create(gazebo_ci_job)
-    OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo")
+    OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo", "gazebo11")
 
     gazebo_ci_job.with
     {
@@ -325,7 +299,7 @@ ci_distro.each { distro ->
     ci_gpu.each { gpu ->
       def gazebo_ci_job = job("gazebo-ci-coverage-${distro}-${arch}-gpu-${gpu}")
       OSRFLinuxCompilation.create(gazebo_ci_job)
-      OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo", "master")
+      OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo", "gazebo11")
       gazebo_ci_job.with
       {
         triggers {
@@ -358,9 +332,9 @@ ci_distro.each { distro ->
 ci_distro.each { distro ->
   supported_arches.each { arch ->
     gazebo_supported_build_types.each { build_type ->
-      def gazebo_ci_job = job("gazebo-ci_BT${build_type}-master-${distro}-${arch}-gpu-none")
+      def gazebo_ci_job = job("gazebo-ci_BT${build_type}-gazebo11-${distro}-${arch}-gpu-none")
       OSRFLinuxCompilation.create(gazebo_ci_job)
-      OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo")
+      OSRFGitHub.create(gazebo_ci_job, "osrf/gazebo", "gazebo11")
 
       gazebo_ci_job.with
       {
@@ -500,7 +474,7 @@ install_brew_job.with
 
 // 2. default in all branches @SCM/daily
 // No gazebo2 for brew
-all_branches = gazebo_supported_branches + 'master'
+all_branches = gazebo_supported_branches
 all_branches.each { branch ->
   if (is_watched_by_buildcop(branch))
     Globals.extra_emails = Globals.build_cop_email

--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -61,7 +61,7 @@ abi_distro.each { distro ->
 
 // MAIN CI job
 // CI JOBS @ SCM/5 min
-[ Globals.get_gz11_ubuntu_distro() ].each { distro ->
+ci_distro.each { distro ->
   supported_arches.each { arch ->
     // --------------------------------------------------------------
     // 1. Create the main ci jobs
@@ -139,10 +139,6 @@ other_supported_distros.each { distro ->
 // BRANCHES CI JOB @ SCM/DAILY
 sdformat_supported_branches.each { branch ->
   ci_distro.each { distro ->
-    // special check to modify ci_distro if the branch is part of gz11
-    if (branch in sdformat_gz11_branches)
-      distro = Globals.get_gz11_ubuntu_distro()
-
     supported_arches.each { arch ->
       // ci_main job for the rest of arches / scm@daily
       def sdformat_ci_job = job("sdformat-ci-${branch}-${distro}-${arch}")
@@ -171,7 +167,7 @@ sdformat_supported_branches.each { branch ->
 //
 
 // EXPERIMENTAL ARCHES @ SCM/WEEKLY
-[ Globals.get_gz11_ubuntu_distro() ].each { distro ->
+ci_distro.each { distro ->
   experimental_arches.each { arch ->
     def sdformat_ci_job = job("sdformat-ci-main-${distro}-${arch}")
     OSRFLinuxCompilation.create(sdformat_ci_job)
@@ -198,13 +194,7 @@ sdformat_supported_branches.each { branch ->
 
 // INSTALL LINUX -DEV PACKAGES ALL PLATFORMS @ CRON/DAILY
 sdformat_supported_branches.each { branch ->
-  // special check to modify ci_distro if the branch is part of gz11
-  if (branch in sdformat_gz11_branches)
-    ref_distro = [ Globals.get_gz11_ubuntu_distro() ]
-  else
-    ref_distro = ci_distro
-
-  ref_distro.each { distro ->
+  ci_distro.each { distro ->
     supported_arches.each { arch ->
       // --------------------------------------------------------------
       def install_default_job = job("sdformat-install-${branch}_pkg-${distro}-${arch}")

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -128,10 +128,9 @@ bullet_pkg="libbullet-dev"
 
 # choose dart version
 if $DART_FROM_PKGS; then
-  dart_pkgs="libdart-utils-urdf-dev"
+  dart_pkgs="libdart-utils-urdf-dev libdart-external-odelcpsolver"
   if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
-    dart_pkgs="${dart_pkgs} \"
-               libdart-collision-bullet-dev \
+    dart_pkgs="${dart_pkgs} libdart-collision-bullet-dev \
                libdart-collision-ode-dev"
   fi
   # If on Bionic/Xenial use custom dart packages, these have a different name

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -128,11 +128,16 @@ bullet_pkg="libbullet-dev"
 
 # choose dart version
 if $DART_FROM_PKGS; then
-  # Use custom packages on Bionic/Xenial and Ubuntu official from Focal on
+  dart_pkgs="libdart-utils-urdf-dev"
+  if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
+    dart_pkgs="${dart_pkgs} \"
+               libdart-collision-bullet-dev \
+               libdart-collision-ode-dev"
+  fi
+  # If on Bionic/Xenial use custom dart packages, these have a different name
+  # dart -> dart6
   if [[ ${DISTRO} == 'bionic' ]] || [[ ${DISTRO} == 'xenial' ]]; then
-    dart_pkg="libdart6-utils-urdf-dev"
-  else
-    dart_pkg="libdart-utils-urdf-dev"
+    dart_pkgs="${dart_pkgs//dart/dart6}"
   fi
 fi
 
@@ -168,7 +173,7 @@ if ! ${GAZEBO_EXPERIMENTAL_BUILD}; then
                             libboost-iostreams-dev           \\
                             ${bullet_pkg}                    \\
                             libsimbody-dev                   \\
-                            ${dart_pkg}"
+                            ${dart_pkgs}"
 
   if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
       GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -129,7 +129,7 @@ bullet_pkg="libbullet-dev"
 # choose dart version
 if $DART_FROM_PKGS; then
   dart_pkgs="libdart-utils-urdf-dev \
-             libdart-external-odelcpsolver-dev
+             libdart-external-odelcpsolver-dev \
              libdart-external-ikfast-dev"
   if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
     dart_pkgs="${dart_pkgs} libdart-collision-bullet-dev \

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -128,7 +128,7 @@ bullet_pkg="libbullet-dev"
 
 # choose dart version
 if $DART_FROM_PKGS; then
-  dart_pkgs="libdart-utils-urdf-dev libdart-external-odelcpsolver"
+  dart_pkgs="libdart-utils-urdf-dev libdart-external-odelcpsolver-dev"
   if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
     dart_pkgs="${dart_pkgs} libdart-collision-bullet-dev \
                libdart-collision-ode-dev"

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -128,7 +128,9 @@ bullet_pkg="libbullet-dev"
 
 # choose dart version
 if $DART_FROM_PKGS; then
-  dart_pkgs="libdart-utils-urdf-dev libdart-external-odelcpsolver-dev"
+  dart_pkgs="libdart-utils-urdf-dev \
+             libdart-external-odelcpsolver-dev
+             libdart-external-ikfast-dev"
   if [[ ${GAZEBO_MAJOR_VERSION} -ge 11 ]]; then
     dart_pkgs="${dart_pkgs} libdart-collision-bullet-dev \
                libdart-collision-ode-dev"

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -128,7 +128,12 @@ bullet_pkg="libbullet-dev"
 
 # choose dart version
 if $DART_FROM_PKGS; then
-  dart_pkg="libdart6-utils-urdf-dev"
+  # Use custom packages on Bionic/Xenial and Ubuntu official from Focal on
+  if [[ ${DISTRO} == 'bionic' ]] || [[ ${DISTRO} == 'xenial' ]]; then
+    dart_pkg="libdart6-utils-urdf-dev"
+  else
+    dart_pkg="libdart-utils-urdf-dev"
+  fi
 fi
 
 # By default, the stable version of gazebo

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -180,7 +180,7 @@ if ! ${GAZEBO_EXPERIMENTAL_BUILD}; then
   elif [[ ${GAZEBO_MAJOR_VERSION} -ge 9 ]]; then
       GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT="${GAZEBO_BASE_DEPENDENCIES_NO_SDFORMAT} \\
                                            libignition-common-dev \\
-                                           libignition-fuel-tools-dev \\
+                                           libignition-fuel-tools1-dev \\
                                            libignition-transport4-dev \\
                                            libignition-math4-dev \\
                                            libignition-msgs-dev"


### PR DESCRIPTION
Our CI is currently defaulting to Bionic. Garden is going to drop Bionic though (see https://github.com/ignitionrobotics/docs/pull/215), so we should default to Focal instead, which is supported for all the Ignition versions we're currently working on (Citadel, Dome, Edifice, Fortress, Garden).

We should do a lot of testing before merging this; I can do it next week. I think we may need to hardcode `bionic` for Gazebo 9 and dependencies.