### PR TITLE
Use custom apt command to avoid problems in noninteractive

### DIFF
--- a/jenkins-scripts/docker/lib/_common_scripts.bash
+++ b/jenkins-scripts/docker/lib/_common_scripts.bash
@@ -1,0 +1,1 @@
+export APT_INSTALL="sudo DEBIAN_FRONTEND=noninteractive apt-get install -y"

--- a/jenkins-scripts/docker/lib/generic-install-base.bash
+++ b/jenkins-scripts/docker/lib/generic-install-base.bash
@@ -5,6 +5,7 @@ echo '# BEGIN SECTION: setup the testing enviroment'
 # Define the name to be used in docker
 DOCKER_JOB_NAME="install_job"
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.sh
 echo '# END SECTION'
 
 cat > build.sh << DELIM
@@ -24,7 +25,7 @@ fi
 if [ `expr length "${INSTALL_JOB_PKG} "` -gt 1 ]; then
 echo "# BEGIN SECTION: try to install package: ${INSTALL_JOB_PKG}"
 sudo apt-get update
-sudo apt-get install -y ${INSTALL_JOB_PKG}
+${APT_INSTALL} ${INSTALL_JOB_PKG}
 echo '# END SECTION'
 fi
 

--- a/jenkins-scripts/docker/lib/generic-install-base.bash
+++ b/jenkins-scripts/docker/lib/generic-install-base.bash
@@ -5,7 +5,7 @@ echo '# BEGIN SECTION: setup the testing enviroment'
 # Define the name to be used in docker
 DOCKER_JOB_NAME="install_job"
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
-. ${SCRIPT_DIR}/lib/_common_scripts.sh
+. ${SCRIPT_DIR}/lib/_common_scripts.bash
 echo '# END SECTION'
 
 cat > build.sh << DELIM


### PR DESCRIPTION
Something in our focal -install- jobs has changed and it is pulling `keyboard-configuration` package into the list of packages to be installed. That requires of user interaction unless we configure the system not to do it.

Failing build: https://build.osrfoundation.org/job/ignition_gazebo6-install-pkg-focal-amd64/15/console

We are using `ARG DEBIAN_FRONTEND=noninteractive` in our Docker images but that variable is not present when we invoke a a command with `sudo`. The PR adds a new variable to encapsulate the `noninteractive` configuration.

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo6-install-pkg-focal-amd64&build=14)](https://build.osrfoundation.org/job/ignition_gazebo6-install-pkg-focal-amd64/14/)