### PR TITLE
Make gdal to work without DEBUG builds in vcpkg

### DIFF
--- a/jenkins-scripts/vcpkg-bootstrap.bat
+++ b/jenkins-scripts/vcpkg-bootstrap.bat
@@ -38,6 +38,9 @@ move %dfcln_portfile%.new %dfcln_portfile% || goto :error
 :: replace it to lowercase
 set ogre_portfile=%VCPKG_DIR%\ports\ogre\portfile.cmake
 powershell -Command "(Get-Content %ogre_portfile%) -replace 'Release', 'release' | Out-File -encoding ASCII %ogre_portfile%" || goto :error
+:: 4. Disable DEBUG libraries in gdal
+set gdal_cmakefile=%VCPKG_DIR%\ports\gdal\vcpkg-cmake-wrapper.cmake
+powershell -Command "(Get-Content %gdal_cmakefile%) -replace 'find_library(GDAL_LIBRARY_DEBUG', '#find_library(GDAL_LIBRARY_DEBUG' | Out-File -encoding ASCII %ogre_cmakefile%" || goto :error
 echo # END SECTION
 
 echo "Using SNAPSHOT: bootstrap vcpkg executable"

--- a/jenkins-scripts/vcpkg-bootstrap.bat
+++ b/jenkins-scripts/vcpkg-bootstrap.bat
@@ -40,7 +40,7 @@ set ogre_portfile=%VCPKG_DIR%\ports\ogre\portfile.cmake
 powershell -Command "(Get-Content %ogre_portfile%) -replace 'Release', 'release' | Out-File -encoding ASCII %ogre_portfile%" || goto :error
 :: 4. Disable DEBUG libraries in gdal
 set gdal_cmakefile=%VCPKG_DIR%\ports\gdal\vcpkg-cmake-wrapper.cmake
-powershell -Command "(Get-Content %gdal_cmakefile%) -replace 'find_library\(GDAL_LIBRARY_DEBUG', '#find_library(GDAL_LIBRARY_DEBUG' | Out-File -encoding ASCII %ogre_cmakefile%" || goto :error
+powershell -Command "(Get-Content %gdal_cmakefile%) -replace 'find_library\(GDAL_LIBRARY_DEBUG', '#find_library(GDAL_LIBRARY_DEBUG' | Out-File -encoding ASCII %gdal_cmakefile%" || goto :error
 echo # END SECTION
 
 echo "Using SNAPSHOT: bootstrap vcpkg executable"

--- a/jenkins-scripts/vcpkg-bootstrap.bat
+++ b/jenkins-scripts/vcpkg-bootstrap.bat
@@ -40,7 +40,7 @@ set ogre_portfile=%VCPKG_DIR%\ports\ogre\portfile.cmake
 powershell -Command "(Get-Content %ogre_portfile%) -replace 'Release', 'release' | Out-File -encoding ASCII %ogre_portfile%" || goto :error
 :: 4. Disable DEBUG libraries in gdal
 set gdal_cmakefile=%VCPKG_DIR%\ports\gdal\vcpkg-cmake-wrapper.cmake
-powershell -Command "(Get-Content %gdal_cmakefile%) -replace 'find_library(GDAL_LIBRARY_DEBUG', '#find_library(GDAL_LIBRARY_DEBUG' | Out-File -encoding ASCII %ogre_cmakefile%" || goto :error
+powershell -Command "(Get-Content %gdal_cmakefile%) -replace 'find_library\(GDAL_LIBRARY_DEBUG', '#find_library(GDAL_LIBRARY_DEBUG' | Out-File -encoding ASCII %ogre_cmakefile%" || goto :error
 echo # END SECTION
 
 echo "Using SNAPSHOT: bootstrap vcpkg executable"


### PR DESCRIPTION
One of the Windows nodes have problems with gdal in vcpkg. The whole story comes from https://github.com/ignitionrobotics/ign-common/pull/292#issuecomment-1039738233.

I was unable to explain why `nuc` is working fine since it does not have the required libs and the code between the two nodes seems to be the same.

The bad news is that our snapshot of vcpkg is too old to keep it working, some files have been removed from the mirrors, so we would need to update it to make all the software pieces to work.