### PR TITLE
Define SKIP_usd only for sdformat version 12 and higher

### DIFF
--- a/jenkins-scripts/docker/sdformat-compilation.bash
+++ b/jenkins-scripts/docker/sdformat-compilation.bash
@@ -24,7 +24,9 @@ fi
 
 export GZDEV_PROJECT_NAME="sdformat${SDFORMAT_MAJOR_VERSION}"
 
-export BUILDING_EXTRA_CMAKE_PARAMS="-DSKIP_usd=true"
+if [[ ${SDFORMAT_MAJOR_VERSION} -ge 12 ]]; then
+  export BUILDING_EXTRA_CMAKE_PARAMS="-DSKIP_usd=true"
+fi
 
 # master and major branches compilations
 export BUILDING_PKG_DEPENDENCIES_VAR_NAME="SDFORMAT_BASE_DEPENDENCIES"


### PR DESCRIPTION
This to eliminate warnings in CI for sdformat11 and earlier.