### PR TITLE
Retry the packages installation in nightlies if failed

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -173,12 +173,24 @@ if [ ${DISTRO} = 'buster' ]; then
   sudo apt-get install -y dwz=0.13-5~bpo10+1
 fi
 
+timeout=1
 # Help to debug race conditions in nightly generation or other problems with versions
 if ${NIGHTLY_MODE}; then
   apt-cache show *ignition* | ( grep 'Package\\|Version' || true)
+  timeout=60
 fi
 
-sudo DEBIAN_FRONTEND=noninteractive mk-build-deps -r -i debian/control --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes'
+update_done=false
+seconds_waiting=0
+while (! \$update_done); do
+  sudo DEBIAN_FRONTEND=noninteractive mk-build-deps \
+    -r -i debian/control \
+    --tool 'apt-get --yes -o Debug::pkgProblemResolver=yes -o  Debug::BuildDeps=yes' \
+  && update_done=true
+  sleep 1 && seconds_waiting=\$((seconds_waiting+1))
+  [ \$seconds_waiting -gt \$timeout ] && exit 1
+done
+
 # new versions of mk-build-deps > 2.21.1 left buildinfo and changes files in the code
 rm -f ${PACKAGE_ALIAS}-build-deps_*.{buildinfo,changes}
 echo '# END SECTION'


### PR DESCRIPTION
The PR implements the mechanism to repeat the execution of mk-build-deps to help with problems in nightlies. This should cover possible race conditions between different packages being built and uploaded at the same time.

Together with #642, this should help to diagnose the problems on the nightly generation.

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-gazebo7-debbuilder&build=202)](https://build.osrfoundation.org/job/ign-gazebo7-debbuilder/202/)