### PR TITLE
Check that debchange is installed in the system for changelog_spawn.sh

### DIFF
--- a/release-repo-scripts/changelog_spawn.sh
+++ b/release-repo-scripts/changelog_spawn.sh
@@ -39,6 +39,12 @@ if [[ ${version%-*} == ${version} ]]; then
   exit 1
 fi
 
+if ! debchange --version > /dev/null 2>/dev/null; then
+  echo "debchange is not installed in the system."
+  echo "On Ubuntu/Debian systems please run: sudo apt-get install -y devscripts"
+  exit 1
+fi
+
 changelog_example=$(find . -name changelog | head -n 1)
 
 if [[ -z ${changelog_example} ]]; then

--- a/release-repo-scripts/changelog_spawn.sh
+++ b/release-repo-scripts/changelog_spawn.sh
@@ -20,6 +20,8 @@
 # $ cd $software-release
 # $ ./changelog_spawn <version> [msg]
 
+set -e
+
 version=${1}
 msg=${2}
 


### PR DESCRIPTION
@caguero was bitten by the fact of not having debchange present in the system. No error, no output, nothing. This PR adds a couple of things:

 * Stop on errors using set -e 
 * Check and warn if the tool is not installed in the system
