### PR TITLE
Don't use HOMEBREW_UPDATE_TO_TAG for now

### DIFF
--- a/jenkins-scripts/lib/_homebrew_base_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_base_setup.bash
@@ -15,7 +15,9 @@ else
 fi
 
 git -C $(${BREW_BINARY} --repo) fsck
-export HOMEBREW_UPDATE_TO_TAG=1
+# don't use HOMEBREW_UPDATE_TO_TAG until brew 3.3.13 is released
+# due to https://github.com/Homebrew/brew/issues/12788
+unset HOMEBREW_UPDATE_TO_TAG
 ${BREW_BINARY} update
 # manually exclude a ruby warning that jenkins thinks is from clang
 # https://github.com/osrf/homebrew-simulation/issues/1343


### PR DESCRIPTION
There is an unreleased fix for a brew doctor bug (https://github.com/Homebrew/brew/issues/12788), so stop using `HOMEBREW_UPDATE_TO_TAG` for now.