### PR TITLE
Ignore brew doctor warnings for proj@7

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -168,10 +168,10 @@ echo '# END SECTION'
 
 echo "#BEGIN SECTION: brew doctor analysis"
 brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
-# if sdl installed, skip brew doctor
-# remove this line when open-scene-graph stops depending on sdl
-# https://github.com/Homebrew/homebrew-core/pull/81101
-brew list | grep '^sdl$' || brew doctor
+# if proj@7 installed, skip brew doctor
+# remove this line when gdal stops depending on a deprecated version of proj
+# https://github.com/Homebrew/homebrew-core/issues/82441
+brew list | grep '^proj@7$' || brew doctor
 echo '# END SECTION'
 
 # CHECK PRE_TESTS_EXECUTION_HOOK AND RUN


### PR DESCRIPTION
Needed by osrf/homebrew-simulation#1790, https://github.com/ignitionrobotics/ign-common/pull/290

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_common-ci-pr_any-homebrew-amd64&build=1271)](https://build.osrfoundation.org/job/ignition_common-ci-pr_any-homebrew-amd64/1271/) https://build.osrfoundation.org/job/ignition_common-ci-pr_any-homebrew-amd64/1271/

~~~
+ echo '#BEGIN SECTION: brew doctor analysis'
#BEGIN SECTION: brew doctor analysis
+ brew missing
+ brew missing
+ brew list
+ grep '^sdl$'
+ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Some installed formulae are deprecated or disabled.
You should find replacements for the following formulae:
  proj@7
~~~