### PR TITLE
brew doctor: unstable instead of fail, ignore proj@7 warnings

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -54,7 +54,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 # Run brew config to print system information
 brew config
 # Run brew doctor to check for problems with the system
-brew doctor
+brew doctor || echo MARK_AS_UNSTABLE
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: setup the osrf/simulation tap'
@@ -171,7 +171,7 @@ brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
 # if proj@7 installed, skip brew doctor
 # remove this line when gdal stops depending on a deprecated version of proj
 # https://github.com/Homebrew/homebrew-core/issues/82441
-brew list | grep '^proj@7$' || brew doctor
+brew list | grep '^proj@7$' || brew doctor || echo MARK_AS_UNSTABLE
 echo '# END SECTION'
 
 # CHECK PRE_TESTS_EXECUTION_HOOK AND RUN

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -73,10 +73,10 @@ echo '# END SECTION'
 
 echo "#BEGIN SECTION: brew doctor analysis"
 brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
-# if sdl installed, skip brew doctor
-# remove this line when open-scene-graph stops depending on sdl
-# https://github.com/Homebrew/homebrew-core/pull/81101
-brew list | grep '^sdl$' || brew doctor
+# if proj@7 installed, skip brew doctor
+# remove this line when gdal stops depending on a deprecated version of proj
+# https://github.com/Homebrew/homebrew-core/issues/82441
+brew list | grep '^proj@7$' || brew doctor
 echo '# END SECTION'
 
 echo "# BEGIN SECTION: re-add group write permissions"

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -38,7 +38,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 # Run brew config to print system information
 brew config
 # Run brew doctor to check for problems with the system
-brew doctor
+brew doctor || echo MARK_AS_UNSTABLE
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: setup the osrf/simulation tap'
@@ -76,7 +76,7 @@ brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
 # if proj@7 installed, skip brew doctor
 # remove this line when gdal stops depending on a deprecated version of proj
 # https://github.com/Homebrew/homebrew-core/issues/82441
-brew list | grep '^proj@7$' || brew doctor
+brew list | grep '^proj@7$' || brew doctor || echo MARK_AS_UNSTABLE
 echo '# END SECTION'
 
 echo "# BEGIN SECTION: re-add group write permissions"


### PR DESCRIPTION
Repeat of #626 for install_bottle jobs.

Needed to fix the following:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_garden-install_bottle-homebrew-amd64&build=72)](https://build.osrfoundation.org/job/ignition_garden-install_bottle-homebrew-amd64/72/) https://build.osrfoundation.org/job/ignition_garden-install_bottle-homebrew-amd64/72/

~~~
#BEGIN SECTION: brew doctor analysis
+ brew missing
+ brew missing
+ brew list
+ grep '^sdl$'
+ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Some installed formulae are deprecated or disabled.
You should find replacements for the following formulae:
  proj@7
Build step 'Execute shell' marked build as failure
~~~