### PR TITLE
Remove docker-jammy jenkins label, not needed anymore

### DIFF
--- a/release.py
+++ b/release.py
@@ -617,8 +617,6 @@ def go(argv):
                     # Need to use JENKINS_NODE_TAG parameter for large memory nodes
                     # since it runs qemu emulation
                     linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a
-                elif(d == 'jammy'):
-                    linux_platform_params['JENKINS_NODE_TAG'] = 'docker-jammy'
                 elif ('ignition-physics' in args.package_alias):
                     linux_platform_params['JENKINS_NODE_TAG'] = 'large-memory'
 


### PR DESCRIPTION
All jenkins nodes were updated to Focal and docker versions should be modern enough to handle jammy. Removing the workaround of `docker-jammy` from release.py.