### PR TITLE
Do not use two ignition-cmake packages in ign-math

### DIFF
--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -384,12 +384,19 @@ fi
 # IGNITION
 #
 
-IGN_MATH_DEPENDENCIES="libeigen3-dev \\
-                       libpython3-dev \\
-                       ruby-dev \\
-                       swig \\
-                       libignition-cmake-dev \\
-                       libignition-cmake2-dev"
+if [[ ${IGN_MATH_MAJOR_VERSION} -eq 4 ]]; then
+  IGN_MATH_DEPENDENCIES="libeigen3-dev \\
+                         libpython3-dev \\
+                         ruby-dev \\
+                         swig \\
+                         libignition-cmake-dev"
+else
+  IGN_MATH_DEPENDENCIES="libeigen3-dev \\
+                         libpython3-dev \\
+                         ruby-dev \\
+                         swig \\
+                         libignition-cmake2-dev"
+fi
 
 # IGN_TRANSPORT related dependencies. Default value points to the development
 # version


### PR DESCRIPTION
Latest version of libignition-cmake2-dev declares a conflict with libignition-cmake-dev to avoid problems with Jammy packages that use the non versioned package. I've seen a regression in https://build.osrfoundation.org/job/ignition_math-ci-pr_any-ubuntu_auto-amd64/1264/console since dependencies_archive use both packages at the same time for ign-math. I did not find other problems looking at the dependency archive.

Failed: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_math-ci-pr_any-ubuntu_auto-amd64&build=1262)](https://build.osrfoundation.org/job/ignition_math-ci-pr_any-ubuntu_auto-amd64/1262/)
Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_math-ci-pr_any-ubuntu_auto-amd64&build=1266)](https://build.osrfoundation.org/job/ignition_math-ci-pr_any-ubuntu_auto-amd64/1266/)