### PR TITLE
Include an Architecture Decision Records (ADRs) in the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This repository holds scripts and tools that are used for testing and releasing
 Gazebo software.
 
+## Architecture Decision Records (ADRs)
+
+Significant decisions about releasing, packaging, infrastructure, and testing are documented as
+[Architecture Decision Records (ADRs)](docs/adrs/README.md).
+
+
 ## Scripts
 
   * [release.py](release.py): Triggers new debian and homebrew releases (major, minor, patch, pre-release...).

--- a/docs/adrs/0000-template.md
+++ b/docs/adrs/0000-template.md
@@ -1,0 +1,40 @@
+---
+status: proposed
+date: YYYY-MM-DD
+category: # e.g. infrastructure, api, security, tooling, policy
+impact: # low | medium | high | critical
+---
+
+# NNNN — Title of the Decision
+
+## Context
+
+Describe the situation that motivates this decision. What problem are we facing?
+What constraints or forces are at play?
+
+## Decision
+
+State the decision clearly and concisely. Use active voice:
+"We will …", "The project adopts …"
+
+## Consequences
+
+### Positive
+
+- List the benefits of this decision.
+
+### Negative
+
+- List the trade-offs, risks, or downsides.
+
+### Neutral
+
+- Any side-effects that are neither clearly good nor bad.
+
+## Alternatives Considered
+
+Briefly describe options that were evaluated and why they were not chosen.
+
+## References
+
+- Links to relevant issues, discussions, RFCs, or external resources.

--- a/docs/adrs/0001-the-rotary-rolling-release.md
+++ b/docs/adrs/0001-the-rotary-rolling-release.md
@@ -18,7 +18,7 @@ mechanism for continuously releasing from `main` into a rolling distribution.
 
 ## Decision
 
-We will create `{package}-rotary-release` repos for each package in a Gazebo
+We will create `gz-rotary-{package_designation}-release` repos for each package in a Gazebo
 collection. These repos contain debian metadata for unversioned Gazebo packages
 (e.g. `libgz-math-dev`) and `rotary`-labeled aliases (e.g.
 `libgz-rotary-math-dev`). Source repo `packages.apt` files use the rotary

