### PR TITLE
Remove large-memory requirement

### DIFF
--- a/docs/BUILDFARM_NODES.md
+++ b/docs/BUILDFARM_NODES.md
@@ -9,16 +9,15 @@ used (can check this in the Jenkins UI)
 
 | Label name | Description | Requirements |
 | -------- | ----------- | ------------ |
-| docker   | Node has capabilities to run Docker CI (standard Linux CI) | Linux system with docker installed |
+| docker   | Node has capabilities to run Docker CI (standard Linux CI) | Linux system with docker installed - 16GB RAM |
 | gpu-reliable | Node has a real GPU able to run simulation for Gazebo | Nvidia card and nvidia-docker installed on Linux |
-| large-memory  | Node has enough RAM to run really demanding RAM compilations | Hardware has no less than 16Gb of RAM and can run abichecker on ign-physics |
 | linux-arm64 | Node has capabilities to run native arm64 code (mostly used in packaging) | Bare-metal ARM machine |
 | linux-armhf | Node has capabilities to run native armhf code (mostly used in packaging) | Bare-metal ARM machine |
 | osx | Node has capabilities to run native OsX code | Apple system |
 | osx_gazebo | Node has capabilities to run Gazebo classic CI and packaging | 'Powerful' Apple system |
 | osx\_$distro | Node has capabilities to build code for the distribution $distro | Apple system running $distro |
 | swarm | Node was created using swarm plugin in Jenkins | Chef provisioned node |
-| win | Node is able to run Windows CI | Windows10 system |
+| win | Node is able to run Windows CI | Windows10 system. 16GB RAM |
 | win_testing | Testing node attached to the production buildfarm | Windows10 system |
 
 ## Provision of Node labels

