### PR TITLE
Remove IGN_PHYSICS_DEPENDENCIES variable

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -521,23 +521,6 @@ elif [[ -n "${IGN_GUI_MAJOR_VERSION}" && ${IGN_GUI_MAJOR_VERSION} -eq 3 ]]; then
                         libignition-transport8-dev"
 fi
 
-IGN_PHYSICS_DEPENDENCIES="libbenchmark-dev \\
-                          dart6-data \\
-                          libdart6-collision-ode-dev \\
-                          libdart6-dev \\
-                          libdart6-utils-urdf-dev \\
-                          libignition-cmake2-dev \\
-                          libignition-common3-dev \\
-                          libignition-math6-dev \\
-                          libignition-math6-eigen3-dev \\
-                          libignition-plugin-dev"
-if [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -ge 3 ]]; then
-  IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
-                            libsdformat10-dev"
-elif [[ -n "${IGN_PHYSICS_MAJOR_VERSION}" && ${IGN_PHYSICS_MAJOR_VERSION} -eq 2 ]]; then
-  IGN_PHYSICS_DEPENDENCIES="${IGN_PHYSICS_DEPENDENCIES} \\
-                            libsdformat9-dev"
-fi
 IGN_PHYSICS_DART_FROM_PKGS="true"
 
 IGN_PLUGIN_DEPENDENCIES="libignition-cmake2-dev"


### PR DESCRIPTION
The dependencies are already properly defined in the
packages.apt files in the ign-physics repository.
The IGN_PHYSICS_DEPENDENCIES variable in
dependencies_archive.sh is incorrect, and we'd be
better off without it.

Focal builds are broken: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics5-focal-amd64&build=1)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics5-focal-amd64/1/) https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics5-focal-amd64/1/

Testing with this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics-ci-ign-physics5-focal-amd64&build=2)](https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics5-focal-amd64/2/) https://build.osrfoundation.org/job/ignition_physics-ci-ign-physics5-focal-amd64/2/