### PR TITLE
Move "enable nightlies" task from bump libraries to post-release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bump_libraries.md
+++ b/.github/ISSUE_TEMPLATE/bump_libraries.md
@@ -30,7 +30,6 @@ Libraries being bumped:
     - [ ] Release repositories of all downstream libraries ([example](https://github.com/ignition-release/ign-fuel-tools7-release/pull/1))
     - [ ] Use `main` branch on `gazebodistro` ([example](https://github.com/ignition-tooling/gazebodistro/pull/42))
     - [ ] Build nightlies from the `main` branch ([example](https://github.com/ignition-tooling/release-tools/pull/437))
-    - [ ] Update gzdev to use nightlies on CI ([example](https://github.com/ignition-tooling/gzdev/pull/31))
     - [ ] homebrew-simulation: create formula and update dependencies ([example](https://github.com/osrf/homebrew-simulation/pull/14230))
     - [ ] docs (the collection’s page) ([example](https://github.com/ignitionrobotics/docs/pull/175))
 * <!-- Add more libraries here and copy the checklist for each of them -->

--- a/.github/ISSUE_TEMPLATE/release_collection.md
+++ b/.github/ISSUE_TEMPLATE/release_collection.md
@@ -56,7 +56,7 @@ When opening PRs, add a link back to this issue for easier tracking.
     - [ ] Add files to `gazebodistro` ([example](https://github.com/ignition-tooling/gazebodistro/pull/12))
     - [ ] Add aliases to `homebrew-simulation` ([example](https://github.com/osrf/homebrew-simulation/commit/1f8602af6f52e06e0542eebfbdbe97f5f6cf950c))
     - [ ] Create new `-release` repositories (use [this script](https://github.com/ignition-tooling/release-tools/blob/master/release-repo-scripts/new_ignition_release_repos.bash))
-
+    - [ ] Enable nightlies for all `main` branches on `gzdev` ([example](https://github.com/ignition-tooling/gzdev/pull/50))
 
 If the collection will be officially paired with a ROS 2 distro:
 


### PR DESCRIPTION
* Goes with https://github.com/ignition-tooling/gzdev/pull/50#issue-1090637906, see that issue for the reasoning