### PR TITLE
Fix failure to clone abi-compliance-checker

### DIFF
--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -54,7 +54,7 @@ fi
 echo '# BEGIN SECTION: compile and install branch: ${DEST_BRANCH}'
 cp -a $WORKSPACE/${ABI_JOB_SOFTWARE_NAME} /tmp/${ABI_JOB_SOFTWARE_NAME}
 cd /tmp/${ABI_JOB_SOFTWARE_NAME}
-git fetch origin 
+git fetch origin
 git checkout origin/${DEST_BRANCH}
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
 rm -rf $WORKSPACE/build
@@ -94,7 +94,7 @@ echo '# BEGIN SECTION: install the ABI checker'
 # Install abi-compliance-checker.git
 cd $WORKSPACE
 rm -fr $WORKSPACE/abi-compliance-checker
-git clone git://github.com/lvc/abi-compliance-checker.git
+git clone https://github.com/lvc/abi-compliance-checker
 cd abi-compliance-checker
 sudo perl Makefile.pl -install --prefix=/usr
 


### PR DESCRIPTION
Fixes this issue:

```
+ git clone git://github.com/lvc/abi-compliance-checker.git
Cloning into 'abi-compliance-checker'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

See build failure here:

https://build.osrfoundation.org/job/ignition_fuel-tools-abichecker-any_to_any-ubuntu_auto-amd64/380/consoleFull#console-section-8
