### PR TITLE
Use brew main branch until bugfix is released

### DIFF
--- a/jenkins-scripts/lib/_homebrew_base_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_base_setup.bash
@@ -15,6 +15,10 @@ fi
 
 git -C $(brew --repo) fsck
 export HOMEBREW_UPDATE_TO_TAG=1
+if [[ $(date +%Y%m%d) -le 20251031 ]]; then
+  # until https://github.com/Homebrew/brew/pull/20909 is released
+  unset HOMEBREW_UPDATE_TO_TAG
+fi
 
 # There might be a background process that blocks `brew update`, so we try to
 # run it several times until it succeeds.

--- a/jenkins-scripts/lib/_homebrew_cleanup.bash
+++ b/jenkins-scripts/lib/_homebrew_cleanup.bash
@@ -12,6 +12,10 @@ restore_brew()
 # but don't fail
 git -C $(brew --repo) fsck || true
 export HOMEBREW_UPDATE_TO_TAG=1
+if [[ $(date +%Y%m%d) -le 20251031 ]]; then
+  # until https://github.com/Homebrew/brew/pull/20909 is released
+  unset HOMEBREW_UPDATE_TO_TAG
+fi
 # call restore_brew if CLEAR_BREW_CACHE is set
 if ${CLEAR_BREW_CACHE}; then
   # Assume that brew is already in the PATH


### PR DESCRIPTION
A bug in brew that causes our `install_bottle` and bottle builder jobs to fail (more details in https://github.com/Homebrew/brew/pull/20896#issuecomment-3419257460) was recently fixed in https://github.com/Homebrew/brew/pull/20909. The fix in `brew` has not yet been released, so unset `HOMEBREW_UPDATE_TO_TAG` for the next 10 days, which should be enough time for the next `brew` tag. This approach was previously used in https://github.com/gazebo-tooling/release-tools/commit/566efb0bd0f03404804a64eb6c45421838735807.

### example failure

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering9-install_bottle-homebrew-arm64&build=41)](https://build.osrfoundation.org/job/gz_rendering9-install_bottle-homebrew-arm64/41/) https://build.osrfoundation.org/job/gz_rendering9-install_bottle-homebrew-arm64/41/

### fixed with this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering9-install_bottle-homebrew-arm64&build=42)](https://build.osrfoundation.org/job/gz_rendering9-install_bottle-homebrew-arm64/42/) https://build.osrfoundation.org/job/gz_rendering9-install_bottle-homebrew-arm64/42/