### PR TITLE
Use autopkgtest (debian testing mechanism) in debbuild runs

### DIFF
--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -52,5 +52,4 @@ fi
 set -e
 echo '# END SECTION'
 fi
-fi
 """

--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -39,9 +39,12 @@ echo '# END SECTION'
 
 DEBBUILD_AUTOPKGTEST="""
 if $RUN_AUTOPKGTEST; then
-echo '# BEGIN SECTION: run tests'
+echo '# BEGIN SECTION: run autopkgtest'
 cd $WORKSPACE/pkgs
 set +e
+ls -lasR
+ls *.deb
+PKGS=\$(find . -name *.deb)
 autopkgtest -B *.deb *.dsc -- null
 # autopkgtest will return 0 if there are successful tests and 8 if there are no tests
 testret=\$?

--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -42,7 +42,7 @@ if $RUN_AUTOPKGTEST; then
 echo '# BEGIN SECTION: run autopkgtest'
 cd $WORKSPACE/pkgs
 set +e
-autopkgtest -B *.deb *.dsc -- null
+sudo autopkgtest -B *.deb *.dsc -- null
 # autopkgtest will return 0 if there are successful tests and 8 if there are no tests
 testret=\$?
 if [[ \$testret != 0 ]] && [[ \$testret != 8 ]]; then

