### PR TITLE
Native docker platform support for armhf on Jammy

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -97,8 +97,17 @@ case ${ARCH} in
        FROM_VALUE=${ARCH}/${LINUX_DISTRO}:${DISTRO}
      fi
      ;;
-   'armhf' | 'arm64' )
-       FROM_VALUE=osrf/${LINUX_DISTRO}_${ARCH}:${DISTRO}
+   'armhf')
+     # There is no osrf/jammy_armhf image. Trying new
+     # platform support in docker
+     if [[ ${DISTRO} == 'jammy' ]]; then
+      FROM_VALUE=${LINUX_DISTRO}:${DISTRO}
+     else
+      FROM_VALUE=osrf/${LINUX_DISTRO}_${ARCH}:${DISTRO}
+     fi
+     ;;
+  'arm64')
+     FROM_VALUE=osrf/${LINUX_DISTRO}_${ARCH}:${DISTRO}
      ;;
   *)
      echo "Arch unknown"

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -25,11 +25,13 @@ USER=$(whoami)
 
 # platform support starts on versions greater than 17.07
 PLAFTORM_PARAM=
+DOCKER_CLI_PLUGIN=
 if [[ ${DISTRO} == 'jammy' && ${ARCH} == 'armhf' ]]; then
   PLAFTORM_PARAM="--platform=linux/armhf"
+  DOCKER_CLI_PLUGIN="buildx"
 fi
 
-sudo docker build ${PLAFTORM_PARAM} ${_DOCKER_BUILD_EXTRA_ARGS} \
+sudo docker ${DOCKER_CLI_PLUGIN} build ${PLAFTORM_PARAM} ${_DOCKER_BUILD_EXTRA_ARGS} \
                   --build-arg GID=$(id -g $USER) \
                   --build-arg USERID=$USERID \
                   --build-arg USER=$USER \

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -23,7 +23,13 @@ fi
 USERID=$(id -u)
 USER=$(whoami)
 
-sudo docker build ${_DOCKER_BUILD_EXTRA_ARGS} \
+# platform support starts on versions greater than 17.07
+PLAFTORM_PARAM=
+if [[ ${DISTRO} == 'jammy' && ${ARCH} == 'armhf' ]]; then
+  PLAFTORM_PARAM="--platform=linux/armhf"
+fi
+
+sudo docker build ${PLAFTORM_PARAM} ${_DOCKER_BUILD_EXTRA_ARGS} \
                   --build-arg GID=$(id -g $USER) \
                   --build-arg USERID=$USERID \
                   --build-arg USER=$USER \
@@ -74,7 +80,7 @@ if [[ -d /dev/snd ]]; then
 fi
 
 # DOCKER_FIX is for workaround https://github.com/docker/docker/issues/14203
-sudo ${docker_cmd} run $EXTRA_PARAMS_STR  \
+sudo ${docker_cmd} run ${PLAFTORM_PARAM} $EXTRA_PARAMS_STR  \
             -e DOCKER_FIX=''  \
             -e WORKSPACE=${WORKSPACE} \
             -e TERM=xterm-256color \


### PR DESCRIPTION
There is no `osrf/jammy_armhf` image so @nuclearsandwich suggested to give it a try to the native platform docker support. That worked just fine: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-math6-debbuilder&build=1365)](https://build.osrfoundation.org/job/ign-math6-debbuilder/1365/)

@nuclearsandwich commented offline:

> One thing I noticed when doing manual testing, the vanilla docker-build command was not platform aware. So using FROM --platform=linux/armhf ubuntu:jammy would work the first time but if I tried to build or run a different platform image for ubuntu:jammy it would keep using the armhf one until I ran docker-rmi ubuntu:jammy It may be worth testing whether that same host will correctly build an arm64 or amd64 package as well. And you may need to switch to the buildx builder to get it working reliably unless you want to untag or remove your base image before each build. https://docs.docker.com/buildx/working-with-buildx/

I still need to address the possible problems.