### PR TITLE
Brew CI: try checking out matching branches

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -68,6 +68,7 @@ then
   pushd $(brew --repo osrf/simulation)
   git fetch origin ${ghprbSourceBranch} || true
   git checkout ${ghprbSourceBranch} || true
+  popd
   echo '# END SECTION'
 fi
 

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -62,7 +62,7 @@ brew tap osrf/simulation
 echo '# END SECTION'
 
 if [[ -n "${ghprbSourceBranch}" ]] && \
-   [[ "${ghprbSourceBranch}" =~ matching_branch\/ ]]
+   [[ "${ghprbSourceBranch}" =~ ci_matching_branch\/ ]]
 then
   echo "# BEGIN SECTION: trying to checkout branch ${ghprbSourceBranch} from osrf/simulation"
   pushd $(brew --repo osrf/simulation)

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -61,9 +61,13 @@ echo '# BEGIN SECTION: setup the osrf/simulation tap'
 brew tap osrf/simulation
 echo '# END SECTION'
 
-if [[ -n "${PULL_REQUEST_URL}" ]]; then
-  echo "# BEGIN SECTION: pulling ${PULL_REQUEST_URL}"
-  brew pull ${PULL_REQUEST_URL}
+if [[ -n "${ghprbSourceBranch}" ]] && \
+   [[ "${ghprbSourceBranch}" =~ matching_branch\/ ]]
+then
+  echo "# BEGIN SECTION: trying to checkout branch ${ghprbSourceBranch} from osrf/simulation"
+  pushd $(brew --repo osrf/simulation)
+  git fetch origin ${ghprbSourceBranch} || true
+  git checkout ${ghprbSourceBranch} || true
   echo '# END SECTION'
 fi
 


### PR DESCRIPTION
Part of #564, similar to #572.

Tested with

* https://github.com/ignitionrobotics/ign-fuel-tools/pull/218
* https://github.com/osrf/homebrew-simulation/compare/scpeters/matching_branch/test_msgs9?expand=1
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-pr_any-homebrew-amd64&build=656)](https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-homebrew-amd64/656/) https://build.osrfoundation.org/job/ignition_fuel-tools-ci-pr_any-homebrew-amd64/656/

The `brew pull` command has been deprecated, so that code was replaced with checking for matching branches.