### PR TITLE
Skip pxr for sdformat

### DIFF
--- a/jenkins-scripts/docker/sdformat-compilation.bash
+++ b/jenkins-scripts/docker/sdformat-compilation.bash
@@ -24,6 +24,8 @@ fi
 
 export GZDEV_PROJECT_NAME="sdformat${SDFORMAT_MAJOR_VERSION}"
 
+export BUILDING_EXTRA_CMAKE_PARAMS="-DSKIP_usd=true"
+
 # master and major branches compilations
 export BUILDING_PKG_DEPENDENCIES_VAR_NAME="SDFORMAT_BASE_DEPENDENCIES"
 


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

We are getting this warning in the CI, because we don't have `pxr` binaries available yet. This PR should remove this warning

```
CMake Warning at /usr/share/cmake/ignition-cmake2/cmake2/IgnConfigureBuild.cmake:55 (message):
   CONFIGURATION WARNINGS:
   -- Skipping component [usd]: Missing dependency [pxr].
      ^~~~~ Set SKIP_usd=true in cmake to suppress this warning.
   
Call Stack (most recent call first):
  CMakeLists.txt:121 (ign_configure_build)
```