### PR TITLE
brew: set PKG_CONFIG_PATH if using ffmpeg@4

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -130,6 +130,10 @@ fi
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'cmake@3.21.4' }.empty?"; then
   export PATH=/usr/local/opt/cmake@3.21.4/bin:${PATH}
 fi
+# Workaround for ffmpeg 4: set CMAKE_PREFIX_PATH and PKG_CONFIG_PATH if we are using ffmpeg@4
+if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'ffmpeg@4' }.empty?"; then
+  export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/opt/ffmpeg@4/lib/pkgconfig
+fi
 # Workaround for tbb@2020_u3: set CPATH, LIBRARY_PATH, and CMAKE_PREFIX_PATH
 if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name).keep_if { |d| d == 'tbb@2020_u3' }.empty?"; then
   export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:/usr/local/opt/tbb@2020_u3


### PR DESCRIPTION
Until we can update the ignition-common code to use the new ffmpeg 5 API, let's stick with using the `ffmpeg@4` formula in homebrew (https://github.com/osrf/homebrew-simulation/pull/1804). This is a keg-only formula, so we have to set `PKG_CONFIG_PATH` to point to the `ffmpeg@4` install prefix.

without this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_common-ci-ign-common1-homebrew-amd64&build=32)](https://build.osrfoundation.org/job/ignition_common-ci-ign-common1-homebrew-amd64/32/) https://build.osrfoundation.org/job/ignition_common-ci-ign-common1-homebrew-amd64/32/

with this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_common-ci-ign-common1-homebrew-amd64&build=33)](https://build.osrfoundation.org/job/ignition_common-ci-ign-common1-homebrew-amd64/33/) https://build.osrfoundation.org/job/ignition_common-ci-ign-common1-homebrew-amd64/33
