### PR TITLE
Try refreshing github key if auth failed for brew

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -16,10 +16,16 @@ echo '# BEGIN SECTION: check github perms'
 # Github autentication. git access is provided by public key access
 # and hub cli needs a token
 if [[ -z $(ssh -T git@github.com 2>&1 | grep successfully) ]]; then
-    echo "The github connection seems not to be valid:"
-    ssh -T git@github.com
-    echo "Please check that the ssh key authentication is working"
-    exit 1
+    # ssh key in github may have changed, let's try to remove and get
+    # the latest one
+    ssh-keygen -R github.com
+    ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+    if [[ -z $(ssh -T git@github.com 2>&1 | grep successfully) ]]; then
+      echo "The github connection seems not to be valid:"
+      ssh -T git@github.com
+      echo "Please check that the ssh key authentication is working"
+      exit 1
+    fi
 fi
 
 GITHUB_TOKEN_FILE="/var/lib/jenkins/.github_token"


### PR DESCRIPTION
Problem happened here https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1079 with the error:
```
+++ ssh -T git@github.com
+++ grep successfully
++ [[ -z '' ]]
++ echo 'The github connection seems not to be valid:'
The github connection seems not to be valid:
++ ssh -T git@github.com
Host key verification failed.
Build step 'Execute shell' marked build as failure
```
Running the same command manually in the server displays the real error:
```
jenkins@ip-172-30-1-10:~$ ssh -T git@github.com
Warning: the ECDSA host key for 'github.com' differs from the key for the IP address '192.30.255.112'
Offending key for IP in /var/lib/jenkins/.ssh/known_hosts:5
Matching host key in /var/lib/jenkins/.ssh/known_hosts:11
Are you sure you want to continue connecting (yes/no)? yes
```
Seems to me like github have changed the key or the IP which makes ssh to fail. This PR tries to remove previous configuration if failed and get a new one.

