### PR TITLE
sdformat.dsl: re-enable sdf10 until release

### DIFF
--- a/jenkins-scripts/dsl/sdformat.dsl
+++ b/jenkins-scripts/dsl/sdformat.dsl
@@ -1,7 +1,7 @@
 import _configs_.*
 import javaposse.jobdsl.dsl.Job
 
-def sdformat_supported_branches = [ 'sdformat6' , 'sdformat9', 'sdformat11', 'sdformat12' ]
+def sdformat_supported_branches = [ 'sdformat6' , 'sdformat9', 'sdformat10', 'sdformat11', 'sdformat12' ]
 def sdformat_gz11_branches = [ 'sdformat9', 'sdformat10', 'sdformat11', 'sdformat12', 'main' ]
 // nightly and prereleases
 def extra_sdformat_debbuilder = [ ]


### PR DESCRIPTION
We have not yet made the final release of libsdformat10, so re-enable it as a supported branch to allow ABI-checker CI jobs. Needed by https://github.com/ignitionrobotics/sdformat/pull/800. Part of https://github.com/ignition-tooling/release-tools/issues/600