### PR TITLE
Reduce max number of builds to keep to 125 in Jenkins

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxABIGitHub.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxABIGitHub.groovy
@@ -40,7 +40,7 @@ class OSRFLinuxABIGitHub
 
       logRotator {
         artifactNumToKeep(10)
-        numToKeep(200)
+        numToKeep(125)
       }
 
       concurrentBuild(true)

--- a/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFLinuxBuildPkgBase.groovy
@@ -18,7 +18,7 @@ class OSRFLinuxBuildPkgBase
      {
        logRotator {
          artifactNumToKeep(25)
-         numToKeep(200)
+         numToKeep(125)
        }
 
        wrappers {


### PR DESCRIPTION
I've seen several timeouts when accessing to -debbuilders pages on Jenkins. Checking the log / resource seems like the CPU is really high and one of the reasons that could be behind this is the number of stored old builds. Reducing here its number for debbuilder and abicheckers from 200 to 125 which is not a small list of builds to keep.