### PR TITLE
Use xz to compress .deb packages on jammy

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -206,7 +206,18 @@ if [[ ${DISTRO} == 'focal' && (${ARCH} == 'arm64' || ${ARCH} == 'armhf') ]]; the
   no_lintian_param="--no-lintian"
 fi
 
-debuild \${no_lintian_param} --no-tgz-check -uc -us -S --source-option=--include-binaries
+# our packages.o.o running xenial does not support default zstd compression of
+# .deb files in jammy. Keep using xz. Not a trivial change, requires wrapper over dpkg-deb
+if [[ ${DISTRO} == 'jammy' ]]; then
+  sudo bash -c 'echo \#\!/bin/bash > /usr/local/bin/dpkg-deb'
+  sudo bash -c 'echo "/usr/bin/dpkg-deb -Zxz \\\$@" >> /usr/local/bin/dpkg-deb'
+  sudo cat /usr/local/bin/dpkg-deb
+  sudo chmod +x /usr/local/bin/dpkg-deb
+  export PATH=/usr/local/bin:\$PATH
+  preserve_path='--preserve-envvar PATH'
+fi
+
+debuild \${no_lintian_param} \${preserve_path} --no-tgz-check -uc -us -S --source-option=--include-binaries
 
 cp ../*.dsc $WORKSPACE/pkgs
 cp ../*.orig.* $WORKSPACE/pkgs
@@ -228,7 +239,7 @@ if [[ $DISTRO != 'bionic' ]]; then
 fi
 
 echo '# BEGIN SECTION: create deb packages'
-debuild \${no_lintian_param} --no-tgz-check -uc -us --source-option=--include-binaries -j${MAKE_JOBS}
+debuild \${no_lintian_param} \${preserve_path} --no-tgz-check -uc -us --source-option=--include-binaries -j${MAKE_JOBS}
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: export pkgs'


### PR DESCRIPTION
The problem with the default compression to zstd on Jammy for .deb packages and our old version of reprepro can be workarounded by keeping compression in xz.

dpkg-deb does not expose the compression option for the internal artifacts inside .deb (the options available seems to affect only to the tarballs not in the .deb). The workaround is a bit tricky since we need to create a wrapper that forces this option, see https://alioth-lists-archive.debian.net/pipermail/devscripts-devel/2014-May/002232.html

Tested here: https://build.osrfoundation.org/job/ign-cmake2-debbuilder/1343/
Upoaded just fine here: https://build.osrfoundation.org/job/repository_uploader_packages/22181/


