### PR TITLE
Use BUILD_DOCS=OFF for ign-gazebo on Jammy

### DIFF
--- a/jenkins-scripts/docker/ign_gazebo-compilation.bash
+++ b/jenkins-scripts/docker/ign_gazebo-compilation.bash
@@ -28,6 +28,11 @@ if ! [[ ${IGN_GAZEBO_MAJOR_VERSION} =~ ^-?[0-9]+$ ]]; then
   exit -1
 fi
 
+# per bug https://github.com/ignitionrobotics/ign-gazebo/issues/1409
+if [[ ${DISTRO} == 'jammy' ]]; then
+  export BUILDING_EXTRA_CMAKE_PARAMS="-DBUILD_DOCS=OFF"
+fi
+
 export NEED_C17_COMPILER=true
 export GPU_SUPPORT_NEEDED=true
 


### PR DESCRIPTION
doxygen is buggy for ign-gazebo on Jammy https://github.com/ignitionrobotics/ign-gazebo/issues/1409

Twin of CI change done per https://github.com/ignitionrobotics/ign-gazebo/pull/1418#issuecomment-1090710034
