### PR TITLE
Limit ign-physics building threads to 1 in arm native nodes

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -163,7 +163,6 @@ fi
 # handled by symlinks (like cmake) in the repository can not be copied directly.
 # Need special care to copy, using first a --dereference
 cp -a --dereference \${PACKAGE_RELEASE_DIR}/* .
-ls -R --color debian/
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install build dependencies'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -163,6 +163,7 @@ fi
 # handled by symlinks (like cmake) in the repository can not be copied directly.
 # Need special care to copy, using first a --dereference
 cp -a --dereference \${PACKAGE_RELEASE_DIR}/* .
+ls -R --color
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install build dependencies'

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -163,7 +163,7 @@ fi
 # handled by symlinks (like cmake) in the repository can not be copied directly.
 # Need special care to copy, using first a --dereference
 cp -a --dereference \${PACKAGE_RELEASE_DIR}/* .
-ls -R --color
+ls -R --color debian/
 echo '# END SECTION'
 
 echo '# BEGIN SECTION: install build dependencies'

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -313,7 +313,7 @@ ignition_software.each { ign_sw ->
           label "huge-memory"
           // on ARM native nodes in buildfarm we need to restrict to 2 the
           // compilation threads to avoid OOM killer
-          extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=2; fi'
+          extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=1; fi'
         }
 
         steps {

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -307,12 +307,13 @@ ignition_software.each { ign_sw ->
                         all_branches(ign_sw) - [ 'main'])
       abi_job.with
       {
+        extra_str=""
         if (ign_sw == 'physics')
         {
           label "huge-memory"
           // on ARM native nodes in buildfarm we need to restrict to 2 the
           // compilation threads to avoid OOM killer
-          GLOBAL_SHELL_CMD = GLOBAL_SHELL_CMD + '\nif [[ $(uname -m) == "aarch64" ]]; then export MAKE_JOBS=2; fi'
+          extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=2; fi'
         }
 
         steps {
@@ -322,6 +323,7 @@ ignition_software.each { ign_sw ->
                 export DISTRO=${distro}
 
                 ${GLOBAL_SHELL_CMD}
+                ${extra_str}
 
                 export ARCH=${arch}
                 export DEST_BRANCH=\${DEST_BRANCH:-\$ghprbTargetBranch}
@@ -472,6 +474,11 @@ all_debbuilders().each { debbuilder_name ->
   extra_str = ""
   if (debbuilder_name.contains("gazebo") || debbuilder_name == "transport7")
     extra_str="export NEED_C17_COMPILER=true"
+
+  // Ignition physics consumes huge amount of memory making arm node to FAIL
+  // Force here to use one compilation thread
+  if (debbuilder_name.contains("-physics"))
+    extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=2; fi'
 
   println("Generating: ${debbuilder_name}-debbuilder")
   def build_pkg_job = job("${debbuilder_name}-debbuilder")

--- a/jenkins-scripts/dsl/ignition.dsl
+++ b/jenkins-scripts/dsl/ignition.dsl
@@ -311,7 +311,7 @@ ignition_software.each { ign_sw ->
         if (ign_sw == 'physics')
         {
           label "huge-memory"
-          // on ARM native nodes in buildfarm we need to restrict to 2 the
+          // on ARM native nodes in buildfarm we need to restrict to 1 the
           // compilation threads to avoid OOM killer
           extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=1; fi'
         }
@@ -478,7 +478,7 @@ all_debbuilders().each { debbuilder_name ->
   // Ignition physics consumes huge amount of memory making arm node to FAIL
   // Force here to use one compilation thread
   if (debbuilder_name.contains("-physics"))
-    extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=2; fi'
+    extra_str += '\nif [ $(uname -m) = "aarch64" ]; then export MAKE_JOBS=1; fi'
 
   println("Generating: ${debbuilder_name}-debbuilder")
   def build_pkg_job = job("${debbuilder_name}-debbuilder")


### PR DESCRIPTION
The PR restricts to 1 the building threads in arm native nodes for both CI and packaging:

 * The CI was using GLOBAL_SHELL_CMD to add the configuration but that variable is global and it is going to affect all jobs generated after setting it. I changed it to a local variable. Also fix bashism to sh.
 * Add the same configuration to packaging jobs

Tested in ign-physics arm64 build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-physics5-debbuilder&build=625)](https://build.osrfoundation.org/job/ign-physics5-debbuilder/625/)