### PR TITLE
Remove libglvnd in docker for jammy (broken) and fix gazebo CI

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -345,6 +345,7 @@ DELIM_NVIDIA_GPU
 GLVND_VERSION=1.2.0
 if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
   GLVND_VERSION=1.4.0
+fi
 cat >> Dockerfile << DELIM_NVIDIA2_GPU
   # nvidia-container-runtime
   ENV NVIDIA_VISIBLE_DEVICES \

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -344,7 +344,7 @@ DELIM_NVIDIA_GPU
 # NVIDIA is using nvidia_docker2 integration
 GLVND_VERSION=1.2.0
 if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
-  GLVND_VERSION=1.4.0
+  GLVND_VERSION=1.3.4
 fi
 cat >> Dockerfile << DELIM_NVIDIA2_GPU
   # nvidia-container-runtime

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -342,16 +342,16 @@ cat >> Dockerfile << DELIM_NVIDIA_GPU
 DELIM_NVIDIA_GPU
    else
 # NVIDIA is using nvidia_docker2 integration
-GLVND_VERSION=1.2.0
-if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
-  GLVND_VERSION=1.3.4
-fi
 cat >> Dockerfile << DELIM_NVIDIA2_GPU
   # nvidia-container-runtime
   ENV NVIDIA_VISIBLE_DEVICES \
     ${NVIDIA_VISIBLE_DEVICES:-all}
   ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+DELIM_NVIDIA2_GPU
+
+if [[ ${LINUX_DISTRO} == 'ubuntu' ]] && [[ ${DISTRO} == 'bionic' && ${DISTRO} == 'focal' ]]; then
+cat >> Dockerfile << DELIM_NVIDIA3_GPU
 # Install libglvnd for OpenGL using nvidia-docker2
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
@@ -367,13 +367,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         x11proto-gl-dev && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
-    git clone -b v${GLVND_VERSION} https://github.com/NVIDIA/libglvnd.git . && \
+    git clone -b v1.2.0 https://github.com/NVIDIA/libglvnd.git . && \
     ./autogen.sh && \
     ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
     make install-strip && \
     find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
 ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}
-DELIM_NVIDIA2_GPU
+DELIM_NVIDIA3_GPU
+fi
   fi
  else
   # No NVIDIA cards needs to have the same X stack than the host

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -341,38 +341,12 @@ cat >> Dockerfile << DELIM_NVIDIA_GPU
   ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\${LD_LIBRARY_PATH}
 DELIM_NVIDIA_GPU
    else
-# NVIDIA is using nvidia_docker2 integration
-GLVND_VERSION=1.2.0
-if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
-  GLVND_VERSION=1.3.4
-fi
 cat >> Dockerfile << DELIM_NVIDIA2_GPU
   # nvidia-container-runtime
   ENV NVIDIA_VISIBLE_DEVICES \
     ${NVIDIA_VISIBLE_DEVICES:-all}
   ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
-# Install libglvnd for OpenGL using nvidia-docker2
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        git \
-        ca-certificates \
-        make \
-        automake \
-        autoconf \
-        libtool \
-        pkg-config \
-        python3 \
-        libxext-dev \
-        libx11-dev \
-        x11proto-gl-dev && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
-    git clone -b v${GLVND_VERSION} https://github.com/NVIDIA/libglvnd.git . && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
-    make install-strip && \
-    find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
-ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}
 DELIM_NVIDIA2_GPU
   fi
  else

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -350,7 +350,7 @@ cat >> Dockerfile << DELIM_NVIDIA2_GPU
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
 DELIM_NVIDIA2_GPU
 
-if [[ ${LINUX_DISTRO} == 'ubuntu' ]] && [[ ${DISTRO} == 'bionic' && ${DISTRO} == 'focal' ]]; then
+if [[ ${LINUX_DISTRO} == 'ubuntu' ]] && [[ ${DISTRO} == 'bionic' || ${DISTRO} == 'focal' ]]; then
 cat >> Dockerfile << DELIM_NVIDIA3_GPU
 # Install libglvnd for OpenGL using nvidia-docker2
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -342,6 +342,9 @@ cat >> Dockerfile << DELIM_NVIDIA_GPU
 DELIM_NVIDIA_GPU
    else
 # NVIDIA is using nvidia_docker2 integration
