### PR TITLE
Fail hard on Windows when a command fails

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -130,4 +130,4 @@ goto :EOF
 
 :error - error routine
 echo Failed with error #%errorlevel%.
-exit /b %errorlevel%
+exit %errorlevel%

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -281,4 +281,4 @@ goto :EOF
 :error - error routine
 ::
 echo Failed in windows_library with error #%errorlevel%.
-exit /B %errorlevel%
+exit %errorlevel%


### PR DESCRIPTION
Do [not use /b](https://ss64.com/nt/exit.html) on error routines to let Windows kill the whole terminal so the build scripts don't keep running.

Testing without this patch: https://build.osrfoundation.org/job/_test_ign_gui/5/consoleFull#console-section-15 (build is failing on `colcon build` but the script keep going)

Testing with this patch: https://build.osrfoundation.org/job/_test_ign_gui/15/consoleFull#console-section-15 (build is failing as soon as the first problem appear)
