### PR TITLE
Use docker-jammy TAG in jenkins for Jammy jobs

### DIFF
--- a/release.py
+++ b/release.py
@@ -617,6 +617,8 @@ def go(argv):
                     # Need to use JENKINS_NODE_TAG parameter for large memory nodes
                     # since it runs qemu emulation
                     linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a
+                elif(d == 'jammy'):
+                    linux_platform_params['JENKINS_NODE_TAG'] = 'docker-jammy'
                 elif ('ignition-physics' in args.package_alias):
                     linux_platform_params['JENKINS_NODE_TAG'] = 'large-memory'
 


### PR DESCRIPTION
The jammy docker image requires updated docker versions to handle it properly. The xenial nodes in the buildfarm are affected and can not be updated easily. The focal nodes, after being updated to version greater than 20.10.07 to deal with different problems on jammy including the clone3 syscall.

This change should be temporary until we update all the nodes. 