### PR TITLE
Change linux-nightly-jammy from ip-* node to to drogon

### DIFF
--- a/docs/BUILDFARM_NODES.md
+++ b/docs/BUILDFARM_NODES.md
@@ -30,7 +30,7 @@ For generating nightlies controlling the generation order of every library, buil
 | -------- | ----------- |
 | linux-nightly-bionic | r2d2  |
 | linux-nightly-focal | optimus |
-| linux-nightly-jammy | linux-ip-172-30-1-216 |
+| linux-nightly-jammy | drogon |
 
 ## Provision of Node labels
 


### PR DESCRIPTION
To setup the `linux-nightly-jammy` label is hard to do it using AWS spawing machines (like current ip-* nodes). The are ocasionally destroyed by AWS and new nodes are using new images for AMI. This makes the fact of keeping the `linux-nightly-jammy` label in a single node 

Let's move the label to one of our permanent nodes, drogon.