### PR TITLE
Enable timestamps in all jobs

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
@@ -43,6 +43,10 @@ class OSRFBase
           }
         }
 
+        wrappers {
+          timestamps()
+        }
+
         // Create the naginator retry tags
         HelperRetryFailures.create(job, [
           regexpForRerun: "java.nio.channels.ClosedChannelException",


### PR DESCRIPTION
I saw https://github.com/osrf/chef-osrf/pull/199. This plugin was added in the 24.04 migration. However, it is disabled.

I tested the timestamper manual configuration in https://build.osrfoundation.org/job/gz_common5-install_bottle-homebrew-amd64/662/console

To enable it, I took a look at [timestamper dsl config](https://build.osrfoundation.org/plugin/job-dsl/api-viewer/index.html#method/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.timestamps).

As the title says. This is applied to OSRFBase.groovy, implying, it's added to all jobs in osrfbuild


