### PR TITLE
dh-make lower than 2.202003 is buggy using --defaultess

### DIFF
--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -158,11 +158,11 @@ if $NIGHTLY_MODE; then
   rm -fr .hg* .git*
   # Versions of dh-make lower than 2.202003 are buggy using defaultless
   # see: https://salsa.debian.org/debian/dh-make/-/merge_requests/8
-  extra_dh_make_str = '--defaultless'
+  extra_dh_make_str='--defaultless'
   if dpkg --compare-versions \$(apt-cache show dh-make | sed -n "s/Version: \\(.*\\)/\\1/p") lt 2.202003; then
-    extra_dh_make_str = ''
+    extra_dh_make_str=''
   fi
-  echo | dh_make -y -s --createorig \${extra_dh_make_str} --defaultless -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
+  echo | dh_make -y -s --createorig \${extra_dh_make_str} -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
   rm -fr debian/
 fi
 

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -158,12 +158,12 @@ if $NIGHTLY_MODE; then
   rm -fr .hg* .git*
   # Versions of dh-make lower than 2.202003 are buggy using defaultless
   # see: https://salsa.debian.org/debian/dh-make/-/merge_requests/8
-  if dpkg --compare-versions \$(apt-cache show dh-make | sed -n "s/Version: \\(.*\\)/\\1/p") gt 2.202003; then
-    echo | dh_make -y -s --createorig -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
-    rm -fr debian/
-  else
-    echo | dh_make -y -s --createorig --defaultless -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
+  extra_dh_make_str = '--defaultless'
+  if dpkg --compare-versions \$(apt-cache show dh-make | sed -n "s/Version: \\(.*\\)/\\1/p") lt 2.202003; then
+    extra_dh_make_str = ''
   fi
+  echo | dh_make -y -s --createorig \${extra_dh_make_str} --defaultless -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
+  rm -fr debian/
 fi
 
 # Adding extra directories to code. debian has no problem but some extra directories

--- a/jenkins-scripts/docker/lib/debbuild-base.bash
+++ b/jenkins-scripts/docker/lib/debbuild-base.bash
@@ -156,7 +156,14 @@ cd \`find $WORKSPACE/build -mindepth 1 -type d |head -n 1\`
 # If use the quilt 3.0 format for debian (drcsim) it needs a tar.gz with sources
 if $NIGHTLY_MODE; then
   rm -fr .hg* .git*
-  echo | dh_make -y -s --createorig --defaultless -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
+  # Versions of dh-make lower than 2.202003 are buggy using defaultless
+  # see: https://salsa.debian.org/debian/dh-make/-/merge_requests/8
+  if dpkg --compare-versions \$(apt-cache show dh-make | sed -n "s/Version: \\(.*\\)/\\1/p") gt 2.202003; then
+    echo | dh_make -y -s --createorig -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
+    rm -fr debian/
+  else
+    echo | dh_make -y -s --createorig --defaultless -p${PACKAGE_ALIAS}_\${UPSTREAM_VERSION}+\${TIMESTAMP}+${RELEASE_VERSION}r\${REV} > /dev/null
+  fi
 fi
 
 # Adding extra directories to code. debian has no problem but some extra directories


### PR DESCRIPTION
Continue of #674 and fixed problems on Focal after merging that PR

dh-make version in Focal and lower is buggy when using the `--defaultless` flag since it requires to have a debian/rules file mandatory. Reported and fixed https://salsa.debian.org/debian/dh-make/-/merge_requests/8

Workaround is to run the tool without the parameter and remove the created debian/ directory afterwards.
Tested in: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-rendering7-debbuilder&build=264)](https://build.osrfoundation.org/job/ign-rendering7-debbuilder/264/)