+GLVND_VERSION=1.2.0
+if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
+  GLVND_VERSION=1.4.0
 cat >> Dockerfile << DELIM_NVIDIA2_GPU
   # nvidia-container-runtime
   ENV NVIDIA_VISIBLE_DEVICES \
@@ -363,7 +366,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         x11proto-gl-dev && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
-    git clone -b v1.2.0 https://github.com/NVIDIA/libglvnd.git . && \
+    git clone -b v${GLVND_VERSION} https://github.com/NVIDIA/libglvnd.git . && \
     ./autogen.sh && \
     ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
     make install-strip && \

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -331,8 +331,8 @@ DELIM_DOCKER_SQUID
 fi
 
 if $USE_GPU_DOCKER; then
- if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
-   if [[ ${NVIDIA_DOCKER_DRIVER} == 'nvidia-docker' ]]; then
+  if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
+    if [[ ${NVIDIA_DOCKER_DRIVER} == 'nvidia-docker' ]]; then
 # NVIDIA-DOCKER1
 cat >> Dockerfile << DELIM_NVIDIA_GPU
   # nvidia-container-runtime
@@ -340,41 +340,6 @@ cat >> Dockerfile << DELIM_NVIDIA_GPU
   ENV PATH /usr/local/nvidia/bin:\${PATH}
   ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\${LD_LIBRARY_PATH}
 DELIM_NVIDIA_GPU
-   else
-# NVIDIA is using nvidia_docker2 integration
-GLVND_VERSION=1.2.0
-if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
-  GLVND_VERSION=1.3.4
-fi
-cat >> Dockerfile << DELIM_NVIDIA2_GPU
-  # nvidia-container-runtime
-  ENV NVIDIA_VISIBLE_DEVICES \
-    ${NVIDIA_VISIBLE_DEVICES:-all}
-  ENV NVIDIA_DRIVER_CAPABILITIES \
-    ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
-# Install libglvnd for OpenGL using nvidia-docker2
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        git \
-        ca-certificates \
-        make \
-        automake \
-        autoconf \
-        libtool \
-        pkg-config \
-        python3 \
-        libxext-dev \
-        libx11-dev \
-        x11proto-gl-dev && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
-    git clone -b v${GLVND_VERSION} https://github.com/NVIDIA/libglvnd.git . && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
-    make install-strip && \
-    find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
-ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}
-DELIM_NVIDIA2_GPU
-  fi
  else
   # No NVIDIA cards needs to have the same X stack than the host
   cat >> Dockerfile << DELIM_DISPLAY
@@ -387,6 +352,7 @@ RUN CHROOT_GRAPHIC_CARD_PKG_VERSION=\$(dpkg -l | grep "^ii.*${GRAPHIC_CARD_PKG}\
        exit 1 \\
    fi
 DELIM_DISPLAY
+    fi
   fi
 fi
 

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -341,12 +341,38 @@ cat >> Dockerfile << DELIM_NVIDIA_GPU
   ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\${LD_LIBRARY_PATH}
 DELIM_NVIDIA_GPU
    else
+# NVIDIA is using nvidia_docker2 integration
+GLVND_VERSION=1.2.0
+if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
+  GLVND_VERSION=1.3.4
+fi
 cat >> Dockerfile << DELIM_NVIDIA2_GPU
   # nvidia-container-runtime
   ENV NVIDIA_VISIBLE_DEVICES \
     ${NVIDIA_VISIBLE_DEVICES:-all}
   ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+# Install libglvnd for OpenGL using nvidia-docker2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        make \
+        automake \
+        autoconf \
+        libtool \
+        pkg-config \
+        python3 \
+        libxext-dev \
+        libx11-dev \
+        x11proto-gl-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
+    git clone -b v${GLVND_VERSION} https://github.com/NVIDIA/libglvnd.git . && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
+    make install-strip && \
+    find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
+ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}
 DELIM_NVIDIA2_GPU
   fi
  else

--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -331,8 +331,8 @@ DELIM_DOCKER_SQUID
 fi
 
 if $USE_GPU_DOCKER; then
-  if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
-    if [[ ${NVIDIA_DOCKER_DRIVER} == 'nvidia-docker' ]]; then
+ if [[ $GRAPHIC_CARD_NAME == "Nvidia" ]]; then
+   if [[ ${NVIDIA_DOCKER_DRIVER} == 'nvidia-docker' ]]; then
 # NVIDIA-DOCKER1
 cat >> Dockerfile << DELIM_NVIDIA_GPU
   # nvidia-container-runtime
