### PR TITLE
Use INVALIDATE_DOCKER_CACHE in nightly generation

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -7,6 +7,9 @@ if [ "${UPLOAD_TO_REPO}" = "nightly" ]; then
    # SOURCE_TARBALL_URI is reused in nightly mode to indicate the branch
    # to built nightly packages from
    NIGHTLY_SRC_BRANCH=${SOURCE_TARBALL_URI}
+   # There are many problem in the nightlies with package versions preventing
+   # the dependency solver to work properly. Set INVALIDATE_DOCKER_CACHE
+   export INVALIDATE_DOCKER_CACHE=true
 fi
 
 # Option to use $WORKSPACE/repo as container (git or hg) for the nightly source


### PR DESCRIPTION
There has been problems with recent nightlies that failed due to problems in the upgrade path of packages. Example: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-gazebo7-debbuilder&build=186)](https://build.osrfoundation.org/job/ign-gazebo7-debbuilder/186/)

The PR force the `INVALIDATE_DOCKER_CACHE` to run all the nightly builds without cache. Tested in the same node failing before, here: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-gazebo7-debbuilder&build=189)](https://build.osrfoundation.org/job/ign-gazebo7-debbuilder/189/)