### PR TITLE
Use docker label in ci__colcon jobs

### DIFF
--- a/jenkins-scripts/ros_buildfarm_config/global/colcon_gpu_any-manual.yaml
+++ b/jenkins-scripts/ros_buildfarm_config/global/colcon_gpu_any-manual.yaml
@@ -4,7 +4,7 @@
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-jenkins_job_label: (docker && gpu-reliable) && !test-instance
+jenkins_job_label: '(docker &amp;&amp; gpu-reliable) &amp;&amp; !test-instance'
 jenkins_job_priority: 200  # same than pr-any
 jenkins_job_timeout: 300
 repos_files:


### PR DESCRIPTION
dry-running with https://github.com/ros-infrastructure/ros_buildfarm/pull/1059/files


```diff
Updating view 'ci' (dry run)
    <<<
Updating job 'ci__colcon_gpu_any-manual_ubuntu_jammy_amd64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -14 +14 @@
    -    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@4.1.0">
    +    <jenkins.advancedqueue.priority.strategy.PriorityJobProperty plugin="PrioritySorter@5.2.0">
    @@ -18 +18 @@
    -    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.33">
    +    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@332.va_1ee476d8f6d">
    @@ -87,3 +87,3 @@
    -    <com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty plugin="build-failure-analyzer@2.2.1">
    -      <doNotScan>false</doNotScan>
    -    </com.sonyericsson.jenkins.plugins.bfa.model.ScannerJobProperty>
    +    <hudson.plugins.heavy__job.HeavyJobProperty plugin="heavy-job@1.1">
    +      <weight>1</weight>
    +    </hudson.plugins.heavy__job.HeavyJobProperty>
    @@ -93 +93 @@
    -  <assignedNode>gpu-reliable</assignedNode>
    +  <assignedNode>(docker &amp;&amp; gpu-reliable) &amp;&amp; !test-instance</assignedNode>
    @@ -98 +98,2 @@
    -  <triggers />
    +  <triggers>
    +  </triggers>
    @@ -101 +102 @@
    -    <hudson.plugins.groovy.SystemGroovy plugin="groovy@2.2">
    +    <hudson.plugins.groovy.SystemGroovy plugin="groovy@457.v99900cb_85593">
    @@ -103 +104 @@
    -        <script plugin="script-security@1145.vb_cf6cf6ed960">
    +        <script plugin="script-security@1369.v9b_98a_4e95b_2d">
    @@ -179 +180 @@
    -    <hudson.plugins.groovy.SystemGroovy plugin="groovy@2.2">
    +    <hudson.plugins.groovy.SystemGroovy plugin="groovy@457.v99900cb_85593">
    @@ -181 +182 @@
    -        <script plugin="script-security@1145.vb_cf6cf6ed960">
    +        <script plugin="script-security@1369.v9b_98a_4e95b_2d">
    @@ -463 +464 @@
    -    <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@9.11.1">
    +    <io.jenkins.plugins.analysis.core.steps.IssuesRecorder plugin="warnings-ng@11.12.0">
    @@ -468 +468,0 @@
    -          <jenkins plugin="plugin-util-api@2.16.0" />
    @@ -476 +475,0 @@
    -          <jenkins plugin="plugin-util-api@2.16.0" />
    @@ -484 +482,0 @@
    -          <jenkins plugin="plugin-util-api@2.16.0" />
    @@ -492 +489,0 @@
    -      <sourceDirectories />
    @@ -498 +495 @@
    -      <minimumSeverity plugin="analysis-model-api@10.9.4">
    +      <minimumSeverity plugin="analysis-model-api@12.9.1">
    @@ -530 +527 @@
    -    <xunit plugin="xunit@3.0.2">
    +    <xunit plugin="xunit@3.1.5">
    @@ -581 +578,14 @@
    -  <buildWrappers />
    +  <buildWrappers>
    +    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.33">
    +      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
    +        <timeoutMinutes>300</timeoutMinutes>
    +      </strategy>
    +      <operationList>
    +        <hudson.plugins.build__timeout.operations.WriteDescriptionOperation>
    +          <description>Build timed out after {0} minutes</description>
    +        </hudson.plugins.build__timeout.operations.WriteDescriptionOperation>
    +        <hudson.plugins.build__timeout.operations.FailOperation />
    +      </operationList>
    +    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
    +    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.28" />
    +  </buildWrappers>
    >>>
```