@@ -340,6 +340,41 @@ cat >> Dockerfile << DELIM_NVIDIA_GPU
   ENV PATH /usr/local/nvidia/bin:\${PATH}
   ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\${LD_LIBRARY_PATH}
 DELIM_NVIDIA_GPU
+   else
+# NVIDIA is using nvidia_docker2 integration
+GLVND_VERSION=1.2.0
+if [[ ${LINUX_DISTRO} == 'ubuntu' && ( ${DISTRO} != 'bionic' && ${DISTRO} != 'focal' ) ]]; then
+  GLVND_VERSION=1.3.4
+fi
+cat >> Dockerfile << DELIM_NVIDIA2_GPU
+  # nvidia-container-runtime
+  ENV NVIDIA_VISIBLE_DEVICES \
+    ${NVIDIA_VISIBLE_DEVICES:-all}
+  ENV NVIDIA_DRIVER_CAPABILITIES \
+    ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
+# Install libglvnd for OpenGL using nvidia-docker2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        make \
+        automake \
+        autoconf \
+        libtool \
+        pkg-config \
+        python3 \
+        libxext-dev \
+        libx11-dev \
+        x11proto-gl-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/libglvnd && cd /opt/libglvnd && \
+    git clone -b v${GLVND_VERSION} https://github.com/NVIDIA/libglvnd.git . && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr/local --libdir=/usr/local/lib/x86_64-linux-gnu && \
+    make install-strip && \
+    find /usr/local/lib/x86_64-linux-gnu -type f -name 'lib*.la' -delete
+ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}
+DELIM_NVIDIA2_GPU
+  fi
  else
   # No NVIDIA cards needs to have the same X stack than the host
   cat >> Dockerfile << DELIM_DISPLAY
@@ -352,7 +387,6 @@ RUN CHROOT_GRAPHIC_CARD_PKG_VERSION=\$(dpkg -l | grep "^ii.*${GRAPHIC_CARD_PKG}\
        exit 1 \\
    fi
 DELIM_DISPLAY
-    fi
   fi
 fi
 

--- a/jenkins-scripts/dsl/gazebo.dsl
+++ b/jenkins-scripts/dsl/gazebo.dsl
@@ -49,6 +49,9 @@ void generate_install_job(Job job, gz_branch, distro, arch, use_osrf_repos = fal
 
     // Branch is exactly in the form of gazeboN
     def dev_packages = "lib${gz_branch}-dev ${gz_branch}"
+    // Ubuntu Jammy has no versioned gazebo package
+    if (distro == 'jammy')
+      dev_packages = "libgazebo-dev gazebo"
 
     def gzdev_str = ""
     if (use_osrf_repos)

--- a/jenkins-scripts/parser_rules/gazebo_err.parser
+++ b/jenkins-scripts/parser_rules/gazebo_err.parser
@@ -1,1 +1,1 @@
-error /.*\[Err\].*/
+error /.*\[Err\].*(!OpenAL.cc).*/


### PR DESCRIPTION
The library libglvnd is being used in our docker build although I'm not sure that we really need it. The description of the library says: "libglvnd is a vendor-neutral dispatch layer for arbitrating OpenGL API calls between multiple vendors" . Our Jenkins nodes should not needed AFAIK.

The compilation is broken on Jammy.  The PR skip it for Jammy although it is maintained for Bionic/Focal to avoid possible regressions on current builds. I've tested the changes with Gazebo classic. To make it work some other fixes are in this PR:

 * Gazebo packages from Ubuntu are unversioned f74de1571f6004f3af0c6066073593dba3068f88
 * Do not make the build to be unstable if Gazebo error about OpenAL (sounds) is found 2e405856b401cb3399b9955034433e47674e8508

Currently broken: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install_ubuntu_official-gazebo11_pkg-jammy-amd64&build=52)](https://build.osrfoundation.org/job/gazebo-install_ubuntu_official-gazebo11_pkg-jammy-amd64/52/)
With this branch:  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install_ubuntu_official-gazebo11_pkg-jammy-amd64&build=53)](https://build.osrfoundation.org/job/gazebo-install_ubuntu_official-gazebo11_pkg-jammy-amd64/53/) (on r2d2)