### PR TITLE
Skip brew doctor if szip is installed

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -176,10 +176,10 @@ echo '# END SECTION'
 
 echo "#BEGIN SECTION: brew doctor analysis"
 brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
-# if proj@7 installed, skip brew doctor
-# remove this line when gdal stops depending on a deprecated version of proj
-# https://github.com/Homebrew/homebrew-core/issues/82441
-brew list | grep '^proj@7$' || brew doctor || echo MARK_AS_UNSTABLE
+# if szip is installed, skip brew doctor
+# remove this line when hdf5 stops depending on the deprecated szip formula
+# https://github.com/Homebrew/homebrew-core/issues/96930
+brew list | grep '^szip$' || brew doctor || echo MARK_AS_UNSTABLE
 echo '# END SECTION'
 
 # CHECK PRE_TESTS_EXECUTION_HOOK AND RUN

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -73,10 +73,10 @@ echo '# END SECTION'
 
 echo "#BEGIN SECTION: brew doctor analysis"
 brew missing || brew install $(brew missing | awk '{print $2}') && brew missing
-# if proj@7 installed, skip brew doctor
-# remove this line when gdal stops depending on a deprecated version of proj
-# https://github.com/Homebrew/homebrew-core/issues/82441
-brew list | grep '^proj@7$' || brew doctor || echo MARK_AS_UNSTABLE
+# if szip is installed, skip brew doctor
+# remove this line when hdf5 stops depending on the deprecated szip formula
+# https://github.com/Homebrew/homebrew-core/issues/96930
+brew list | grep '^szip$' || brew doctor || echo MARK_AS_UNSTABLE
 echo '# END SECTION'
 
 echo "# BEGIN SECTION: re-add group write permissions"


### PR DESCRIPTION
szip is currently deprecated in homebrew-core, so skip
brew doctor checks until it is fixed. Replaces similar
logic for proj@7 since that is now fixed.

## Current unstable builds

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics2-install_bottle-homebrew-amd64&build=645)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_physics2-install_bottle-homebrew-amd64/645/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_physics2-install_bottle-homebrew-amd64/645/

~~~
#BEGIN SECTION: brew doctor analysis
+ brew missing
+ brew missing
+ brew list
+ grep '^proj@7$'
+ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Some installed formulae are deprecated or disabled.
You should find replacements for the following formulae:
  szip
+ echo MARK_AS_UNSTABLE
~~~

## Testing this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_physics2-install_bottle-homebrew-amd64&build=646)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_physics2-install_bottle-homebrew-amd64/646/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_physics2-install_bottle-homebrew-amd64/646/
