### PR TITLE
Fix GZDEV_PROJECT_NAME for ign-utils2

### DIFF
--- a/jenkins-scripts/docker/ign_utils-compilation.bash
+++ b/jenkins-scripts/docker/ign_utils-compilation.bash
@@ -30,6 +30,6 @@ fi
 
 export NEED_C17_COMPILER=true
 
-export GZDEV_PROJECT_NAME="ignition-utils${IGN_UTILS_DEPENDENCIES}"
+export GZDEV_PROJECT_NAME="ignition-utils${IGN_UTILS_MAJOR_VERSION}"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash

--- a/release-repo-scripts/bump_major_version.bash
+++ b/release-repo-scripts/bump_major_version.bash
@@ -36,10 +36,10 @@ if [[ ! -d ubuntu/ ]]; then
 fi
 
 
-#if [[ $old_version != 1 ]] && [[ $(find . -name *${old_version}-*.install | wc -l) -lt 1 ]]; then
-#    echo "Not found a single install file with the old_version number"
-#    exit 1
-#fi
+if [[ $old_version != 1 ]] && [[ $(find . -name *${old_version}-*.install | wc -l) -lt 1 ]]; then
+    echo "Not found a single install file with the old_version number"
+    exit 1
+fi
 
 # extract software name (prune for not in debian/, -quit to stop at first)
 old_software_name=$(find . -path ./debian -prune -o -name changelog -exec dpkg-parsechangelog -l {} -S source \; -quit)

--- a/release-repo-scripts/bump_major_version.bash
+++ b/release-repo-scripts/bump_major_version.bash
@@ -36,10 +36,10 @@ if [[ ! -d ubuntu/ ]]; then
 fi
 
 
-if [[ $old_version != 1 ]] && [[ $(find . -name *${old_version}-*.install | wc -l) -lt 1 ]]; then
-    echo "Not found a single install file with the old_version number"
-    exit 1
-fi
+#if [[ $old_version != 1 ]] && [[ $(find . -name *${old_version}-*.install | wc -l) -lt 1 ]]; then
+#    echo "Not found a single install file with the old_version number"
+#    exit 1
+#fi
 
 # extract software name (prune for not in debian/, -quit to stop at first)
 old_software_name=$(find . -path ./debian -prune -o -name changelog -exec dpkg-parsechangelog -l {} -S source \; -quit)


### PR DESCRIPTION
Needed by 
* https://github.com/ignition-tooling/release-tools/issues/685
* https://github.com/ignitionrobotics/ign-utils/pull/49

Oops, that was probably bad copy-paste. See how other libs are correct:

https://github.com/ignition-tooling/release-tools/blob/54d09aeadb420e6f9bbb7836fa929cda5dfd1788/jenkins-scripts/docker/ign_math-compilation.bash#L36

https://github.com/ignition-tooling/release-tools/blob/54d09aeadb420e6f9bbb7836fa929cda5dfd1788/jenkins-scripts/docker/ign_msgs-compilation.bash#L35

Without this, `gzdev` is not enabling nightlies for `ign-utils2` ubuntu builds

