### PR TITLE
release.py: only use arm* nodes for arm* builds

### DIFF
--- a/release.py
+++ b/release.py
@@ -616,7 +616,7 @@ def go(argv):
                         continue
                     # Need to use JENKINS_NODE_TAG parameter for large memory nodes
                     # since it runs qemu emulation
-                    linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a + '|| large-memory'
+                    linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a
                 elif ('ignition-physics' in args.package_alias):
                     linux_platform_params['JENKINS_NODE_TAG'] = 'large-memory'
 


### PR DESCRIPTION
We currently always have an arm node in our buildfarm, and sometimes arm builds fail in qemu ( https://github.com/ignitionrobotics/ign-rendering/issues/212 ), so update the docker node label tag to only use arm agents for arm builds.