### PR TITLE
Monitor the new gz-names in github repositories

### DIFF
--- a/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/GenericAnyJobGitHub.groovy
@@ -25,6 +25,8 @@ class GenericAnyJobGitHub
 
     // Get repo name for relativeTargetDirectory
     String github_repo_name = github_repo.substring(github_repo.lastIndexOf("/") + 1)
+    // Use new gz- repositories
+    github_repo = Globals.ign2gz(github_repo)
 
     job.with
     {

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -30,6 +30,12 @@ class Globals
                                       'galactic' : ['11'] ,
                                       'rolling'  : ['11']]
 
+   static String ign2gz(String str) {
+     str = str.replaceAll("ignitionrobotics","gazebosim")
+     str = str.replaceAll("ign-gazebo","gz-sim")
+     return str.replaceAll("ign-","gz-")
+   }
+
    static ArrayList get_ros_distros_by_ubuntu_distro(String ubuntu_distro)
    {
       ArrayList result = []

--- a/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFGitHub.groovy
@@ -13,6 +13,8 @@ class OSRFGitHub
     if (subdir == 'NOT-DEFINED-USE-DEFAULT')
       subdir = software_name
 
+    repo = Globals.ign2gz(repo)
+
     job.with
     {
       scm {


### PR DESCRIPTION
Targeting only ignitionrobotics new repositories by now.

To be merged and run on dsl as soon as the migration is done.
