### PR TITLE
Use colcon auto major version for ign-tools

### DIFF
--- a/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
@@ -5,6 +5,6 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 set COLCON_PACKAGE=ignition-tools
-set COLCON_AUTO_MAJOR_VERSION=false
+set COLCON_AUTO_MAJOR_VERSION=true
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"


### PR DESCRIPTION
* Needed by https://github.com/ignitionrobotics/ign-tools/pull/82
* Part of https://github.com/ignition-tooling/release-tools/issues/685

I checked that `jenkins-scripts/tools/detect_cmake_major_version.py` correctly returns `1` for the `ign-tools1` branch and `2` for the branch on the PR above.

Build with this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_tools-pr-win&build=44)](https://build.osrfoundation.org/job/ign_tools-pr-win/44/)