### PR TITLE
Avoid generating templates for packaging when using dh_make

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -156,7 +156,7 @@ cd \`find $WORKSPACE/build -mindepth 1 -type d |head -n 1\`
 # If use the quilt 3.0 format for debian (drcsim) it needs a tar.gz with sources
 if $NIGHTLY_MODE; then
   rm -fr .hg* .git*
-  echo | dh_make -y -s --createorig -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
+  echo | dh_make -y -s --createorig --defaultless -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
 fi
 
 # Adding extra directories to code. debian has no problem but some extra directories


### PR DESCRIPTION
Nightly generation use `dh_make` to generate the sources tarball. The side effect is that `dh_make` generates a lot of templates to be used in Debian packaging that are superfluous to our packaging. The QA checker usually complains:
```
E: ignition-transport12 source: readme-source-is-dh_make-template
W: ignition-transport12 source: dh-make-template-in-source [debian/ignition-transport12.cron.d.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/ignition-transport12.doc-base.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/manpage.1.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/manpage.md.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/manpage.sgml.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/manpage.xml.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/postinst.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/postrm.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/preinst.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/prerm.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/salsa-ci.yml.ex]
W: ignition-transport12 source: dh-make-template-in-source [debian/watch.ex]
```
Adding the `--defaultless` parameter get rid of the template generation and thus of the QA errors and warnings. 

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-gui7-debbuilder&build=266)](https://build.osrfoundation.org/job/ign-gui7-debbuilder/266/)