--- a/jenkins-scripts/dsl/debian.dsl
+++ b/jenkins-scripts/dsl/debian.dsl
@@ -8,7 +8,7 @@ OSRFLinuxBase.create(ratt_pkg_job)
 ratt_pkg_job.with
 {
   // use only the most powerful nodes
-  label Globals.nontest_label("docker && large-memory")
+  label Globals.nontest_label("docker")
 
   parameters
   {

--- a/jenkins-scripts/dsl/dsl_checks.bash
+++ b/jenkins-scripts/dsl/dsl_checks.bash
@@ -119,7 +119,7 @@ check_tag_without_platforms()
   echo $(awk -v tag="$tag" 'FNR==1{filename=FILENAME} /<assignedNode>/ && $0 ~ tag && !/win/ && !/docker/ {print filename ": " $0}' *.xml)
 }
 
-for tag in gpu-reliable large-memory; do
+for tag in gpu-reliable; do
   no_tag_without_platforms=$(check_tag_without_platforms ${tag})
   if [[ -n ${no_tag_without_platforms} ]]; then
     echo "Found jobs with the ${tag}"

--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -23,7 +23,7 @@ release_repo_debbuilds.each { software ->
   build_pkg_job.with
   {
     // use only the most powerful nodes
-    label Globals.nontest_label("docker && large-memory")
+    label Globals.nontest_label("docker")
 
     steps {
       shell("""\
@@ -43,7 +43,7 @@ gbp_repo_debbuilds.each { software ->
   build_pkg_job.with
   {
     // use only the most powerful nodes
-    label Globals.nontest_label("docker && large-memory")
+    label Globals.nontest_label("docker")
 
     parameters
     {

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -31,13 +31,6 @@ String get_windows_distro_sortname(ci_config)
 
 void generate_label_by_requirements(job, lib_name, requirements, base_label)
 {
-
-  if (requirements.nvidia_gpu.contains(lib_name) &&
-      requirements.large_memory.contains(lib_name)) {
-     println ("ERROR: more than one label is not supported by requirements")
-     exit(1)
-  }
-
   label = requirements.nvidia_gpu.contains(lib_name) ? "gpu-reliable" : null
   if (! label)
       return

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -40,8 +40,6 @@ void generate_label_by_requirements(job, lib_name, requirements, base_label)
 
   label = requirements.nvidia_gpu.contains(lib_name) ? "gpu-reliable" : null
   if (! label)
-    label = requirements.large_memory.contains(lib_name) ? "large-memory" : null
-    if (! label)
       return
 
   job.with

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -532,8 +532,6 @@ ci_configs:
       version: focal
       arch: amd64
     requirements:
-      large_memory:
-        - gz-physics
       nvidia_gpu:
         - gz-sim
         - gz-gui
@@ -561,8 +559,6 @@ ci_configs:
       version: jammy
       arch: amd64
     requirements:
-      large_memory:
-        - gz-physics
       nvidia_gpu:
         - gz-sim
         - gz-gui
@@ -591,8 +587,6 @@ ci_configs:
       version: noble
       arch: amd64
     requirements:
-      large_memory:
-        - gz-physics
       nvidia_gpu:
         - gz-sim
         - gz-gui
@@ -623,8 +617,6 @@ ci_configs:
       version: noble
       arch: amd64
     requirements:
-      large_memory:
-        - gz-physics
       nvidia_gpu:
         - gz-sim
         - gz-gui
@@ -712,8 +704,6 @@ ci_configs:
       version: legacy
       arch: amd64
     requirements:
-      large_memory:
-        - gz-physics
       nvidia_gpu:
         - gz-sim
         - gz-gui
@@ -748,8 +738,6 @@ ci_configs:
       version: noble_like
       arch: amd64
     requirements:
-      large_memory:
-        - gz-physics
       nvidia_gpu:
         - gz-sim
         - gz-gui
@@ -785,8 +773,6 @@ ci_configs:
       version: legacy_ogre23
       arch: amd64
     requirements:
-      large_memory:
-        - gz-physics
       nvidia_gpu:
         - gz-sim
         - gz-gui

--- a/jenkins-scripts/dsl/gzdev.dsl
+++ b/jenkins-scripts/dsl/gzdev.dsl
@@ -18,7 +18,7 @@ supported_distros.each { distro ->
     gzdev_ci_job.with
     {
     
-      label Globals.nontest_label("docker && large-memory")
+      label Globals.nontest_label("docker")
 
       scm {
         git {
@@ -56,7 +56,7 @@ supported_distros.each { distro ->
 
     gzdev_any_job.with
     {
-      label Globals.nontest_label("docker && large-memory")
+      label Globals.nontest_label("docker")
 
       steps {
         shell("""\

--- a/jenkins-scripts/tools/label-assignment-backstop.groovy
+++ b/jenkins-scripts/tools/label-assignment-backstop.groovy
@@ -16,9 +16,7 @@ import hudson.model.Label;
 */
 def nightly_label_prefix = "linux-nightly"
 def exactly_one_labels = [
-  ["${nightly_label_prefix}-focal", "docker && large-memory"],
-  ["${nightly_label_prefix}-jammy", "docker && large-memory"],
-  ["${nightly_label_prefix}-noble", "docker && large-memory"],
+  ["${nightly_label_prefix}-noble", "docker"],
 ]
 
 for (tup in exactly_one_labels) {

--- a/release.py
+++ b/release.py
@@ -920,14 +920,10 @@ def go(argv):
                         # Need to use JENKINS_NODE_TAG parameter for large memory nodes
                         # since it runs qemu emulation
                         linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a
-                    elif ('ignition-physics' in args.package_alias) or \
-                         ('gz-physics' in args.package_alias):
-                        linux_platform_params['JENKINS_NODE_TAG'] = 'large-memory'
 
                     # control nightly generation using a single machine to process
                     # all distribution builds to avoid race conditions. Note: this
-                    # assumes that large-memory nodes are being used for nightly
-                    # tags.
+                    # assumes that nodes are being tagged for nightly tags.
                     # https://github.com/gazebo-tooling/release-tools/issues/644
                     if (NIGHTLY):
                         assert a == 'amd64', f'Nightly tag assumed amd64 but arch is {a}'

--- a/release.py
+++ b/release.py
@@ -344,7 +344,7 @@ def get_version_from_cmake(cmake_file="CMakeLists.txt"):
     version_regex = re.compile(
         r"project\s*\(\s*[a-z0-9-_]*\s*VERSION\s*([0-9.]*)", re.MULTILINE
     )
-    # Note the re.DOTALL is used to match any newlines and arguments to 
+    # Note the re.DOTALL is used to match any newlines and arguments to
     # gz_configure_project before VERSION_SUFFIX
     suffix_regex = re.compile(
         r"(?:gz|ign)_configure_project\s*\(.*VERSION_SUFFIX\s*(pre\d+)",
@@ -921,9 +921,10 @@ def go(argv):
                         # since it runs qemu emulation
                         linux_platform_params['JENKINS_NODE_TAG'] = 'linux-' + a
 
-                    # control nightly generation using a single machine to process
-                    # all distribution builds to avoid race conditions. Note: this
-                    # assumes that nodes are being tagged for nightly tags.
+                    # The control nightly generation is done using a single machine to
+                    # process all gz libraries builds sequentially to avoid race
+                    # conditions. Note: this assumes that nodes are being tagged
+                    # 'linux-nightly-${ubuntu_distro} for nightly tags.
                     # https://github.com/gazebo-tooling/release-tools/issues/644
                     if (NIGHTLY):
                         assert a == 'amd64', f'Nightly tag assumed amd64 but arch is {a}'


### PR DESCRIPTION
This goes together with the change on standard agents in Windows and Linux to 16Gb.

This pull request removes the use of the `large-memory` label from Jenkins job configurations and documentation, consolidating requirements to use only the `docker` label for relevant jobs. It also updates documentation to specify memory requirements directly in the description for clarity. These changes simplify label management and make node requirements more explicit.

**Jenkins job label and requirements simplification:**

* Removed the `large_memory` requirement for `gz-physics` from all relevant sections in the `gz-collections.yaml` configuration.
* Removed the `large-memory` label from all Jenkins job definitions in DSL scripts (`debian.dsl`, `extra.dsl`, `gzdev.dsl`), so jobs now only require the `docker` label. 
* Updated the label assignment backstop script to remove `large-memory` from nightly label definitions, leaving only the `docker` label for the noble release.

**Documentation updates:**

* Updated `BUILDFARM_NODES.md` to specify that both `docker` and `win` nodes require 16GB RAM, moving the memory requirement into the description instead of using a separate `large-memory` label.

**Script and logic adjustments:**

* Removed checks and code paths related to the `large-memory` label from the DSL check script and the release script, since the label is no longer in use.