### PR TITLE
Revert "Set HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK for now (#656)"

### DIFF
--- a/jenkins-scripts/lib/_homebrew_base_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_base_setup.bash
@@ -16,7 +16,6 @@ fi
 
 git -C $(${BREW_BINARY} --repo) fsck
 export HOMEBREW_UPDATE_TO_TAG=1
-export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
 ${BREW_BINARY} update
 # manually exclude a ruby warning that jenkins thinks is from clang
 # https://github.com/osrf/homebrew-simulation/issues/1343


### PR DESCRIPTION
This reverts commit e316d8497c67d5342c6f595f8a3c48363fdccb5e from #656.
This is no longer needed since Homebrew/brew#12979 was merged.

There is still an issue with the rpath in some formulae (see https://github.com/osrf/homebrew-simulation/issues/1827), but CI works without setting this environment variable, so we can revert it.

Testing with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gui-ci-ign-gui3-homebrew-amd64&build=76)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_gui-ci-ign-gui3-homebrew-amd64/76/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_gui-ci-ign-gui3-homebrew-amd64/76/