### PR TITLE
Add newgrp binary to debian ratt job

### DIFF
--- a/jenkins-scripts/docker/debian-ratt-builder.bash
+++ b/jenkins-scripts/docker/debian-ratt-builder.bash
@@ -60,7 +60,7 @@ if $USE_UNSTABLE; then
 fi
 rm -fr ${WORKSPACE}/logs && mkdir ${WORKSPACE}/logs
 
-sudo apt-get install -y golang-go
+sudo apt-get install -y golang-go login
 pushd /tmp 2> /dev/null
 git clone https://github.com/j-rivero/ratt
 cd ratt


### PR DESCRIPTION
The job needs the newgrp binary installed by the login package