### PR TITLE
Remove NEED_C11_COMPILER variable and simplify NEED_C17_COMPILER

### DIFF
--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -106,13 +106,15 @@ if [ -Z ${GITHUB_ORG} ]; then
     GITHUB_ORG="osrf"
 fi
 
-# By default, do not need to use C++11 compiler
-if [ -z ${NEED_C11_COMPILER} ]; then
-  NEED_C11_COMPILER=false
-fi
-
-if [ -z ${NEED_C17_COMPILER} ]; then
-  NEED_C17_COMPILER=false
+if [ -z "${NEED_C17_COMPILER}" ]; then
+  export INSTALL_C17_COMPILER=false
+else
+  # Newer distributions don't need custom compiler
+  if [ ${DISTRO} = 'bionic' ] || [ ${DISTRO} = 'buster' ]; then
+    export INSTALL_C17_COMPILER=true
+  else
+    export INSTALL_C17_COMPILER=false
+  fi
 fi
 
 # By default, do not use ROS
@@ -124,14 +126,6 @@ fi
 # which can break some software. Use it as a workaround in this case
 if [ -z ${NEED_GCC48_COMPILER} ]; then
   NEED_GCC48_COMPILER=false
-fi
-
-# Only precise needs to install a C++11 compiler. Trusty on
-# already have a supported version
-if $NEED_C11_COMPILER; then
-  if [[ $DISTRO != 'precise' ]]; then
-      NEED_C11_COMPILER=false
-  fi
 fi
 
 # in some machines squid is returning

--- a/jenkins-scripts/docker/lib/boilerplate_prepare.sh
+++ b/jenkins-scripts/docker/lib/boilerplate_prepare.sh
@@ -102,18 +102,18 @@ if [ -z ${ENABLE_REAPER} ]; then
 fi
 
 # We use ignitionsrobotics or osrf. osrf by default
-if [ -Z ${GITHUB_ORG} ]; then
+if [ -z ${GITHUB_ORG} ]; then
     GITHUB_ORG="osrf"
 fi
 
 if [ -z "${NEED_C17_COMPILER}" ]; then
   export INSTALL_C17_COMPILER=false
-else
-  # Newer distributions don't need custom compiler
+fi
+# Check if we need to install a custom compiler in old distributions
+export INSTALL_C17_COMPILER=false
+if ${NEED_C17_COMPILER}; then
   if [ ${DISTRO} = 'bionic' ] || [ ${DISTRO} = 'buster' ]; then
     export INSTALL_C17_COMPILER=true
-  else
-    export INSTALL_C17_COMPILER=false
   fi
 fi
 

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -202,7 +202,7 @@ fi
 # Be sure that a previous bug using g++8 compiler is not present anymore
 if [[ ${DISTRO} == 'jammy' || ${DISTRO} == 'focal' ]]; then
  [[ \$(/usr/bin/gcc --version | grep 'gcc-8') ]] && ( echo "gcc-8 version found. A bug." ; exit 1 )
-elif $NEED_C17_COMPILER; then
+elif $INSTALL_C17_COMPILER; then
   echo '# BEGIN SECTION: install C++17 compiler'
   sudo apt-get install -y gcc-8 g++-8
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -200,7 +200,7 @@ if [ -f /usr/bin/rosdep ]; then
 fi
 
 # Be sure that a previous bug using g++8 compiler is not present anymore
-if [[ ${DISTRO} == 'jammy' ]]; then
+if [[ ${DISTRO} == 'jammy' || ${DISTRO} == 'focal' ]]; then
  [[ \$(/usr/bin/gcc --version | grep 'gcc-8') ]] && ( echo "gcc-8 version found. A bug." ; exit 1 )
 elif $NEED_C17_COMPILER; then
   echo '# BEGIN SECTION: install C++17 compiler'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -176,20 +176,6 @@ if [ -f /usr/bin/rosdep ]; then
   rosdep init
 fi
 
-if $NEED_C11_COMPILER || $NEED_GCC48_COMPILER; then
-echo '# BEGIN SECTION: install C++11 compiler'
-if [ ${DISTRO} = 'precise' ]; then
-sudo apt-get install -y python-software-propertie software-properties-common || true
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt-get update
-fi
-sudo apt-get install -y gcc-4.8 g++-4.8
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-g++ --version
-echo '# END SECTION'
-fi
-
 if $NEED_C17_COMPILER; then
 echo '# BEGIN SECTION: install C++17 compiler'
 sudo apt-get install -y gcc-8 g++-8

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -299,16 +299,13 @@ DELIM_DOCKER31
 
 # Beware of moving this code since it needs to run update-alternative after
 # installing the default compiler in PACKAGES_CACHE_AND_CHECK_UPDATES
-if ${NEED_C17_COMPILER} && [[ ${DISTRO} != jammy ]]; then
-# Newer distributions don't need custom compiler
-if ${DISTRO} == 'bionic' || ${DISTRO} == 'buster'; then
+if ${INSTALL_C17_COMPILER}; then
 cat >> Dockerfile << DELIM_GCC8
    RUN apt-get update \\
    && apt-get install -y g++-8 \\
    && rm -rf /var/lib/apt/lists/* \\
    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 DELIM_GCC8
-fi
 fi
 
 if ${USE_SQUID}; then

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -306,12 +306,15 @@ DELIM_DOCKER31
 # Beware of moving this code since it needs to run update-alternative after
 # installing the default compiler in PACKAGES_CACHE_AND_CHECK_UPDATES
 if ${NEED_C17_COMPILER}; then
+# Newer distributions don't need custom compiler
+if ${DISTRO} == 'bionic' || ${DISTRO} == 'buster'; then
 cat >> Dockerfile << DELIM_GCC8
    RUN apt-get update \\
    && apt-get install -y g++-8 \\
    && rm -rf /var/lib/apt/lists/* \\
    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
 DELIM_GCC8
+fi
 fi
 
 if ${USE_SQUID}; then

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -27,7 +27,7 @@ if [[ -z ${LINUX_DISTRO} ]]; then
   export LINUX_DISTRO="ubuntu"
 fi
 
-[[ -z ${NEED_C17_COMPILER} ]] && NEED_C17_COMPILER=false
+[[ -z ${INSTALL_C17_COMPILER} ]] && INSTALL_C17_COMPILER=false
 
 export APT_PARAMS=
 

--- a/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
+++ b/jenkins-scripts/docker/multidistribution-ignition-debbuild.bash
@@ -7,6 +7,5 @@ SCRIPT_DIR="${SCRIPT_DIR%/*}"
 export RELEASE_REPO_DIRECTORY=${DISTRO}
 export ENABLE_ROS=false
 export GITHUB_ORG=ignitionrobotics
-export NEED_C11_COMPILER=true
 
 . ${SCRIPT_DIR}/lib/debbuild-base.bash


### PR DESCRIPTION
This should stop problems with #639. Two main changes in the PR:

 * Remove `NEED_C11_COMPILER` since all our linux platforms implements the standard by default.
 * Reduce logic duplication for `NEED_C17_COMPILER`

Tested:
 * common4 build on Bionic, needs the custom compiler:  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-common4-debbuilder&build=814)](https://build.osrfoundation.org/job/ign-common4-debbuilder/814/)
 * common4 build on Focal, don't use the custom compiler: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-common4-debbuilder&build=815)](https://build.osrfoundation.org/job/ign-common4-debbuilder/815/)