### PR TITLE
CI: disable macOS amd64 'pr' jobs

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -681,7 +681,8 @@ ci_configs:
       - gz-transport
       - sdformat
     ci_categories_enabled:
-      - pr
+      # pr jobs disabled for amd64 in favor of arm64
+      # https://github.com/gazebo-tooling/release-tools/issues/1416
       - stable_branches
   - name: brew_arm64
     system:


### PR DESCRIPTION
Fixes https://github.com/gazebo-tooling/release-tools/issues/1416.

We are currently getting by with both amd64 and arm64 brew jobs in pull request CI, but CI will be a little faster if we don't use the amd64 brew jobs. We could strategically choose to keep them in place, so it's up for discussion.