### PR TITLE
Allow CI Workflow jobs to run concurrently.

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericCompilation.groovy
@@ -41,6 +41,7 @@ class GenericCompilation
 
      job.with
      {
+        concurrentBuild(true)
         properties {
           priority 300
         }

--- a/jenkins-scripts/dsl/_configs_/OSRFCIWorkFlowMultiAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFCIWorkFlowMultiAnyGitHub.groovy
@@ -31,6 +31,7 @@ class OSRFCIWorkFlowMultiAnyGitHub
   {
     job.with
     {
+      concurrentBuild(true)
       logRotator {
         numToKeep(25)
       }

--- a/jenkins-scripts/dsl/_configs_/OSRFCIWorkFlowMultiAnyGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFCIWorkFlowMultiAnyGitHub.groovy
@@ -31,7 +31,6 @@ class OSRFCIWorkFlowMultiAnyGitHub
   {
     job.with
     {
-      concurrentBuild(true)
       logRotator {
         numToKeep(25)
       }


### PR DESCRIPTION
At the moment there is a backlog of ign_gazebo-pr-win jobs due in part to the fact that only one may run at a time.

I am not sure if there are some job types which should not be allowed to run conditionally but decided to start by just opening the floodgates in case it was just that easy.