### PR TITLE
Clean the whole workspace in -debbuild jobs

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
@@ -23,7 +23,6 @@ class OSRFLinuxBuildPkgBase
 
        wrappers {
          preBuildCleanup {
-           includePattern('pkgs/*')
            // the sudo does not seems to be able to remove root owned packaged
            deleteCommand('sudo rm -rf %s')
          }


### PR DESCRIPTION
There are problems with non cleaning up the whole workspace on -debbuild jobs.

Reported by @scpeters:

 * https://build.osrfoundation.org/job/sdformat10-debbuilder/245/ is good
 * https://build.osrfoundation.org/job/sdformat10-debbuilder/246/  is failing

The reason for the failure is the lack of liburdfdom-dev installed in the system. Problem is the `SOURCE_DEFINED_DEPS` variable. Bionic seems not to find anything:

```
+++ DEPENDENCIES_PATH_TO_SEARCH=.
++++ tr '\n' ' '
+++++ find . -iname packages-bionic.apt -o -iname packages.apt
+++++ grep -v '/\.git/'
++++ sort -u
+++ SOURCE_DEFINED_DEPS=
```

Focal find a build/ directory with a packages.apt file:

```
+++ DEPENDENCIES_PATH_TO_SEARCH=.
++++ tr '\n' ' '
+++++ find . -iname packages-focal.apt -o -iname packages.apt
+++++ grep -v '/\.git/'
++++ sort -u ./build/sdformat-10.7.0~pre1/.github/ci/packages.apt
+++ SOURCE_DEFINED_DEPS='libignition-cmake2-dev libignition-math6-dev libignition-tools-dev libtinyxml2-dev liburdfdom-dev libxml2-utils python3-psutil ruby-dev '
```

I think that the problem comes from the fact of not clearing the workspace before/after-last-build so the focal one found something while the bionic one seems to have been run in a clean environment and did not find the packages.apt in the build dir from another build. This PR removes the clean up pattern to make it affect to the whole wokspace directory.