### PR TITLE
Relocate gzdev 2nd run after cache invalidation

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -279,11 +279,6 @@ cat >> Dockerfile << DELIM_DOCKER3
 RUN echo "${MONTH_YEAR_STR}"
 DELIM_DOCKER3
 
-# A new install of gzdev is needed to update to possible recent changes in
-# configuration and/or code and not being used since the docker cache did
-# not get them.
-dockerfile_install_gzdev_repos
-
 cat >> Dockerfile << DELIM_DOCKER3_2
 RUN sed -i -e 's:13\.56\.139\.45:packages.osrfoundation.org:g' /etc/apt/sources.list.d/* || true \
  && (apt-get update || (rm -rf /var/lib/apt/lists/* && apt-get ${APT_PARAMS} update)) \
@@ -294,6 +289,11 @@ RUN sed -i -e 's:13\.56\.139\.45:packages.osrfoundation.org:g' /etc/apt/sources.
 # update.
 RUN echo "Invalidating cache $(( ( RANDOM % 100000 )  + 1 ))"
 DELIM_DOCKER3_2
+
+# A new install of gzdev is needed to update to possible recent changes in
+# configuration and/or code and not being used since the docker cache did
+# not get them.
+dockerfile_install_gzdev_repos
 
 cat >> Dockerfile << DELIM_DOCKER31
 # Note that we don't remove the apt/lists file here since it will make


### PR DESCRIPTION
Closes #666. Relocate gzdev 2nd run after the full cache invalidation.

Being tested [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci-pr_any-ubuntu_auto-amd64&build=8247)](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-ubuntu_auto-amd64/8247/)