### PR TITLE
detect_ci_matching_branch: support python < 3.6

### DIFF
--- a/jenkins-scripts/tools/detect_ci_matching_branch.py
+++ b/jenkins-scripts/tools/detect_ci_matching_branch.py
@@ -11,6 +11,6 @@ branchName = sys.argv[1]
 pattern = 'ci_matching_branch/'
 match = re.search(pattern, branchName)
 if match:
-    print(f"{branchName} matches {pattern}")
+    print(branchName, "matches", pattern)
 else:
     sys.exit("{} does not match {}".format(branchName, pattern))


### PR DESCRIPTION
This has been failing on some of our CI runs, such as [this](https://build.osrfoundation.org/job/ignition_common-ci-pr_any-ubuntu_auto-amd64/1015/console)

```
+++ python3 ./scripts/jenkins-scripts/docker/../tools/detect_ci_matching_branch.py ci_matching_branch/bump_garden_ign-common5
  File "./scripts/jenkins-scripts/docker/../tools/detect_ci_matching_branch.py", line 14
    print(f"{branchName} matches {pattern}")
                                          ^
SyntaxError: invalid syntax
```

This may be fixed when we migrate to Focal (#565), but until then, we can just use a backwards-compatible syntax