### PR TITLE
Use -quick for all the gz-physics abi-checker jobs

### DIFF
--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -175,7 +175,12 @@ REPORTS_DIR=$WORKSPACE/reports/
 rm -fr \${REPORTS_DIR} && mkdir -p \${REPORTS_DIR}
 rm -fr compat_reports/
 # run report tool
-abi-compliance-checker -lang C++ -lib ${ABI_JOB_SOFTWARE_NAME} -old pkg.xml -new devel.xml || true
+# Use -quick for gz-physics to avoid OOM due to template-heavy headers
+ABI_CHECKER_EXTRA_ARGS=""
+if [[ "${ABI_JOB_SOFTWARE_NAME}" = "gz-physics" ]]; then
+  ABI_CHECKER_EXTRA_ARGS="-quick"
+fi
+abi-compliance-checker -lang C++ -lib ${ABI_JOB_SOFTWARE_NAME} \${ABI_CHECKER_EXTRA_ARGS} -old pkg.xml -new devel.xml || true
 
 # if report was not generated, run again with -quick
 if ! ls "compat_reports/${ABI_JOB_SOFTWARE_NAME}"


### PR DESCRIPTION
There were some problems in the buildfarm probably coming from the template expansion in gz-physics that ended up executing OOM.

We can use the -quick version in the ABI checker to workaround the problem, it should reduce the template expansion.

Tested here: https://build.osrfoundation.org/job/gz_physics-abichecker-any_to_any-ubuntu-jammy-amd64/230/