### PR TITLE
Do not run autogenerated tests in autopkgtest

### DIFF
--- a/jenkins-scripts/docker/lib/_gazebo_utils.sh
+++ b/jenkins-scripts/docker/lib/_gazebo_utils.sh
@@ -42,7 +42,7 @@ if $RUN_AUTOPKGTEST; then
 echo '# BEGIN SECTION: run autopkgtest'
 cd $WORKSPACE/pkgs
 set +e
-sudo autopkgtest -B *.deb *.dsc -- null
+sudo autopkgtest --no-auto-control -B *.deb *.dsc -- null
 # autopkgtest will return 0 if there are successful tests and 8 if there are no tests
 testret=\$?
 if [[ \$testret != 0 ]] && [[ \$testret != 8 ]]; then


### PR DESCRIPTION
When the debbuilds run the `autopkgtest` (mechanism to smoke testing the freshly generated packages) the tool automatically generates tests for python packages by trying to guess the python module in the case that no other autopkgtest were defined in (`debian/tests/*` directory). This is probably going to fail in most of the occasions for us since our python bindings use a different filesystem schema.

This PR disabled that auto-generation for python packages.