### PR TITLE
brew: try to rescue if `brew list` fails

### DIFF
--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -15,6 +15,7 @@ export HOMEBREW_UPDATE_TO_TAG=1
 ${BREW_BINARY} up || { restore_brew && ${BREW_BINARY} up ; }
 
 # Clear all installed homebrew packages, links, taps, and kegs
+${BREW_BINARY} list --formula | wc || { restore_brew && ${BREW_BINARY} list --formula | wc; }
 BREW_LIST=$(${BREW_BINARY} list --formula)
 if [[ -n "${BREW_LIST}" ]]; then
   ${BREW_BINARY} remove --force --ignore-dependencies ${BREW_LIST}

--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -15,7 +15,7 @@ export HOMEBREW_UPDATE_TO_TAG=1
 ${BREW_BINARY} up || { restore_brew && ${BREW_BINARY} up ; }
 
 # Clear all installed homebrew packages, links, taps, and kegs
-${BREW_BINARY} list --formula | wc || { restore_brew && ${BREW_BINARY} list --formula | wc; }
+${BREW_BINARY} list --formula > /dev/null || { restore_brew && ${BREW_BINARY} list --formula > /dev/null; }
 BREW_LIST=$(${BREW_BINARY} list --formula)
 if [[ -n "${BREW_LIST}" ]]; then
   ${BREW_BINARY} remove --force --ignore-dependencies ${BREW_LIST}


### PR DESCRIPTION
Sometimes `brew list` fails if the brew installation on a build machine has been corrupted. This will check for failures and invoke restore_brew if needed.


## Background

The [mac-ultron.bigsur](https://build.osrfoundation.org/computer/mac-ultron.bigsur/) Jenkins node recently started failing jobs with the following error message:

* https://build.osrfoundation.org/job/sdformat12-install_bottle-homebrew-amd64/180/console

 
~~~
+++ /usr/local/bin/brew list --formula
/usr/local/Homebrew/Library/Homebrew/standalone/sorbet.rb:11:in `require': cannot load such file -- sorbet-runtime-stub (LoadError)
	from /usr/local/Homebrew/Library/Homebrew/standalone/sorbet.rb:11:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/startup/sorbet.rb:9:in `require'
	from /usr/local/Homebrew/Library/Homebrew/startup/sorbet.rb:9:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/startup.rb:10:in `require_relative'
	from /usr/local/Homebrew/Library/Homebrew/startup.rb:10:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/global.rb:4:in `require_relative'
	from /usr/local/Homebrew/Library/Homebrew/global.rb:4:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:29:in `require_relative'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:29:in `<main>'
~~~

Looking at the build history, these failures appear to start after an aborted build:

<img width="1067" alt="Screen Shot 2022-03-29 at 10 09 23 PM" src="https://user-images.githubusercontent.com/3650755/160755628-0c085b2c-bc22-4c7a-827a-9870bfd2a91b.png">

Here is the context from the console log of the aborted build:

* https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-homebrew-amd64/7907/console

~~~
++ git clean -d -f
++ /usr/local/bin/brew audit cmake
Error: Failure while executing; `/usr/bin/env XDG_CACHE_HOME=/Users/jenkins/Library/Caches/Homebrew/style /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/bin/ruby /usr/local/Homebrew/Library/Homebrew/utils/rubocop.rb --format json --force-exclusion --parallel --except FormulaAuditStrict --config /usr/local/Homebrew/Library/.rubocop.yml /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/cmake.rb` was terminated by uncaught signal TERM.
++ restore_brew
++ rm -fr /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby
Build was aborted
~~~

It appears that the build was stopped during the initialization phase, leaving `brew` in a corrupted state, and the `brew list` call in subsequent builds fails.
