### PR TITLE
Try to checkout matching gzdev branch for PR jobs

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -46,6 +46,7 @@ RUN if [ -n $GZDEV_TRY_BRANCH ]; then \
         git -C ${GZDEV_DIR} fetch origin $GZDEV_TRY_BRANCH || true; \
         git -C ${GZDEV_DIR} checkout $GZDEV_TRY_BRANCH || true; \
     fi || true"
+# print branch for informational purposes
 RUN git -C ${GZDEV_DIR} branch
 DELIM_OSRF_REPO_GIT
 if [[ -n ${GZDEV_PROJECT_NAME} ]]; then

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -33,24 +33,32 @@ export APT_PARAMS=
 
 GZDEV_DIR=${WORKSPACE}/gzdev
 GZDEV_BRANCH=${GZDEV_BRANCH:-master}
+if [[ "$ghprbSourceBranch" =~ matching_branch\/ ]]; then
+  GZDEV_TRY_BRANCH=$ghprbSourceBranch
+fi
 
 dockerfile_install_gzdev_repos()
 {
 cat >> Dockerfile << DELIM_OSRF_REPO_GIT
 RUN rm -fr ${GZDEV_DIR}
-RUN git clone --depth 1 https://github.com/ignition-tooling/gzdev -b ${GZDEV_BRANCH} ${GZDEV_DIR}
+RUN git clone https://github.com/ignition-tooling/gzdev -b ${GZDEV_BRANCH} ${GZDEV_DIR}
+RUN bash -c "if [[ -n \"$GZDEV_TRY_BRANCH\" ]]; then git -C ${GZDEV_DIR} fetch origin \"$GZDEV_TRY_BRANCH\"; fi || true"
+RUN bash -c "if [[ -n \"$GZDEV_TRY_BRANCH\" ]]; then git -C ${GZDEV_DIR} checkout \"$GZDEV_TRY_BRANCH\"; fi || true"
+RUN git -C ${GZDEV_DIR} branch
 DELIM_OSRF_REPO_GIT
 if [[ -n ${GZDEV_PROJECT_NAME} ]]; then
 # debian sid docker images does not return correct name so we need to use
 # force-linux-distro
 cat >> Dockerfile << DELIM_OSRF_REPO_GZDEV
 RUN ${GZDEV_DIR}/gzdev.py repository enable --project=${GZDEV_PROJECT_NAME} --force-linux-distro=${DISTRO} || ( git -C ${GZDEV_DIR} pull origin ${GZDEV_BRANCH} && \
+    (bash -c "if [[ -n \"$GZDEV_TRY_BRANCH\" ]]; then git -C ${GZDEV_DIR} checkout \"$GZDEV_TRY_BRANCH\"; fi || true") && \
     ${GZDEV_DIR}/gzdev.py repository enable --project=${GZDEV_PROJECT_NAME} --force-linux-distro=${DISTRO} )
 DELIM_OSRF_REPO_GZDEV
 else
 for repo in ${OSRF_REPOS_TO_USE}; do
 cat >> Dockerfile << DELIM_OSRF_REPO
 RUN ${GZDEV_DIR}/gzdev.py repository enable osrf ${repo} --force-linux-distro=${DISTRO}  || ( git -C ${GZDEV_DIR} pull origin ${GZDEV_BRANCH} && \
+    (bash -c "if [[ -n \"$GZDEV_TRY_BRANCH\" ]]; then git -C ${GZDEV_DIR} checkout \"$GZDEV_TRY_BRANCH\"; fi || true") && \
     ${GZDEV_DIR}/gzdev.py repository enable osrf ${repo} --force-linux-distro=${DISTRO} )
 DELIM_OSRF_REPO
 done


### PR DESCRIPTION
If a GitHub pull request branch contains `matching_branch/`, then try to checkout that branch from `gzdev`. To simplify checking out other branches, clone gzdev without `--depth 1`.

Part of #564.

Testing:

* https://github.com/ignitionrobotics/ign-fuel-tools/pull/218
* https://github.com/ignition-tooling/gzdev/compare/scpeters/matching_branch/test_msgs9?expand=1
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-pr_any-ubuntu_auto-amd64&build=673)](https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-ubuntu_auto-amd64/673/) https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-ubuntu_auto-amd64/673/