### PR TITLE
Script for printing brew badge dashboard

### DIFF
--- a/jenkins-scripts/tools/print-homebrew-simulation-badges.bash
+++ b/jenkins-scripts/tools/print-homebrew-simulation-badges.bash
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+tool_dir=$(dirname ${0})
+generated_jobs="${tool_dir}/../dsl/logs/generated_jobs.txt"
+
+JOB_URL='https://build.osrfoundation.org/job/'
+BADGE_URL='https://build.osrfoundation.org/buildStatus/icon?job='
+arches=( \
+  amd64 \
+  arm64 \
+)
+collections=( \
+  fortress \
+  harmonic \
+  ionic \
+  jetty \
+  rotary \
+)
+packages=( \
+  gz-cmake \
+  gz-common \
+  gz-fuel-tools \
+  gz-gui \
+  gz-launch \
+  gz-math \
+  gz-msgs \
+  gz-physics \
+  gz-plugin \
+  gz-rendering \
+  gz-sensors \
+  gz-sim \
+  gz-tools \
+  gz-transport \
+  gz-utils \
+  sdformat \
+)
+
+# print table of badges
+# one row for each package / arch
+# one column for each collection
+# Status        | Arch | Fortress | Harmonic | Ionic | Jetty
+echo -n "Status        | Arch"
+for c in ${collections[@]};
+do
+  echo -n " | $c"
+done
+echo
+# ------------- | ---- | -------- | -------- | ----- | -------
+echo -n "------------- | ----"
+for c in ${collections[@]};
+do
+  echo -n " | $(echo $c | tr '[:print:]' '-')"
+done
+echo
+for p in ${packages[@]};
+do
+  p_=$(echo $p | tr '-' '_')
+  designation=$(echo $p_ | sed -e 's@^gz_@@')
+  for arch in ${arches[@]};
+  do
+    echo -n "[$p][$designation-repo] | $(echo ${arch} | sed -e 's@amd64@intel@')"
+    for c in ${collections[@]};
+    do
+      if [ "$c" = "rotary" ] && [ "$designation" = "launch" ]; then
+        echo -n " |"
+      else
+        #         | [![Build Status][cmake-fortress-amd64-badge]][cmake-fortress-amd64]
+        echo -n " | [![Build Status][$designation-$c-$arch-badge]][$designation-$c-$arch]"
+      fi
+    done
+    echo
+  done
+done
+
+# print extra blank line
+echo
+
+# define URLs for each package
+for p in ${packages[@]};
+do
+  p_=$(echo $p | tr '-' '_')
+  designation=$(echo $p_ | sed -e 's@^gz_@@')
+  echo "[${designation}-repo]: https://github.com/gazebosim/${p}"
+  for arch in ${arches[@]};
+  do
+    grep "^install_ci [a-z]* \(gz_rotary_${designation}\|${p_}\).*homebrew-${arch}" ${generated_jobs} \
+      | awk -v arch="$arch" \
+            -v badge_url="${BADGE_URL}" \
+            -v designation="$designation" \
+            -v job_url="${JOB_URL}" \
+            '{print "[" designation "-" $2 "-" arch "]: " job_url $3 "\n" \
+                    "[" designation "-" $2 "-" arch "-badge]: " badge_url $3;}'
+  done
+  # print a blank line between packages
+  echo
+done

--- a/jenkins-scripts/tools/print-homebrew-simulation-badges.bash
+++ b/jenkins-scripts/tools/print-homebrew-simulation-badges.bash
@@ -68,8 +68,25 @@ do
         echo -n " | [![Build Status][$designation-$c-$arch-badge]][$designation-$c-$arch]"
       fi
     done
+    # print blank line at end of row for each package / arch combination
     echo
   done
+done
+# print row of collection install jobs
+for arch in ${arches[@]};
+do
+  echo -n "collection | $(echo ${arch} | sed -e 's@amd64@intel@')"
+  for c in ${collections[@]};
+  do
+    if [ "$c" = "rotary" ]; then
+      echo -n " |"
+    else
+      #         | [![Build Status][cmake-fortress-amd64-badge]][cmake-fortress-amd64]
+      echo -n " | [![Build Status][collection-$c-$arch-badge]][collection-$c-$arch]"
+    fi
+  done
+  # print blank line at end of row for each arch
+  echo
 done
 
 # print extra blank line
@@ -94,3 +111,20 @@ do
   # print a blank line between packages
   echo
 done
+
+# define URLs for each collection
+for c in ${collections[@]};
+do
+  for arch in ${arches[@]};
+  do
+    grep "^install_ci [a-z]* gz_${c}-install.*homebrew-${arch}" ${generated_jobs} \
+      | awk -v arch="$arch" \
+            -v badge_url="${BADGE_URL}" \
+            -v job_url="${JOB_URL}" \
+            '{print "[collection-" $2 "-" arch "]: " job_url $3 "\n" \
+                    "[collection-" $2 "-" arch "-badge]: " badge_url $3;}'
+  done
+done
+
+# print a blank line at the end
+echo


### PR DESCRIPTION
This is a script for printing the table of Jenkins job badges in the [osrf/homebrew-simulation README](https://github.com/osrf/homebrew-simulation/blob/master/README.md). I saw that the script for generating the [buildfarm-tools Gazebo dashboard](https://github.com/osrf/buildfarm-tools/blob/main/Gazebo.md) uses the [generated_jobs.txt file from release-tools](https://github.com/gazebo-tooling/release-tools/blob/master/jenkins-scripts/dsl/logs/generated_jobs.txt), so I used that file with an `awk` program to generate the Markdown URLs, and then printed the table with nested `for` loops in bash.

I used this script to generate Rotary badges and manually copy/pasted to the README in https://github.com/osrf/homebrew-simulation/pull/3387.