### PR TITLE
Be sure of not using gcc8 on jammy

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -193,7 +193,7 @@ fi
 # Be sure that a previous bug using g++8 compiler is not present anymore
 if [[ ${DISTRO} == 'jammy' ]]; then
  [[ \$(/usr/bin/gcc --version | grep 'gcc-8') ]] && ( echo "gcc-8 version found. A bug." ; exit 1 )
-else
+elif $NEED_C17_COMPILER; then
   echo '# BEGIN SECTION: install C++17 compiler'
   sudo apt-get install -y gcc-8 g++-8
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -190,12 +190,9 @@ g++ --version
 echo '# END SECTION'
 fi
 
-if $NEED_C17_COMPILER; then
-echo '# BEGIN SECTION: install C++17 compiler'
-sudo apt-get install -y gcc-8 g++-8
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
-g++ --version
-echo '# END SECTION'
+# Be sure that a previous bug using g++8 compiler is not present anymore
+if [[ ${DISTRO} == 'jammy' ]]; then
+ [[ \$(/usr/bin/gcc --version | grep 'gcc-8') ]] && ( echo "gcc-8 version found. A bug." ; exit 1 )
 fi
 
 echo '# BEGIN SECTION: create source package' \${OSRF_VERSION}

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -193,6 +193,12 @@ fi
 # Be sure that a previous bug using g++8 compiler is not present anymore
 if [[ ${DISTRO} == 'jammy' ]]; then
  [[ \$(/usr/bin/gcc --version | grep 'gcc-8') ]] && ( echo "gcc-8 version found. A bug." ; exit 1 )
+else
+  echo '# BEGIN SECTION: install C++17 compiler'
+  sudo apt-get install -y gcc-8 g++-8
+  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+  g++ --version
+  echo '# END SECTION'
 fi
 
 echo '# BEGIN SECTION: create source package' \${OSRF_VERSION}

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -305,7 +305,7 @@ DELIM_DOCKER31
 
 # Beware of moving this code since it needs to run update-alternative after
 # installing the default compiler in PACKAGES_CACHE_AND_CHECK_UPDATES
-if ${NEED_C17_COMPILER}; then
+if ${NEED_C17_COMPILER} && [[ ${DISTRO} != jammy ]]; then
 cat >> Dockerfile << DELIM_GCC8
    RUN apt-get update \\
    && apt-get install -y g++-8 \\


### PR DESCRIPTION
Part of the mitigation measure for the impact of https://github.com/ignition-tooling/release-tools/issues/639.
First, try to avoid the problem by all means on new Jammy releases that are being done these days.

Tested here: https://build.osrfoundation.org/job/ign-math6-debbuilder/1359/console