### PR TITLE
Simplify brew install hub

### DIFF
--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -60,10 +60,7 @@ rm -fr ${PKG_DIR} && mkdir -p ${PKG_DIR}
 # don't use HOMEBREW_UPDATE_TO_TAG for bottle builds
 unset HOMEBREW_UPDATE_TO_TAG
 brew up
-# manually exclude a ruby warning that jenkins thinks is from clang
-# https://github.com/osrf/homebrew-simulation/issues/1343
-brew install hub \
-   2>&1 | grep -v 'warning: conflicting chdir during another chdir block'
+brew install hub
 echo '# END SECTION'
 
 # set display before building bottle


### PR DESCRIPTION
Remove an outdated workaround (since https://github.com/Homebrew/brew/pull/10689 was already merged) to see if that fixes failures in bottle building script.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder%2Flabel%3Dosx_arm64_sonoma&build=1825)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_arm64_sonoma/1825/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_arm64_sonoma/1825/

~~~
16:51:27 + brew install hub
16:51:27 + grep -v 'warning: conflicting chdir during another chdir block'
16:51:29 ==> Fetching downloads for: hub
16:51:29 ✔︎ Bottle Manifest hub (2.14.2)
16:51:29 ✔︎ Bottle Manifest hub (2.14.2)
16:51:29 ✔︎ Bottle hub (2.14.2)
16:51:29 Error: A `brew install hub` process has already locked /opt/homebrew/Cellar/pkgconf.
16:51:29 Please wait for it to finish or terminate it to continue.
~~~