### PR TITLE
Revert "Don't use HOMEBREW_UPDATE_TO_TAG for now (#629)"

### DIFF
--- a/jenkins-scripts/lib/_homebrew_base_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_base_setup.bash
@@ -15,9 +15,7 @@ else
 fi
 
 git -C $(${BREW_BINARY} --repo) fsck
-# don't use HOMEBREW_UPDATE_TO_TAG until brew 3.3.13 is released
-# due to https://github.com/Homebrew/brew/issues/12788
-unset HOMEBREW_UPDATE_TO_TAG
+export HOMEBREW_UPDATE_TO_TAG=1
 ${BREW_BINARY} update
 # manually exclude a ruby warning that jenkins thinks is from clang
 # https://github.com/osrf/homebrew-simulation/issues/1343


### PR DESCRIPTION
This reverts commit 6370d9882faeb8615c9ff5590e33948e170b29dd (#629).
It is no longer needed since brew 3.3.13 has been released.

Testing: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat12-install_bottle-homebrew-amd64&build=124)](https://build.osrfoundation.org/job/sdformat12-install_bottle-homebrew-amd64/124/) https://build.osrfoundation.org/job/sdformat12-install_bottle-homebrew-amd64/124/