### PR TITLE
brew: fix SKIP_COMMIT logic

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_commit.bash
+++ b/jenkins-scripts/lib/_homebrew_github_commit.bash
@@ -8,9 +8,13 @@
 PR_URL_export_file=${PR_URL_export_file:-${WORKSPACE}/pull_request_created.properties}
 
 echo '# BEGIN SECTION: check variables'
-if [ -z "${COMMIT_MESSAGE}" ]; then
-  if [ -z "${SKIP_COMMIT}" ]; then
-    echo One of COMMIT_MESSAGE or SKIP_COMMIT must be specified
+if [ -z "${SKIP_COMMIT}" ]; then
+  echo SKIP_COMMIT not specified
+  exit 1
+fi
+if ! ${SKIP_COMMIT}; then
+  if [ -z "${COMMIT_MESSAGE}" ]; then
+    echo COMMIT_MESSAGE must be specified if SKIP_COMMIT is false
     exit 1
   fi
 fi

--- a/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_pullrequest.bash
@@ -54,4 +54,5 @@ export FORMULA_PATH='-a'
 echo '# END SECTION'
 
 COMMIT_MESSAGE="update bottle"
+SKIP_COMMIT=false
 . ${SCRIPT_LIBDIR}/_homebrew_github_commit.bash

--- a/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
+++ b/jenkins-scripts/lib/homebrew_formula_pullrequest.bash
@@ -112,5 +112,6 @@ fi
 PULL_REQUEST_BRANCH="${PACKAGE_ALIAS}_$(echo ${VERSION_SANITIZED} | tr ' ~:^?*[' '_')_$(date +%s)"
 PULL_REQUEST_TITLE="${PACKAGE_ALIAS} ${VERSION}"
 COMMIT_MESSAGE="${PACKAGE_ALIAS} ${VERSION}"
+SKIP_COMMIT=false
 
 . ${SCRIPT_LIBDIR}/_homebrew_github_commit.bash


### PR DESCRIPTION
I introduced a bug in https://github.com/gazebo-tooling/release-tools/pull/1390, since the pull_request_updater and bottle_hash_updater jobs don't set `SKIP_COMMIT` to anything and the new logic prevents those jobs from committing. This updates the logic to always set `SKIP_COMMIT` to true or false in brew pull request scripts.

### Test showing failure with master branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_pull_request_updater&build=1742)](https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1742/) https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1742/

### Test showing success with this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_pull_request_updater&build=1743)](https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1743/) https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1743/