### PR TITLE
Fix _ handling in bump_dependency for formula

### DIFF
--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -371,7 +371,7 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
 
   # libN
   sed -i -E "s ((${LIB#"ign-"}))${PREV_VER} \1${VER} g" $FORMULA
-  sed -i -E "s ((${LIB_#"ign-"}))${PREV_VER} \1${VER} g" $FORMULA
+  sed -i -E "s ((${LIB_#"ign_"}))${PREV_VER} \1${VER} g" $FORMULA
   # ign-libN -> main
   sed -i "s ${LIB}${PREV_VER} main g" $FORMULA
   # class IgnitionLibN


### PR DESCRIPTION
There were some errors in osrf/homebrew-simulation#1704 with `fuel_tools` not properly recognized by the regex. I re-ran with this branch to generate https://github.com/osrf/homebrew-simulation/pull/1704/commits/f31f88251caf8aeeac1c0ffbd99069a9441f3095.