### PR TITLE
Update vcpkg-snapshot to 2022.02.23

### DIFF
--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -15,6 +15,6 @@ set VCPKG_CMD=%VCPKG_DIR%\vcpkg.exe
 set VCPKG_CMAKE_TOOLCHAIN_FILE=%VCPKG_DIR%/scripts/buildsystems/vcpkg.cmake
 if NOT DEFINED VCPKG_SNAPSHOT (
   :: see https://github.com/microsoft/vcpkg/releases
-  set VCPKG_SNAPSHOT=2021.05.12
+  set VCPKG_SNAPSHOT=2022.02.23
 )
 goto :EOF

--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -244,10 +244,13 @@ goto :EOF
 :: ##################################
 :check_vcpkg_snapshot
 setlocal EnableDelayedExpansion
-for /f %%i in ('git -C %VCPKG_DIR% describe --tags HEAD') do set VCPKG_HEAD=%%i
-echo "VCPKG_HEAD is %VCPKG_HEAD%"
-if NOT %VCPKG_HEAD% == %VCPKG_SNAPSHOT% (
+:: look for same sha in repository HEAD and in the tag
+for /f %%i in ('git -C %VCPKG_DIR% rev-parse HEAD') do set VCPKG_HEAD=%%i
+for /f %%i in ('git -C %VCPKG_DIR% rev-list -n 1 %VCPKG_SNAPSHOT%') do set VCPKG_TAG=%%i
+if NOT %VCPKG_HEAD% == %VCPKG_TAG% (
   echo The vpckg directory is not using the expected snapshot %VCPKG_SNAPSHOT%
+  echo VCPKG_HEAD points to %VCPKG_HEAD% while VCPKG_TAG points to %VCPKG_TAG%
+  echo They should point to the same commit hash
   goto :error
 )
 goto :EOF

--- a/jenkins-scripts/vcpkg-bootstrap.bat
+++ b/jenkins-scripts/vcpkg-bootstrap.bat
@@ -38,6 +38,10 @@ move %dfcln_portfile%.new %dfcln_portfile% || goto :error
 :: replace it to lowercase
 set ogre_portfile=%VCPKG_DIR%\ports\ogre\portfile.cmake
 powershell -Command "(Get-Content %ogre_portfile%) -replace 'Release', 'release' | Out-File -encoding ASCII %ogre_portfile%" || goto :error
+:: 4. Fix for bug in hash in zeromq
+:: https://github.com/microsoft/vcpkg/issues/23461
+set zeromq_portfile=%VCPKG_DIR%\ports\zeromq\portfile.cmake
+powershell -Command "(Get-Content %zeromq_portfile%) -replace '64e6d37ab843e5b9aa9e56ba7904423ce0a2c6b4101dbd86b7b8b22c52c384ed7ea9764f9e0a53be04e7ade09923ca95452104e9760b66ebc0ed3ffef08a75c5', '42663c9b16a09a5c30d61a027c544ea318a9f745129579dcc0d5dd2d529be42e8dbaee1b9406497c4da7815fa60fc877d2e26f807135b2bbc0ea7ea4214b8af6' | Out-File -encoding ASCII %zeromq_portfile%" || goto :error
 echo # END SECTION
 
 echo "Using SNAPSHOT: bootstrap vcpkg executable"


### PR DESCRIPTION
Follow up and superseed https://github.com/ignition-tooling/release-tools/pull/657. Originally coming from https://github.com/ignitionrobotics/ign-common/pull/292#issuecomment-1039738233 , problems with gdal in some of the Windows nodes.

We can not install gdal again from previous versions of vcpkg because some of the files have been removed from the mirrors since new versions are out. This PR updates vcpkg to the latest snapshot available. This is going to bump many versions at once, including ogre to 1.12.9, ffmpeg to 4.4.1, etc.

The testing job for compiling all ignition family up to main on[ ign-gazebo seems fine](https://build.osrfoundation.org/job/_vcpkg_testing_snapshot/113/). Probably all the update work done in Brew and all the patched for Windows sent by conda-forge contributors make it to work out-of-box.

There is a problem with a hash in zeromq that I patched in e0505323d3d0d311e0e63d7b91d7d14b4e958221.

I also needed to update our check on the vcpkg tag being used since it failed when multiple tags were in the same commit sha. 48084de907390aea3c2679922213509a5ff900a8.

//cc @Blast545 