### PR TITLE
ign-tools auto version

### DIFF
--- a/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
+++ b/jenkins-scripts/ign_tools-default-devel-windows-amd64.bat
@@ -5,6 +5,6 @@ set PLATFORM_TO_BUILD=x86_amd64
 set IGN_CLEAN_WORKSPACE=true
 
 set COLCON_PACKAGE=ignition-tools
-set COLCON_AUTO_MAJOR_VERSION=true
+set COLCON_AUTO_MAJOR_VERSION=false
 
 call "%SCRIPT_DIR%\lib\colcon-default-devel-windows.bat"

--- a/jenkins-scripts/lib/colcon-default-devel-windows.bat
+++ b/jenkins-scripts/lib/colcon-default-devel-windows.bat
@@ -29,8 +29,8 @@ set LOCAL_WS_BUILD=%WORKSPACE%\build
 @if "%COLCON_AUTO_MAJOR_VERSION%" == "" set COLCON_AUTO_MAJOR_VERSION=false
 
 setlocal ENABLEDELAYEDEXPANSION
-if "%COLCON_AUTO_MAJOR_VERSION%" == "true" (
-   for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i
+for /f %%i in ('python "%SCRIPT_DIR%\tools\detect_cmake_major_version.py" "%WORKSPACE%\%VCS_DIRECTORY%\CMakeLists.txt"') do set PKG_MAJOR_VERSION=%%i
+if "%COLCON_AUTO_MAJOR_VERSION%" == "true" || "%PKG_MAJOR_VERSION%" != "1" (
    set COLCON_PACKAGE=%COLCON_PACKAGE%!PKG_MAJOR_VERSION!
    echo "MAJOR_VERSION detected: !PKG_MAJOR_VERSION!"
 )


### PR DESCRIPTION
I broke CI for `ign-tools1` on #702 because now the package ends up being `ignition-tools1` when it should be `ignition-tools`.

I moved the logic around to support this specific use case. The `COLCON_AUTO_MAJOR_VERSION` variable's meaning is a bit changed now, but grepping through the code it looks like `ign-tools` is the only one setting it to false anyway.

I don't know if the syntax is correct 🙃 

Test builds:

* `ign-tools1`: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_tools-pr-win&build=47)](https://build.osrfoundation.org/job/ign_tools-pr-win/47/)
* `ign-tools2`: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_tools-pr-win&build=48)](https://build.osrfoundation.org/job/ign_tools-pr-win/48/)