### PR TITLE
Fix checking for ci_matching_branch on windows

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -149,7 +149,8 @@ git clone https://github.com/ignition-tooling/gazebodistro %gzdistro_dir% -b %GA
 :: Check if ci_matching_branch name is used
 if "%ghprbSourceBranch%" == "" (echo ghprbSourceBranch is unset) else (
   python "%SCRIPT_DIR%\tools\detect_ci_matching_branch.py" "%ghprbSourceBranch%"
-  :: if error code is less than 1
+  :: "if ERRORLEVEL N" tests for ">= N"
+  :: To test for error code == 0, use !(error >= 1)
   if NOT ERRORLEVEL 1 (
     echo trying to checkout branch %ghprbSourceBranch% from gazebodistro
     git -C %gzdistro_dir% fetch origin %ghprbSourceBranch% || rem

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -149,7 +149,8 @@ git clone https://github.com/ignition-tooling/gazebodistro %gzdistro_dir% -b %GA
 :: Check if ci_matching_branch name is used
 if "%ghprbSourceBranch%" == "" (echo ghprbSourceBranch is unset) else (
   python "%SCRIPT_DIR%\tools\detect_ci_matching_branch.py" "%ghprbSourceBranch%"
-  if "%ERRORLEVEL%" == "0" (
+  :: if error code is less than 1
+  if NOT ERRORLEVEL 1 (
     echo trying to checkout branch %ghprbSourceBranch% from gazebodistro
     git -C %gzdistro_dir% fetch origin %ghprbSourceBranch% || rem
     git -C %gzdistro_dir% checkout %ghprbSourceBranch% || rem

--- a/jenkins-scripts/tools/detect_ci_matching_branch.py
+++ b/jenkins-scripts/tools/detect_ci_matching_branch.py
@@ -5,7 +5,7 @@ import sys
 
 if len(sys.argv) != 2:
     print('need to specify branch name', file=sys.stderr)
-    exit()
+    sys.exit(1)
 branchName = sys.argv[1]
 
 pattern = 'ci_matching_branch/'
@@ -13,4 +13,5 @@ match = re.search(pattern, branchName)
 if match:
     print(branchName, "matches", pattern)
 else:
-    sys.exit("{} does not match {}".format(branchName, pattern))
+    print("{} does not match {}".format(branchName, pattern))
+    sys.exit(1)


### PR DESCRIPTION
I noticed in the [ign_gazebo-pr-win/3576](https://build.osrfoundation.org/job/ign_gazebo-pr-win/3576/) build that `detect_ci_matching_branch.py` printed `chapulina/7/triggered does not match ci_matching_branch/`, but it still tried to checkout `chapulina/7/triggered` from `gazebodistro`. This is caused by a syntax problem when checking the `ERRORLEVEL` in `windows_library.bat`. This fixes it by explicitly setting error codes in `detect_ci_matching_branch.py`
and fixes the syntax for checking `ERRORLEVEL` in `windows_library.bat` since `ERRORLEVEL` evaluates to true if the error number is `>=` the number specified (see [documentation](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/if)).

## Testing pull request with non-matching branch name

Testing with https://github.com/ignitionrobotics/ign-utils/pull/34

### Using master it incorrectly tries to checkout a matching `gazebodistro` branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_utils-pr-win&build=78)](https://build.osrfoundation.org/job/ign_utils-pr-win/78/) https://build.osrfoundation.org/job/ign_utils-pr-win/78/

~~~
Cloning into 'gazebodistro'...
scpeters/test_branch does not match ci_matching_branch/
trying to checkout branch scpeters/test_branch from gazebodistro
fatal: couldn't find remote ref scpeters/test_branch
error: pathspec 'scpeters/test_branch' did not match any file(s) known to git
* master
~~~

### Using this branch it correctly doesn't try to checkout a matching branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_utils-pr-win&build=81)](https://build.osrfoundation.org/job/ign_utils-pr-win/81/) https://build.osrfoundation.org/job/ign_utils-pr-win/81/

~~~
Cloning into 'gazebodistro'...
scpeters/test_branch does not match ci_matching_branch/
branch name scpeters/test_branch is not a match
* master
~~~
