### PR TITLE
Script to generate release summaries

### DIFF
--- a/release_summary.bash
+++ b/release_summary.bash
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Print a summary of a release, with its changelog and contributors
+#
+# cd <path_to_source_code>
+# bash release_summary.bash gui 5.3.0 5.4.0
+
+LIB=$1
+PREV=$2
+NEW=$3
+
+MAJOR=${PREV%.*.*}
+
+echo "---------------------------------"
+NAME_FOR_TAGS=ignition-${LIB}
+NAME_FOR_TAGS="${NAME_FOR_TAGS/ignition-sdf/sdformat}"
+echo "NAME_FOR_TAGS: $NAME_FOR_TAGS"
+
+NAME_FOR_REPO=ign-${LIB}
+NAME_FOR_REPO="${NAME_FOR_REPO/ign-sdf/sdformat}"
+echo "NAME_FOR_REPO: $NAME_FOR_REPO"
+
+NAME_FOR_BRANCH=ign-${LIB}
+NAME_FOR_BRANCH="${NAME_FOR_BRANCH/ign-sdf/sdf}"
+echo "NAME_FOR_BRANCH: $NAME_FOR_BRANCH"
+
+NAME_FOR_TITLE="Ignition ${LIB^}"
+NAME_FOR_TITLE="${NAME_FOR_TITLE/Ignition Sdf/SDFormat}"
+echo "NAME_FOR_TITLE: $NAME_FOR_TITLE"
+
+echo "Previous version: ${PREV}"
+echo "New version: ${NEW}"
+echo "Major version: ${MAJOR}"
+echo "---------------------------------"
+echo ""
+
+git fetch --all --tags
+
+git checkout ${NAME_FOR_BRANCH}${MAJOR}
+git pull origin ${NAME_FOR_BRANCH}${MAJOR}
+
+echo ""
+echo ""
+echo ""
+echo ""
+echo "## $NAME_FOR_TITLE $NEW"
+echo ""
+echo "## Changelog"
+echo ""
+echo "[Full changelog](https://github.com/ignitionrobotics/${NAME_FOR_REPO}/blob/${NAME_FOR_BRANCH}${MAJOR}/Changelog.md)"
+echo ""
+#awk '/${NEW}/{ f = 1; next } /${PREV}/{ f = 0 } f' Changelog.md
+sed -n "/${NEW}/, /${PREV}/{ /${NEW}/! { /${PREV}/! p } }" Changelog.md
+echo ""
+echo "## Contributors"
+echo ""
+git log --pretty="%an" ${NAME_FOR_TAGS}${MAJOR}_${PREV}...${NAME_FOR_TAGS}${MAJOR}_${NEW} | sort | uniq | sed "s/.*/\*&\*/"
+echo ""
+echo "---"


### PR DESCRIPTION
Generate markdown summaries to be posted on Community posts like this: [New Ignition releases 2022-03-01 (Citadel, Edifice, Fortress)](https://community.gazebosim.org/t/new-ignition-releases-2022-03-01-citadel-edifice-fortress/1313).

Example:

```
$ bash release_summary.bash transport 10.1.0 10.2.0
---------------------------------
NAME_FOR_TAGS: ignition-transport
NAME_FOR_REPO: ign-transport
NAME_FOR_BRANCH: ign-transport
NAME_FOR_TITLE: Ignition Transport
Previous version: 10.1.0
New version: 10.2.0
Major version: 10
---------------------------------

Fetching origin
remote: Enumerating objects: 61, done.
remote: Counting objects: 100% (59/59), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 22 (delta 16), reused 20 (delta 15), pack-reused 0
Unpacking objects: 100% (22/22), 2.93 KiB | 38.00 KiB/s, done.
From ssh://github.com/ignitionrobotics/ign-transport
 * [new branch]        chapulina/11_to_12 -> origin/chapulina/11_to_12
   b4473a56..b4709257  ign-transport11    -> origin/ign-transport11
Branch 'ign-transport10' set up to track remote branch 'ign-transport10' from 'origin'.
Switched to a new branch 'ign-transport10'
From ssh://github.com/ignitionrobotics/ign-transport
 * branch              ign-transport10 -> FETCH_HEAD
Already up to date.




## Ignition Transport 10.2.0

## Changelog

[Full changelog](https://github.com/ignitionrobotics/ign-transport/blob/ign-transport10/Changelog.md)


1. Use exec instead of popen to run ign-launch binary
    * [Pull request #300](https://github.com/ignitionrobotics/ign-transport/pull/300)

1. Focal CI: static checkers, doxygen linters, compiler warnings
    * [Pull request #298](https://github.com/ignitionrobotics/ign-transport/pull/298)

1. Add option to output messages in JSON format
    * [Pull request #288](https://github.com/ignitionrobotics/ign-transport/pull/288)

1. Remove no username error messages
    * [Pull request #286](https://github.com/ignitionrobotics/ign-transport/pull/286)

1. Documented the default value of `IGN_PARTITION`
    * [Pull request #281](https://github.com/ignitionrobotics/ign-transport/pull/281)

1. Remove static on `registrationCb` and `unregistrationCb`.
    * [Pull request #273](https://github.com/ignitionrobotics/ign-transport/pull/273)

1. Make zmq check for post 4.3.1 not to include 4.3.1
    * [Pull request #237](https://github.com/ignitionrobotics/ign-transport/pull/237)

1. NetUtils: simplify logic in `determineInterfaces`
    * [Pull request #257](https://github.com/ignitionrobotics/ign-transport/pull/257)

1. Fix Homebrew warning (backport from Fortress)
    * [Pull request #268](https://github.com/ignitionrobotics/ign-transport/pull/268)


## Contributors

*Addisu Z. Taddese*
*Alexander Graber-Tilton*
*Carlos Agüero*
*Hill Ma*
*Jose Luis Rivero*
*Louise Poubel*
*Martin Pecka*
*Nate Koenig*
*Steve Peters*

---

```

