### PR TITLE
 Remove vcpkg boost,ogre,gdal,protobuf before running Gazebo builds on Windows

### DIFF
--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -14,6 +14,7 @@ call %win_lib% :disable_vcpkg_integration
 call %win_lib% :remove_vcpkg_package protobuf 
 call %win_lib% :remove_vcpkg_package qt5
 call %win_lib% :remove_vcpkg_package qwt
+call %win_lib% :remove_vcpkg_package boost
 
 :: IF exist %LOCAL_WS% ( rmdir /s /q %LOCAL_WS% ) || goto %win_lib% :error
 :: reusing the workspace

--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -14,7 +14,7 @@ call %win_lib% :disable_vcpkg_integration
 call %win_lib% :remove_vcpkg_package protobuf 
 call %win_lib% :remove_vcpkg_package qt5
 call %win_lib% :remove_vcpkg_package qwt
-call %win_lib% :remove_vcpkg_package boost
+call %win_lib% :remove_vcpkg_package boost-core
 
 :: IF exist %LOCAL_WS% ( rmdir /s /q %LOCAL_WS% ) || goto %win_lib% :error
 :: reusing the workspace

--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -11,10 +11,10 @@ echo # END SECTION
 
 :: avoid conflicts with vcpkg packages
 call %win_lib% :disable_vcpkg_integration
-call %win_lib% :remove_vcpkg_package protobuf 
+call %win_lib% :remove_vcpkg_package protobuf
 call %win_lib% :remove_vcpkg_package qt5
 call %win_lib% :remove_vcpkg_package qwt
-call %win_lib% :remove_vcpkg_package boost-core
+call %win_lib% :remove_vcpkg_package boost-uninstall
 
 :: IF exist %LOCAL_WS% ( rmdir /s /q %LOCAL_WS% ) || goto %win_lib% :error
 :: reusing the workspace

--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -11,10 +11,13 @@ echo # END SECTION
 
 :: avoid conflicts with vcpkg packages
 call %win_lib% :disable_vcpkg_integration
+call %win_lib% :remove_vcpkg_package boost-uninstall
+call %win_lib% :remove_vcpkg_package gdal
+call %win_lib% :remove_vcpkg_package tinyxml2
+call %win_lib% :remove_vcpkg_package ogre
 call %win_lib% :remove_vcpkg_package protobuf
 call %win_lib% :remove_vcpkg_package qt5
 call %win_lib% :remove_vcpkg_package qwt
-call %win_lib% :remove_vcpkg_package boost-uninstall
 
 :: IF exist %LOCAL_WS% ( rmdir /s /q %LOCAL_WS% ) || goto %win_lib% :error
 :: reusing the workspace

--- a/jenkins-scripts/lib/gazebo-base-windows.bat
+++ b/jenkins-scripts/lib/gazebo-base-windows.bat
@@ -13,11 +13,14 @@ echo # END SECTION
 call %win_lib% :disable_vcpkg_integration
 call %win_lib% :remove_vcpkg_package boost-uninstall
 call %win_lib% :remove_vcpkg_package gdal
-call %win_lib% :remove_vcpkg_package tinyxml2
 call %win_lib% :remove_vcpkg_package ogre
 call %win_lib% :remove_vcpkg_package protobuf
 call %win_lib% :remove_vcpkg_package qt5
 call %win_lib% :remove_vcpkg_package qwt
+
+:: msgs5 needs tinyxml2 which was never in the win32 deps but it can be used
+:: from vcpkg.
+call %win_lib% :install_vcpkg_package tinyxml2
 
 :: IF exist %LOCAL_WS% ( rmdir /s /q %LOCAL_WS% ) || goto %win_lib% :error
 :: reusing the workspace


### PR DESCRIPTION
This fixes https://github.com/osrf/gazebo/issues/3170. 

The problem with the linking of boost there was the mix of vcpkg header files with the tarballs we use to build Gazebo. While working in the fix I removed everything I see used by vcpkg including tinyxml2.

Turns out that `msgs5` requires tinyxml2 and that was coming from vcpkg. This is an obvious bug in the buildsystem but I'm going to live with this until we solve #373 or provide a good build environment to Gazebo classic.

Failing before: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo11-windows7-amd64&build=129)](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-windows7-amd64/129/)
Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo11-windows7-amd64&build=130)](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-windows7-amd64/130/)
