### PR TITLE
Fix some bump_dependency edgecases

### DIFF
--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -468,6 +468,16 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     # Replace lines like "find_package(ignition-cmake2 2.0.0)"
     #               with "find_package(ignition-cmake3)"
     find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@\(find_package.*${DEP_LIB}\)${DEP_PREV_VER} \+${DEP_PREV_VER}[^ )]*@\1${DEP_VER}@g"
+
+    # Replace lines like "ign_find_package(ignition-math6 VERSION 6.5.0)"
+    #               with "ign_find_package(ignition-math7)"
+    # Preserves other args and handles edge cases:
+    #               like "ign_find_package(ignition-math6 VERSION 6.5.0 REQUIRED)"
+    #               with "ign_find_package(ignition-math6 REQUIRED)"
+    #               like "ign_find_package(ignition-math6 REQUIRED COMPONENTS VERSION 6.10 eigen3)"
+    #               with "ign_find_package(ignition-math7 REQUIRED COMPONENTS eigen3)"
+    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@\(ign_find_package.*${DEP_LIB}\)${DEP_PREV_VER}\(.*\) \+VERSION \+${DEP_PREV_VER}[^ )]*@\1${DEP_VER}\2@g"
+
     # Replace collection yaml branch names with main
     if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then
       find . -type f -name "collection-${COLLECTION}.yaml" -print0 | xargs -0 sed -i "s ign-${DEP_LIB}${DEP_VER} main g"
@@ -501,4 +511,3 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
   commitAndPR ${TOOLING_ORG} master
 
 done
-

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -476,7 +476,7 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     #               with "ign_find_package(ignition-math6 REQUIRED)"
     #               like "ign_find_package(ignition-math6 REQUIRED COMPONENTS VERSION 6.10 eigen3)"
     #               with "ign_find_package(ignition-math7 REQUIRED COMPONENTS eigen3)"
-    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@\(ign_find_package.*${DEP_LIB}\)${DEP_PREV_VER}\(.*\) \+VERSION \+${DEP_PREV_VER}[^ )]*@\1${DEP_VER}\2@g"
+    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@\(find_package.*${DEP_LIB}\)${DEP_PREV_VER}\(.*\) \+VERSION \+${DEP_PREV_VER}[^ )]*@\1${DEP_VER}\2@g"
 
     # Replace collection yaml branch names with main
     if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -464,6 +464,10 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     # Replace lines like: "set(IGN_PLUGIN_VER 2)"
     #               with: "set(IGN_PLUGIN_VER 3)"
     find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s@IGN_${DEP_LIB}_VER ${DEP_PREV_VER}@\UIGN_${DEP_LIB}_VER ${DEP_VER}@ig"
+
+    # Replace lines like "find_package(ignition-cmake2 2.0.0)"
+    #               with "find_package(ignition-cmake3)"
+    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@\(find_package.*${DEP_LIB}\)${DEP_PREV_VER} \+${DEP_PREV_VER}[^ )]*@\1${DEP_VER}@g"
     # Replace collection yaml branch names with main
     if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then
       find . -type f -name "collection-${COLLECTION}.yaml" -print0 | xargs -0 sed -i "s ign-${DEP_LIB}${DEP_VER} main g"

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -455,6 +455,9 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     DEP_VER=${VERSIONS[$j]}
     DEP_PREV_VER="$((${DEP_VER}-1))"
 
+    # Rule: *plugin2 -> *plugin3
+    # Replace lines like: "find_package(ignition-cmake2)"
+    #               with: "find_package(ignition-cmake3)"
     find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
 
     # Replace collection yaml branch names with main

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -460,6 +460,10 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     #               with: "find_package(ignition-cmake3)"
     find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
 
+    # Rule: IGN_PLUGIN_VER 2 -> IGN_PLUGIN_VER 3
+    # Replace lines like: "set(IGN_PLUGIN_VER 2)"
+    #               with: "set(IGN_PLUGIN_VER 3)"
+    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s@IGN_${DEP_LIB}_VER ${DEP_PREV_VER}@\UIGN_${DEP_LIB}_VER ${DEP_VER}@ig"
     # Replace collection yaml branch names with main
     if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then
       find . -type f -name "collection-${COLLECTION}.yaml" -print0 | xargs -0 sed -i "s ign-${DEP_LIB}${DEP_VER} main g"


### PR DESCRIPTION
Handles some of the edge cases tracked here:
https://github.com/ignition-tooling/release-tools/issues/689

Specifically:
- Cases like `ign-tools2 2.0.0` -> `ign-tools3 2.0.0` don't bump properly. (2.0.0 is expected to be bumped to 3.0.0)
  - Handle cases where those versions come as an argument to another parameter (e.g. `ign-tools2 VERSION 2.0.0`)
- Case: `IGN_<LIB>_VER N-1` -> `IGN_<LIB>_VER N` is not addressed