### PR TITLE
Fix build/ cleanup in colcon Windows build

### DIFF
--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -66,7 +66,7 @@ call %win_lib% :configure_msvc2019_compiler
 echo # END SECTION
 
 echo # BEGIN SECTION: setup workspace
-if defined KEEP_WORKSPACE (
+if not defined KEEP_WORKSPACE (
   IF exist %LOCAL_WS_BUILD% (
     echo # BEGIN SECTION: preclean workspace
     rmdir /s /q %LOCAL_WS_BUILD% || goto :error


### PR DESCRIPTION
Somehow one of the colcon windows build for ign-gazebo failed with problems on the build/ directory https://github.com/ignitionrobotics/ign-gazebo/pull/1246#issuecomment-993714643. 

I think that our check for `KEEP_WORKSPACE` flag is wrong and is not cleaning up the workspaces as expected.