--- a/docs/adrs/0001-the-rotary-rolling-release.md
+++ b/docs/adrs/0001-the-rotary-rolling-release.md
@@ -1,0 +1,127 @@
+---
+status: accepted
+implementation: in-progress
+date: 2026-02-14
+category: releasing, packaging
+impact: high
+---
+
+# 0001 — The Rotary Rolling Release
+
+## Context
+
+Gazebo needs a strategy for releasing packages from `main` branches between
+versioned collection releases. This is supplemental to the strategy for major
+version bumps discussed in [issue #1403]. The current approach of creating new
+versioned release repos each cycle has maintenance overhead, and there was no
+mechanism for continuously releasing from `main` into a rolling distribution.
+
+## Decision
+
+We will create `{package}-rotary-release` repos for each package in a Gazebo
+collection. These repos contain debian metadata for unversioned Gazebo packages
+(e.g. `libgz-math-dev`) and `rotary`-labeled aliases (e.g.
+`libgz-rotary-math-dev`). Source repo `packages.apt` files use the rotary
+aliases.
+
+### Naming Convention
+
+The alias naming rule is to inject the collection name after `gz-`:
+
+| Platform | Original                | Rotary alias                    |
+|----------|-------------------------|---------------------------------|
+| Ubuntu   | `libgz-cmake-dev`      | `libgz-rotary-cmake-dev`       |
+| Ubuntu   | `gz-plugin-cli`        | `gz-rotary-plugin-cli`         |
+| Ubuntu   | `python3-gz-math`      | `python3-gz-rotary-math`       |
+| Brew     | `gz-mathN`             | `gz-rotary-math`               |
+
+Special case for sdformat (no `gz-` in its package name):
+`libsdformat-dev` -> `libgz-rotary-sdformat-dev` (Ubuntu),
+`gz-rotary-sdformat` (Brew).
+
+### Implementation Phases
+
+**Initial implementation:**
+
+- Remove versions from control files (packages and Gazebo dependencies become
+  unversioned).
+- Add rotary aliases pointing to the unversioned packages.
+- Remove versions from `rules` (including versioned install path directories).
+- Make nightly releases from `rotary` by modifying `ignition_collection.dsl`.
+- Bump `main` source branches to new major versions (can happen in parallel
+  with the next step).
+- Update `packages.apt` files to use `rotary` aliases packages.
+- The `__upcoming__` collection is replaced by the new `rotary` collection
+  in PR integration and the Jenkins views.
+
+**At branch-off (when creating a new Gazebo Stable Release):**
+
+- Fork each `{package}-rotary-release` repo and modify control files to include
+  the major version number.
+- Set explicit versions in `find_package` calls using
+  `set_explicit_find_package_versions.bash`.
+- As stable branches are created, update `packages.apt` with the rotary ->
+  versioned package mapping.
+- Update `gz-collection.yaml`, `gazebodistro`, and homebrew so the new
+  collection points to stable branches with versioned package dependencies.
+
+**Next release cycle:**
+
+- No changes needed to `{package}-rotary-release` repos.
+- Bump major version numbers in `main`; no change in `packages.apt`.
+- Follow the same branch-off steps as above.
+
+## Consequences
+
+### Positive
+
+- The `rotary` label follows a similar pattern to numbered versions, so
+  existing tooling handles it with little or no modification.
+- At branch-off, forking `*-rotary-release` repos makes creating versioned
+  release repos straightforward.
+- No annual updates needed for the rotary release repos between cycles.
+- Provides a continuous integration path for packages built from `main`.
+
+### Negative
+
+- Requires initial effort to create and populate all `{package}-rotary-release`
+  repos.
+- The sdformat package requires special-case handling due to its non-standard
+  naming (no `gz-` prefix).
+- Some `debian/rules` files need non-trivial changes to remove versioned
+  install paths.
+- Nightly build infrastructure (`ignition_collection.dsl`) needs modifications
+  since debbuilder names are computed as `{package}{major_version}-debbuilder`.
+
+### Neutral
+
+- Existing Jetty collection aliases use a different format (`gz-jetty-math`
+  rather than `libgz-jetty-math-dev`). Jetty aliases will be duplicated to
+  match the new convention.
+- The `gzdev` tool requires updates to support the rotary workflow
+  ([gzdev#103]).
+
+## Alternatives Considered
+
+**Single `gz-rotary-release` repo with aliases to versioned packages:** Instead
+of per-package rotary release repos, create a single `gz-rotary-release` repo
+containing aliases that point to all the versioned packages from `main`
+branches. This was rejected because the alias repo would need to be updated
+every year when version numbers change, adding recurring maintenance overhead
+that the per-package approach avoids.
+
+## References
+
+- [Issue #1446 — proposal: Rotary release repos][issue #1446]
+- [Issue #1403 — Strategy for major version bumps in new collections][issue #1403]
+- [PR #1449 — Tool for adding collection-specific aliases](https://github.com/gazebo-tooling/release-tools/pull/1449)
+- [PR #1430 — set_explicit_find_package_versions.bash](https://github.com/gazebo-tooling/release-tools/pull/1430)
+- [Prototype: gz-rotary-cmake-release](https://github.com/scpeters/gz-rotary-cmake-release/pull/1)
+- [Prototype: gz-rotary-utils-release](https://github.com/scpeters/gz-rotary-utils-release/pull/1)
+- [Prototype: homebrew-simulation rotary formulae](https://github.com/osrf/homebrew-simulation/pull/3287)
+- [Full Jetty alias naming convention gist](https://gist.github.com/j-rivero/2f6f910db5f38fe36d9c54d516d9e0a9)
+- [Support source metadata that defines the GZDEV_PROJECT_NAME (technical debt)][gzdev#103]
+
+[issue #1446]: https://github.com/gazebo-tooling/release-tools/issues/1446
+[issue #1403]: https://github.com/gazebo-tooling/release-tools/issues/1403
+[gzdev#103]: https://github.com/gazebo-tooling/gzdev/pull/103

--- a/docs/adrs/0001-the-rotary-rolling-release.md
+++ b/docs/adrs/0001-the-rotary-rolling-release.md
@@ -47,7 +47,7 @@ Special case for sdformat (no `gz-` in its package name):
   unversioned).
 - Add rotary aliases pointing to the unversioned packages.
 - Remove versions from `rules` (including versioned install path directories).
-- Make nightly releases from `rotary` by modifying `ignition_collection.dsl`.
+- Make nightly releases from `rotary` by modifying `ignition_collection.dsl` ([PR #1463](https://github.com/gazebo-tooling/release-tools/pull/1463)).
 - Bump `main` source branches to new major versions (can happen in parallel
   with the next step).
 - Update `packages.apt` files to use `rotary` aliases packages.

--- a/docs/adrs/0001-the-rotary-rolling-release.md
+++ b/docs/adrs/0001-the-rotary-rolling-release.md
@@ -52,7 +52,8 @@ Special case for sdformat (no `gz-` in its package name):
   with the next step).
 - Update `packages.apt` files to use `rotary` aliases packages.
 - The `__upcoming__` collection is replaced by the new `rotary` collection
-  in PR integration and the Jenkins views.
+  in PR integration and the Jenkins views
+  ([PR #1461](https://github.com/gazebo-tooling/release-tools/pull/1461)).
 
 **At branch-off (when creating a new Gazebo Stable Release):**
 

--- a/docs/adrs/0001-the-rotary-rolling-release.md
+++ b/docs/adrs/0001-the-rotary-rolling-release.md
@@ -60,7 +60,8 @@ Special case for sdformat (no `gz-` in its package name):
 - Fork each `{package}-rotary-release` repo and modify control files to include
   the major version number.
 - Set explicit versions in `find_package` calls using
-  `set_explicit_find_package_versions.bash`.
+  [set_explicit_find_package_versions.bash](https://github.com/gazebo-tooling/release-tools/blob/master/source-repo-scripts/set_explicit_find_package_versions.bash)
+  (see also [gazebosim/gz-jetty#137](https://github.com/gazebosim/gz-jetty/issues/137) for reference.
 - As stable branches are created, update `packages.apt` with the rotary ->
   versioned package mapping.
 - Update `gz-collection.yaml`, `gazebodistro`, and homebrew so the new

--- a/docs/adrs/0001-the-rotary-rolling-release.md
+++ b/docs/adrs/0001-the-rotary-rolling-release.md
@@ -86,7 +86,7 @@ Special case for sdformat (no `gz-` in its package name):
 
 ### Negative
 
-- Requires initial effort to create and populate all `{package}-rotary-release`
+- Requires initial effort to create and populate all `gz-rotary-{package_designation}-release`
   repos.
 - The sdformat package requires special-case handling due to its non-standard
   naming (no `gz-` prefix).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,57 @@
+This directory captures the key architectural decisions made related to Gazebo
+releasing, packaging, infra, testing and other devops related topics.
+
+## What is an ADR?
+
+An Architecture Decision Record is a short document that describes a significant
+decision made about the software architecture of the project. Each ADR describes
+the context, the decision itself, and the consequences — both positive and
+negative.
+
+## File Naming
+
+ADRs are numbered sequentially:
+
+```
+NNNN-short-title.md
+```
+
+For example: `0001-the-rotary-rolling-release.md`
+
+## Metadata Fields
+
+Every ADR includes a YAML front-matter block with four fields:
+
+| Field        | Values                                                       | Description                            |
+|--------------|--------------------------------------------------------------|----------------------------------------|
+| **status**   | `proposed` · `accepted` · `deprecated` · `superseded`        | Current lifecycle stage of the decision |
+| **implementation** | `not-started` · `in-progress` · `done` `              | Progress of the *work* that follows the decision |
+| **date**     | `YYYY-MM-DD`                                                 | Date the ADR was created or last updated |
+| **category** | Free-form tag(s), e.g. `infrastructure`, `releasing`, `packaging`   | Domain the decision relates to          |
+| **impact**   | `low` · `medium` · `high` · `critical`                       | How broadly the decision affects the project |
+
+## Lifecycle
+
+```
+proposed  ──►  accepted  ──►  deprecated
+                         ──►  superseded by NNNN
+```
+
+- **Proposed** — Under discussion, not yet binding.
+- **Accepted** — The team has agreed; this is the current policy.
+- **Deprecated** — No longer relevant (e.g. feature removed).
+- **Superseded** — Replaced by a newer ADR (link to it in the body).
+
+## How to Create a New ADR
+
+1. Copy `0000-template.md` to a new file with the next available number.
+2. Fill in the front-matter and all sections.
+3. Submit as a pull request for Gazebo PMC to review.
+4. Once ready, update the status to `accepted` and add an entry to the index below and merge.
+
+## Index
+ 
+| #    | Title                                  | Status    | Implementation | Date       | Category        | Impact   |
+|------|----------------------------------------|-----------|----------------|------------|-----------------|----------|
+| 0000 | Template for ADRs                | proposed  | not-started           | 2026-03-18 | documentation  | low |
+| 0001 | The Rotary Rolling Release       | accepted  | in-progress           | 2026-02-14 | releasing, packaging | high |


### PR DESCRIPTION
(This needs the PMC approval probably, open as draft to discuss)

Motivated by all the discussion and talks related to the Rotary release, this pull request introduces a new system for documenting significant architectural decisions in the repository by adopting Architecture Decision Records (ADRs). It adds supporting documentation, a template, and an initial ADR describing the "Rotary Rolling Release" strategy for Gazebo packages. 

These changes establish a clear process for recording, reviewing, and tracking major decisions related to releasing, packaging, infrastructure, and testing.

**ADRs documentation and process:**

* Added an ADR section to the `README.md` to explain the purpose of ADRs and where to find them.
* Created `docs/adrs/README.md` to define what ADRs are, their metadata, lifecycle, naming conventions, and instructions for creating and maintaining them, including an index of existing ADRs.
* Added an ADR template (`docs/adrs/0000-template.md`) to standardize new decision records.

**Initial architectural decision:**

* Documented the "Rotary Rolling Release" strategy in `docs/adrs/0001-the-rotary-rolling-release.md`, detailing the context, decision, implementation phases, consequences, alternatives considered, and references for the new release process for Gazebo packages.