--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -36,3 +36,21 @@ if [ \$DIFF -lt 180 ]; then
 fi
 echo '# END SECTION'
 """
+
+DEBBUILD_AUTOPKGTEST="""
+if $RUN_AUTOPKGTEST; then
+echo '# BEGIN SECTION: run tests'
+cd $WORKSPACE/pkgs
+set +e
+autopkgtest -B *.deb *.dsc -- null
+# autopkgtest will return 0 if there are successful tests and 8 if there are no tests
+testret=\$?
+if [[ \$testret != 0 ]] && [[ \$testret != 8 ]]; then
+  echo 'Problem in running autopkgtest: \$testret'
+  exit 1
+fi
+set -e
+echo '# END SECTION'
+fi
+fi
+"""

--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -42,9 +42,6 @@ if $RUN_AUTOPKGTEST; then
 echo '# BEGIN SECTION: run autopkgtest'
 cd $WORKSPACE/pkgs
 set +e
-ls -lasR
-ls *.deb
-PKGS=\$(find . -name *.deb)
 autopkgtest -B *.deb *.dsc -- null
 # autopkgtest will return 0 if there are successful tests and 8 if there are no tests
 testret=\$?

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -19,7 +19,12 @@ fi
 # testing jobs and seems to be slow at the end of jenkins jobs
 export ENABLE_REAPER=false
 
+# autopkgtest is a mechanism to test the installation of the generated packages
+# at the end of the package production.
+RUN_AUTOPKGTEST=${RUN_AUTOPKGTEST:-true}
+
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 cat > build.sh << DELIM
 ###################################################
@@ -230,6 +235,8 @@ fi
 echo '# BEGIN SECTION: create deb packages'
 debuild \${no_lintian_param} --no-tgz-check -uc -us --source-option=--include-binaries -j${MAKE_JOBS}
 echo '# END SECTION'
+
+${DEBBUILD_AUTOPKGTEST}
 
 echo '# BEGIN SECTION: export pkgs'
 PKGS=\`find .. -name '*.deb' || true\`

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -251,6 +251,7 @@ done
 test \$FOUND_PKG -eq 1 || exit 1
 echo '# END SECTION'
 
+cat /etc/apt/sources.list
 ${DEBBUILD_AUTOPKGTEST}
 DELIM
 

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -236,8 +236,6 @@ echo '# BEGIN SECTION: create deb packages'
 debuild \${no_lintian_param} --no-tgz-check -uc -us --source-option=--include-binaries -j${MAKE_JOBS}
 echo '# END SECTION'
 
-${DEBBUILD_AUTOPKGTEST}
-
 echo '# BEGIN SECTION: export pkgs'
 PKGS=\`find .. -name '*.deb' || true\`
 
@@ -252,6 +250,8 @@ done
 # check at least one upload
 test \$FOUND_PKG -eq 1 || exit 1
 echo '# END SECTION'
+
+${DEBBUILD_AUTOPKGTEST}
 DELIM
 
 OSRF_REPOS_TO_USE=${OSRF_REPOS_TO_USE:=stable}

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -256,13 +256,14 @@ DELIM
 
 OSRF_REPOS_TO_USE=${OSRF_REPOS_TO_USE:=stable}
 DEPENDENCY_PKGS="devscripts \
-		 ubuntu-dev-tools \
-		 debhelper \
-		 wget \
-		 ca-certificates \
-		 equivs \
-		 dh-make \
-		 git"
+                ubuntu-dev-tools \
+                debhelper \
+                wget \
+                ca-certificates \
+                equivs \
+                dh-make \
+                git \
+                autopkgtest"
 
 . ${SCRIPT_DIR}/lib/docker_generate_dockerfile.bash
 . ${SCRIPT_DIR}/lib/docker_run.bash

--- a/jenkins-scripts/docker/lib/debian-git-repo-base.bash
+++ b/jenkins-scripts/docker/lib/debian-git-repo-base.bash
@@ -5,6 +5,7 @@
 export ENABLE_REAPER=false
 
 . ${SCRIPT_DIR}/lib/boilerplate_prepare.sh
+. ${SCRIPT_DIR}/lib/_gazebo_utils.sh
 
 # The git plugin leaves a repository copy with a detached HEAD
 # state. gbp does not like it thus the need of using --git-ignore-branch
@@ -128,23 +129,7 @@ done
 test \$FOUND_PKG -eq 1 || exit 1
 echo '# END SECTION'
 
-if $RUN_AUTOPKGTEST; then
-# Ubuntu has no autopkgtest command in the autopkgtest package
-if [ "$LINUX_DISTRO" != "ubuntu" ]; then
-echo '# BEGIN SECTION: run tests'
-cd $WORKSPACE/pkgs
-set +e
-autopkgtest -B *.deb *.dsc -- null
-# autopkgtest will return 0 if there are successful tests and 8 if there are no tests
-testret=\$?
-if [[ \$testret != 0 ]] && [[ \$testret != 8 ]]; then
-  echo "Problem in running autopkgtest: \$testret"
-  exit 1
-fi
-set -e
-echo '# END SECTION'
-fi
-fi
+${DEBBUILD_AUTOPKGTEST}
 
 echo '# BEGIN SECTION: clean up git build'
 cd $REPO_PATH

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -156,14 +156,8 @@ fi
 if [[ ${LINUX_DISTRO} == 'ubuntu' ]]; then
   if [[ ${ARCH} != 'armhf' && ${ARCH} != 'arm64' ]]; then
 cat >> Dockerfile << DELIM_DOCKER_ARCH
-  # Note that main,restricted and universe are not here, only multiverse
-  # main, restricted and unvierse are already setup in the original image
-  RUN echo "deb ${SOURCE_LIST_URL} ${DISTRO} multiverse" \\
-                                                         >> /etc/apt/sources.list && \\
-      echo "deb ${SOURCE_LIST_URL} ${DISTRO}-updates main restricted universe multiverse" \\
-                                                         >> /etc/apt/sources.list && \\
-      echo "deb ${SOURCE_LIST_URL} ${DISTRO}-security main restricted universe multiverse" && \\
-                                                         >> /etc/apt/sources.list
+  RUN echo "deb ${SOURCE_LIST_URL} ${DISTRO}-security main restricted universe multiverse" && \\
+                                                     >> /etc/apt/sources.list
 DELIM_DOCKER_ARCH
   fi
 fi


### PR DESCRIPTION
The PR generalize the use of [autopkgtest](https://wiki.debian.org/ContinuousIntegration/autopkgtest) to be shared between the debian-git-repo and now with debbuild-base. autopkgtest basically supports CI for packages generated by defining the build and testing scripts in the debian metadata. See https://github.com/ignition-release/ign-cmake2-release/pull/2 for an example of it.

As a side change required, the cleanup of the `sources.list` file to avoid warnings that make autopkgtest to fail, here d31418ea0f300005a06cc5bdc563df43c6f74970.

Tested [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-cmake2-debbuilder&build=1317)](https://build.osrfoundation.org/job/ign-cmake2-debbuilder/1317/):
```
# BEGIN SECTION: run autopkgtest
+ cd /home/jenkins/workspace/ign-cmake2-debbuilder/pkgs
+ set +e
+ sudo autopkgtest -B libignition-cmake2-dev_2.10.0-1~jammy_amd64.deb ignition-cmake2_2.10.0-1~jammy.dsc -- null
[33mautopkgtest [17:00:23]: starting date: 2022-02-09
[0m[33mautopkgtest [17:00:23]: version 5.19
[0m[33mautopkgtest [17:00:23]: host 19ca3b6d0412; command line: /usr/bin/autopkgtest -B 'libignition-cmake2-dev_2.10.0-1~jammy_amd64.deb' 'ignition-cmake2_2.10.0-1~jammy.dsc' -- null
[0m[33mautopkgtest [17:00:23]: testbed dpkg architecture: amd64
[0m[33mautopkgtest [17:00:23]: testbed running kernel: Linux 5.4.0-80-generic #90-Ubuntu SMP Fri Jul 9 22:49:44 UTC 2021
[0m[33mautopkgtest [17:00:23]: @@@@@@@@@@@@@@@@@@@@ source ignition-cmake2_2.10.0-1~jammy.dsc
[0m[1mdpkg-source: [0m[1;33mwarning[0m: extracting unsigned source package (/tmp/autopkgtest.FsMoM9/ignition-cmake2_2.10.0-1~jammy.dsc)
[1mdpkg-source: [0m[32minfo[0m: extracting ignition-cmake2 in src
[1mdpkg-source: [0m[32minfo[0m: unpacking ignition-cmake2_2.10.0.orig.tar.bz2
[1mdpkg-source: [0m[32minfo[0m: unpacking ignition-cmake2_2.10.0-1~jammy.debian.tar.xz
[33mautopkgtest [17:00:23]: testing package ignition-cmake2 version 2.10.0-1~jammy
[0m[33mautopkgtest [17:00:23]: build not needed
[0m[33mautopkgtest [17:00:23]: test build: preparing testbed
[0mGet:1 file:/tmp/autopkgtest.FsMoM9/binaries  InRelease
Ign:1 file:/tmp/autopkgtest.FsMoM9/binaries  InRelease
Get:2 file:/tmp/autopkgtest.FsMoM9/binaries  Release [816 B]
Get:2 file:/tmp/autopkgtest.FsMoM9/binaries  Release [816 B]
Get:3 file:/tmp/autopkgtest.FsMoM9/binaries  Release.gpg
Ign:3 file:/tmp/autopkgtest.FsMoM9/binaries  Release.gpg
Get:4 file:/tmp/autopkgtest.FsMoM9/binaries  Packages [1,028 B]
Reading package lists...

Reading package lists... 0%

Reading package lists... 0%

Reading package lists... 0%

Reading package lists... 9%

Reading package lists... 9%

Reading package lists... 10%

Reading package lists... 10%

Reading package lists... 97%

Reading package lists... 97%

Reading package lists... 99%

Reading package lists... 99%

Reading package lists... 99%

Reading package lists... 99%

Reading package lists... Done


Building dependency tree... 0%

Building dependency tree... 0%

Building dependency tree... 50%

Building dependency tree... 50%

Building dependency tree... Done


Reading state information... 0% 

Reading state information... 0%

Reading state information... Done

Correcting dependencies...Starting pkgProblemResolver with broken count: 0
Starting 2 pkgProblemResolver with broken count: 0
Done
 Done
Starting pkgProblemResolver with broken count: 0
Starting 2 pkgProblemResolver with broken count: 0
Done
The following additional packages will be installed:
  libignition-cmake-dev
The following NEW packages will be installed:
  libignition-cmake-dev
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
1 not fully installed or removed.
Need to get 236 kB of archives.
After this operation, 2,301 kB of additional disk space will be used.

0% [Working]
            
Get:1 http://archive.ubuntu.com/ubuntu jammy/universe amd64 libignition-cmake-dev all 2.10.0-2 [236 kB]

1% [1 libignition-cmake-dev 2,613 B/236 kB 1%]
56% [1 libignition-cmake-dev 165 kB/236 kB 70%]
                                               
100% [Working]
              
Fetched 236 kB in 1s (269 kB/s)
Selecting previously unselected package libignition-cmake-dev.

(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 36224 files and directories currently installed.)

Preparing to unpack .../libignition-cmake-dev_2.10.0-2_all.deb ...

Unpacking libignition-cmake-dev (2.10.0-2) ...

Setting up libignition-cmake-dev (2.10.0-2) ...

Setting up autopkgtest-satdep (0) ...

(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 36426 files and directories currently installed.)
Removing autopkgtest-satdep (0) ...
[33mautopkgtest [17:00:28]: test build: [-----------------------
[0m-- The C compiler identification is GNU 11.2.0
-- The CXX compiler identification is GNU 11.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- test version 1.0.0
-- Operating system is Linux
-- Found CPack generators: DEB
-- 
-- Searching for host SSE information
-- SSE2 found
-- SSE3 found
-- SSE4.1 found
-- SSE4.2 found
-- Adding codecheck target
-- Build configuration successful
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/tmp.msprfT6t6l
configure: OK
[33mautopkgtest [17:00:30]: test build: -----------------------]
[0m[33mautopkgtest [17:00:31]: test build:  - - - - - - - - - - results - - - - - - - - - -
[0mbuild                PASS
[33mautopkgtest [17:00:31]: @@@@@@@@@@@@@@@@@@@@ summary
[0mbuild                PASS
[33mautopkgtest [17:00:31]: Binaries: resetting testbed apt configuration
[0mHit:1 http://packages.osrfoundation.org/gazebo/ubuntu-stable jammy InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:3 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists...
+ testret=0
+ [[ 0 != 0 ]]
+ set -e
+ echo '# END SECTION'
```