### PR TITLE
Fix ordering and remove IGN_<LIB>_VER pattern

### DIFF
--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -455,10 +455,10 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     DEP_VER=${VERSIONS[$j]}
     DEP_PREV_VER="$((${DEP_VER}-1))"
 
-    # Rule: IGN_PLUGIN_VER 2 -> IGN_PLUGIN_VER 3
+    # Rule: IGN_<LIB>_VER <N> -> IGN_<LIB>_VER ${ignition-<lib><N>_VERSION_MAJOR}
     # Replace lines like: "set(IGN_PLUGIN_VER 2)"
-    #               with: "set(IGN_PLUGIN_VER 3)"
-    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@IGN_${DEP_LIB}_VER ${DEP_PREV_VER}@\UIGN_${DEP_LIB}_VER ${DEP_VER}@ig"
+    #               with: "set(IGN_PLUGIN_VER ${ignition-plugin3_VERSION_MAJOR})"
+    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@IGN_${DEP_LIB}_VER ${DEP_PREV_VER}@\UIGN_${DEP_LIB}_VER \L\$\{ignition-${DEP_LIB}${DEP_VER}_\UVERSION_MAJOR\}@ig"
 
     # Replace lines like "find_package(ignition-cmake2 2.0.0)"
     #               with "find_package(ignition-cmake3)"

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -455,15 +455,10 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     DEP_VER=${VERSIONS[$j]}
     DEP_PREV_VER="$((${DEP_VER}-1))"
 
-    # Rule: *plugin2 -> *plugin3
-    # Replace lines like: "find_package(ignition-cmake2)"
-    #               with: "find_package(ignition-cmake3)"
-    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
-
     # Rule: IGN_PLUGIN_VER 2 -> IGN_PLUGIN_VER 3
     # Replace lines like: "set(IGN_PLUGIN_VER 2)"
     #               with: "set(IGN_PLUGIN_VER 3)"
-    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s@IGN_${DEP_LIB}_VER ${DEP_PREV_VER}@\UIGN_${DEP_LIB}_VER ${DEP_VER}@ig"
+    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@IGN_${DEP_LIB}_VER ${DEP_PREV_VER}@\UIGN_${DEP_LIB}_VER ${DEP_VER}@ig"
 
     # Replace lines like "find_package(ignition-cmake2 2.0.0)"
     #               with "find_package(ignition-cmake3)"
@@ -477,6 +472,12 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     #               like "ign_find_package(ignition-math6 REQUIRED COMPONENTS VERSION 6.10 eigen3)"
     #               with "ign_find_package(ignition-math7 REQUIRED COMPONENTS eigen3)"
     find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@\(find_package.*${DEP_LIB}\)${DEP_PREV_VER}\(.*\) \+VERSION \+${DEP_PREV_VER}[^ )]*@\1${DEP_VER}\2@g"
+
+
+    # Rule: *plugin2 -> *plugin3
+    # Replace lines like: "find_package(ignition-cmake2)"
+    #               with: "find_package(ignition-cmake3)"
+    find . -type f ! -name 'Changelog.md' ! -name 'Migration.md' -print0 | xargs -0 sed -i "s ${DEP_LIB}${DEP_PREV_VER} ${DEP_LIB}${DEP_VER} g"
 
     # Replace collection yaml branch names with main
     if [[ "${LIB}" == "ign-${COLLECTION}" ]]; then

--- a/release-repo-scripts/bump_dependency.bash
+++ b/release-repo-scripts/bump_dependency.bash
@@ -455,11 +455,6 @@ for ((i = 0; i < "${#LIBRARIES[@]}"; i++)); do
     DEP_VER=${VERSIONS[$j]}
     DEP_PREV_VER="$((${DEP_VER}-1))"
 
-    # Rule: IGN_<LIB>_VER <N> -> IGN_<LIB>_VER ${ignition-<lib><N>_VERSION_MAJOR}
-    # Replace lines like: "set(IGN_PLUGIN_VER 2)"
-    #               with: "set(IGN_PLUGIN_VER ${ignition-plugin3_VERSION_MAJOR})"
-    find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@IGN_${DEP_LIB}_VER ${DEP_PREV_VER}@\UIGN_${DEP_LIB}_VER \L\$\{ignition-${DEP_LIB}${DEP_VER}_\UVERSION_MAJOR\}@ig"
-
     # Replace lines like "find_package(ignition-cmake2 2.0.0)"
     #               with "find_package(ignition-cmake3)"
     find . -type f -name 'CMakeLists.txt' -print0 | xargs -0 sed -i "s@\(find_package.*${DEP_LIB}\)${DEP_PREV_VER} \+${DEP_PREV_VER}[^ )]*@\1${DEP_VER}@g"


### PR DESCRIPTION
Followups from: https://github.com/ignition-tooling/release-tools/pull/699 , which introduced a bug where later replacements wouldn't get caught due to prior replacements.

Also introduces a rule to remove the IGN_<LIB>_VER N pattern:
```
    # Rule: IGN_<LIB>_VER <N> -> IGN_<LIB>_VER ${ignition-<lib><N>_VERSION_MAJOR}
    # Replace lines like: "set(IGN_PLUGIN_VER 2)"
    #               with: "set(IGN_PLUGIN_VER ${ignition-plugin3_VERSION_MAJOR})"
                                                              ^^^ <-- Bumped!
```