### PR TITLE
Support for Rolling on Jammy for gazebo_ros_pkgs

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -21,7 +21,7 @@ class Globals
                      'noetic'   : ['focal'] ,
                      'foxy'     : ['focal'] ,
                      'galactic' : ['focal'] ,
-                     'rolling'  : ['focal']]
+                     'rolling'  : ['jammy']]
 
    // This should be in sync with archive_library
    static gz_version_by_rosdistro = [ 'melodic'  : ['9'] ,

--- a/jenkins-scripts/lib/dependencies_archive.sh
+++ b/jenkins-scripts/lib/dependencies_archive.sh
@@ -246,9 +246,16 @@ else
 
   case ${GAZEBO_VERSION_FOR_ROS} in
      *)
-      # both packages see  http://answers.ros.org/question/217970
-      _GZ_ROS_PACKAGES="libgazebo${GAZEBO_VERSION_FOR_ROS}-dev \\
-                       gazebo${GAZEBO_VERSION_FOR_ROS}"
+      # Rolling is supported only on Jammy. Gazebo11 packages from Jammy
+      # are coming directly from Ubuntu repositories, package names are
+      # unversioned
+      if [[ ${DISTRO} == 'jammy' ]]; then
+        _GZ_ROS_PACKAGES="libgazebo-dev gazebo"
+      else
+        # both packages see  http://answers.ros.org/question/217970
+        _GZ_ROS_PACKAGES="libgazebo${GAZEBO_VERSION_FOR_ROS}-dev \\
+                         gazebo${GAZEBO_VERSION_FOR_ROS}"
+      fi
     ;;
   esac
 


### PR DESCRIPTION
- Move ROS 2 Rolling CI to Jammy
- Use unversioned gazebo packages in Jammy

DSL testing
https://build.osrfoundation.org/job/_dsl_gazebo_ros_pkgs/880/console
```
Unreferenced items:
    GeneratedJob{name='ros2_gazebo_pkgs-ci-default_rolling-focal-amd64'}
    GeneratedJob{name='ros2_gazebo_pkgs-ci-pr_any_rolling-focal-amd64'}
Disabled items:
    GeneratedJob{name='ros2_gazebo_pkgs-ci-default_rolling-focal-amd64'}
    GeneratedJob{name='ros2_gazebo_pkgs-ci-pr_any_rolling-focal-amd64'}
Finished: SUCCESS
```
Build ci:
[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros2_gazebo_pkgs-ci-default_rolling-jammy-amd64&build=1)](https://build.osrfoundation.org/job/ros2_gazebo_pkgs-ci-default_rolling-jammy-amd64/1/)