### PR TITLE
Only set SKIP_usd for libsdformat 12+

### DIFF
--- a/jenkins-scripts/docker/sdformat-compilation.bash
+++ b/jenkins-scripts/docker/sdformat-compilation.bash
@@ -24,7 +24,9 @@ fi
 
 export GZDEV_PROJECT_NAME="sdformat${SDFORMAT_MAJOR_VERSION}"
 
-export BUILDING_EXTRA_CMAKE_PARAMS="-DSKIP_usd=true"
+if [[ ${SDFORMAT_MAJOR_VERSION} -ge 12 ]]; then
+  export BUILDING_EXTRA_CMAKE_PARAMS="-DSKIP_usd=true"
+fi
 
 # master and major branches compilations
 export BUILDING_PKG_DEPENDENCIES_VAR_NAME="SDFORMAT_BASE_DEPENDENCIES"


### PR DESCRIPTION
Follow-up to https://github.com/ignition-tooling/release-tools/pull/625.

Without this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat11-focal-amd64&build=5)](https://build.osrfoundation.org/view/ign-edifice/job/sdformat-ci-sdformat11-focal-amd64/5/) https://build.osrfoundation.org/view/ign-edifice/job/sdformat-ci-sdformat11-focal-amd64/5

With this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat11-focal-amd64&build=6)](https://build.osrfoundation.org/view/ign-edifice/job/sdformat-ci-sdformat11-focal-amd64/6/) https://build.osrfoundation.org/view/ign-edifice/job/sdformat-ci-sdformat11-focal-amd64/6