### PR TITLE
Use a special node tag for processing nightlies

### DIFF
--- a/release.py
+++ b/release.py
@@ -623,6 +623,15 @@ def go(argv):
                 if (NIGHTLY and a == 'i386'):
                     continue
 
+                # control nightly generation using a single machine to process
+                # all distribution builds to avoid race conditions. Note: this
+                # assumes that large-memory nodes are beind used for nightly
+                # tags.
+                # https://github.com/ignition-tooling/release-tools/issues/644
+                if (NIGHTLY):
+                    assert a == 'amd64', f'Nightly tag assumed amd64 but arch is {a}'
+                    linux_platform_params['JENKINS_NODE_TAG'] = 'linux-nightly-' + d
+
                 linux_platform_params_query = urllib.parse.urlencode(linux_platform_params)
 
                 url = '%s/job/%s/buildWithParameters?%s'%(JENKINS_URL, job_name, linux_platform_params_query)


### PR DESCRIPTION
Part of https://github.com/ignition-tooling/release-tools/issues/644 as suggested by @scpeters.

We have Bionic, Focal and Jammy, I've setup temporary the tags in docker (need permanent configuration) as follow:
 * optimus: focal
 * r2d2: bionic
 * linux-ip-172-30-1-216: jammy (not large-memory but can probably handle the existing jammys)

