### PR TITLE
Update vcpkg snapshot to 2021.05.12

### DIFF
--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -15,6 +15,6 @@ set VCPKG_CMD=%VCPKG_DIR%\vcpkg.exe
 set VCPKG_CMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%/scripts/buildsystems/vcpkg.cmake
 if NOT DEFINED VCPKG_SNAPSHOT (
   :: see https://github.com/microsoft/vcpkg/releases
-  set VCPKG_SNAPSHOT=2020.11
+  set VCPKG_SNAPSHOT=2021.05.12
 )
 goto :EOF


### PR DESCRIPTION
Update the vcpkg snapshot used by all our CI jobs to `2021-05-12`. 

@Blast545 was testing the different supported versions:
 * Citadel / Gazebo3: not supported
 * Dome / Gazebo4: not supported
 * Edifice / Gazebo5: https://build.osrfoundation.org/job/_vcpkg_testing_snapshot/104/
 * Fortress / Gazebo6: https://build.osrfoundation.org/job/_vcpkg_testing_snapshot/102/
 * Garden / GazeboMain: https://build.osrfoundation.org/job/_vcpkg_testing_snapshot/103/

The Windows machine should be update using https://build.osrfoundation.org/job/_vcpkg_update_snapshot/ before merging this.