### PR TITLE
Restore sanity check for gh tool

### DIFF
--- a/release.py
+++ b/release.py
@@ -438,7 +438,9 @@ def sanity_checks(args, repo_dir):
             sanity_check_cmake_version(args.package, args.version)
         sanity_project_package_in_stable(args.version, args.upload_to_repository)
 
-    sanity_check_gh_tool()
+    # Don't check for gh here since it's not currently installed on built-in
+    # Move the checks to cases when we know ROS vendor package PRs will be generated
+    # sanity_check_gh_tool()
     check_credentials(args.auth_input_arg)
     print_success("Jenkins credentials are good")
     shutil.rmtree(repo_dir)
@@ -845,6 +847,8 @@ def go(argv):
 
     # If only the process of ROS vendor package is set, just do it
     if args.bump_ros_vendor_only:
+        # gh is needed for ROS vendor package PR
+        sanity_check_gh_tool()
         process_ros_vendor_package(args)
         sys.exit(0)
 
@@ -945,6 +949,8 @@ def go(argv):
                                        args.auth_input_arg)
     else:
         # b) Mode generate source
+        # gh is needed for ROS vendor package PR
+        sanity_check_gh_tool()
         # Choose platform to run gz-source on. It will need to install gz-cmake
         # Take the first key in the supported distros since all them should be
         # able to install the needed gz-cmake.


### PR DESCRIPTION
A sanity check for presence of the `gh` tool was recently added in #1436 and reverted in #1443. This is an attempt to restore the sanity check by only checking for `gh` in cases when a ROS vendor package PR may be opened by `process_ros_vendor_package()`.

This should be tested before merging.