### PR TITLE
ign-tools doesn't depend on ign-cmake

### DIFF
--- a/jenkins-scripts/docker/ign_tools-compilation.bash
+++ b/jenkins-scripts/docker/ign_tools-compilation.bash
@@ -16,6 +16,6 @@ fi
 
 export BUILDING_SOFTWARE_DIRECTORY="ign-tools"
 export BUILDING_JOB_REPOSITORIES="stable"
-export BUILDING_DEPENDENCIES="libignition-cmake2-dev ruby"
+export BUILDING_DEPENDENCIES="ruby"
 
 . ${SCRIPT_DIR}/lib/generic-building-base.bash


### PR DESCRIPTION
This was probably added back when we attempted to add `ign-cmake` as a dependency, and it wasn't reverted when we failed.

I noticed it because it's making `ign-cmake2` and `ign-cmake3` be installed side-by-side as we bump libraries in

* https://github.com/ignition-tooling/release-tools/issues/685