### PR TITLE
Invalidate docker cache in OSRF_REPOS_TO_USE change

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -227,6 +227,15 @@ RUN apt-get ${APT_PARAMS} update && \\
     apt-get install -y dirmngr git python3 python3-docopt python3-yaml python3-distro
 DELIM_DOCKER_DIRMNGR
 
+# Invalidate cache if OSRF_REPOS_TO_USE changes to ensure repository
+# configuration changes are picked up and not served from stale cache
+if [[ -n ${OSRF_REPOS_TO_USE} ]]; then
+cat >> Dockerfile << DELIM_OSRF_REPOS_CACHE
+# Invalidate docker cache based on OSRF_REPOS_TO_USE configuration
+RUN echo "OSRF repositories configured: ${OSRF_REPOS_TO_USE}"
+DELIM_OSRF_REPOS_CACHE
+fi
+
 # Install necessary repositories using gzdev
 dockerfile_install_gzdev_repos
 


### PR DESCRIPTION
This pull request introduces a mechanism to ensure that Docker builds correctly pick up changes to the `OSRF_REPOS_TO_USE` configuration. This helps prevent issues where repository configuration changes are missed due to Docker's build cache.

We also invalidate on changes in gzdev but sometimes I was injecting changes to this variable in manual operations in the build farm.