### PR TITLE
Use ci_matching_branch/ in bump_dependency.bash

### DIFF
--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -344,14 +344,14 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
 
     find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
 
-    # Second run with _ instead of -, to support multiple variations of fuel-tools
-    DEP_LIB=${DEP_LIB//-/_}
-    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
-
     # Replace collection yaml branch names with main
     if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then
       find . -type f -name "collection-${COLLECTION}.yaml" -print0 | xargs -0 sed -i "s ign-${DEP_LIB}${DEP_VER} main g"
     fi
+
+    # Second run with _ instead of -, to support multiple variations of fuel-tools
+    DEP_LIB=${DEP_LIB//-/_}
+    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
   done
 
   commitAndPR ${ORG} main

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -313,7 +313,7 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   PREV_VER="$((${VER}-1))"
   LIB_UPPER=`echo ${LIB#"ign-"} | tr a-z A-Z`
   ORG=${IGN_ORG}
-  BUMP_BRANCH="bump_${COLLECTION}_${LIB}${VER}"
+  BUMP_BRANCH="ci_matching_branch/bump_${COLLECTION}_${LIB}${VER}"
 
   echo -e "${BLUE_BG}Processing [${LIB}]${DEFAULT_BG}"
 
@@ -384,7 +384,7 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   echo -e "${GREEN}${LIB}: homebrew${DEFAULT}"
 
   cd ${TEMP_DIR}/homebrew-simulation
-  startFromCleanBranch bump_${COLLECTION}_${LIB} master
+  startFromCleanBranch ${BUMP_BRANCH} master
 
   # expand ign-* to ignition-*
   FORMULA_BASE=${LIB/ign/ignition}

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -318,45 +318,6 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   echo -e "${BLUE_BG}Processing [${LIB}]${DEFAULT_BG}"
 
   ##################
-  # source code
-  ##################
-
-  echo -e "${GREEN}${LIB}: source code${DEFAULT}"
-
-  cloneIfNeeded ${ORG} ${LIB}
-  startFromCleanBranch ${BUMP_BRANCH} main
-
-  # Check if main branch of that library is the correct version
-  PROJECT_NAME="${LIB_}${VER}"
-  PROJECT_NAME="${PROJECT_NAME/ign_/ignition-}"
-  PROJECT="project.*(${PROJECT_NAME}"
-  if ! grep -q ${PROJECT} "CMakeLists.txt"; then
-    echo -e "${RED}Wrong project name on [CMakeLists.txt], looking for [$PROJECT_NAME].${DEFAULT}"
-    exit
-  fi
-
-  echo -e "${GREEN}${LIB}: Updating source code${DEFAULT}"
-  for ((j = 0; j < "${#LIBRARIES[@]}"; j++)); do
-
-    DEP_LIB=${LIBRARIES[$j]#"ign-"}
-    DEP_VER=${VERSIONS[$j]}
-    DEP_PREV_VER="$((${DEP_VER}-1))"
-
-    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
-
-    # Replace collection yaml branch names with main
-    if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then
-      find . -type f -name "collection-${COLLECTION}.yaml" -print0 | xargs -0 sed -i "s ign-${DEP_LIB}${DEP_VER} main g"
-    fi
-
-    # Second run with _ instead of -, to support multiple variations of fuel-tools
-    DEP_LIB=${DEP_LIB//-/_}
-    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
-  done
-
-  commitAndPR ${ORG} main
-
-  ##################
   # release repo
   ##################
 
@@ -468,6 +429,45 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   done
 
   commitAndPR ${TOOLING_ORG} master
+
+  ##################
+  # source code
+  ##################
+
+  echo -e "${GREEN}${LIB}: source code${DEFAULT}"
+
+  cloneIfNeeded ${ORG} ${LIB}
+  startFromCleanBranch ${BUMP_BRANCH} main
+
+  # Check if main branch of that library is the correct version
+  PROJECT_NAME="${LIB_}${VER}"
+  PROJECT_NAME="${PROJECT_NAME/ign_/ignition-}"
+  PROJECT="project.*(${PROJECT_NAME}"
+  if ! grep -q ${PROJECT} "CMakeLists.txt"; then
+    echo -e "${RED}Wrong project name on [CMakeLists.txt], looking for [$PROJECT_NAME].${DEFAULT}"
+    exit
+  fi
+
+  echo -e "${GREEN}${LIB}: Updating source code${DEFAULT}"
+  for ((j = 0; j < "${#LIBRARIES[@]}"; j++)); do
+
+    DEP_LIB=${LIBRARIES[$j]#"ign-"}
+    DEP_VER=${VERSIONS[$j]}
+    DEP_PREV_VER="$((${DEP_VER}-1))"
+
+    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
+
+    # Replace collection yaml branch names with main
+    if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then
+      find . -type f -name "collection-${COLLECTION}.yaml" -print0 | xargs -0 sed -i "s ign-${DEP_LIB}${DEP_VER} main g"
+    fi
+
+    # Second run with _ instead of -, to support multiple variations of fuel-tools
+    DEP_LIB=${DEP_LIB//-/_}
+    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
+  done
+
+  commitAndPR ${ORG} main
 
   # Collection ends here
   if ! [[ $VER == ?(-)+([0-9]) ]] ; then

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -181,7 +181,7 @@ commitAndPR() {
 
   # Sanity check that we're on a bump branch already
   local CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  if [[ ! $CURRENT_BRANCH = bump_* ]]
+  if [[ ! $CURRENT_BRANCH =~ bump_* ]]
   then
     echo -e "${RED}${REPO}: Something's wrong, trying to commit to branch ${CURRENT_BRANCH}.${DEFAULT}"
     return


### PR DESCRIPTION
This updates the `bump_dependency.bash` script to prefix branch names with `ci_matching_branch/` so that CI should automatically use the matching branch in infrastructure repositories. I'm using this branch with #554, and branch matching currently works for `homebrew-simulation`, so I would expect the homebrew builds to work properly.

The following changes support the matching branch names:

* https://github.com/ignition-tooling/release-tools/commit/861c0229633177b970837a67e0ebf6c68d64a839: use consistent branch names with `ci_matching_branch/` prefix
* https://github.com/ignition-tooling/release-tools/commit/7a0f7369d79d8a2a8efdd87e3a3c7c103f2cc62b: fix sanity check of branch names, which was hard-coded to expect that the names start with `bump_`

The following fixes a bug in fuel-tools branch name replacement:

* https://github.com/ignition-tooling/release-tools/commit/efce3f61afb147e01ec75f09b18e4c5cda717143: reorder the `-` for `_` substitution in the search/replace for collection repositories since it didn't replace `ign-fuel-tools8` with `main` properly

I've also re-ordered the pull requests so that metadata pull requests should be opened first. I think the CI jobs will be more likely to pass with this approach.