### PR TITLE
fix: Local build to change cwd to temp workspace before running colcon

### DIFF
--- a/jenkins-scripts/lib/windows_library.bat
+++ b/jenkins-scripts/lib/windows_library.bat
@@ -142,7 +142,7 @@ colcon build --build-base "build"^
   %COLCON_EXTRA_ARGS% %COLCON_PACKAGE%^
   --cmake-args " -DCMAKE_BUILD_TYPE=%BUILD_TYPE%"^
   %COLCON_EXTRA_CMAKE_ARGS% %COLCON_EXTRA_CMAKE_ARGS2%^
-  --event-handler console_cohesion+ || goto :error
+  --event-handler console_cohesion+  desktop_notification- || goto :error
 @echo off
 
 goto :EOF
@@ -188,7 +188,7 @@ echo # BEGIN SECTION: colcon test for !COLCON_PACKAGE!
 colcon test --install-base "install"^
             --packages-select !COLCON_PACKAGE!^
             --executor sequential^
-            --event-handler console_direct+
+            --event-handler console_direct+ desktop_notification-
 echo # END SECTION
 echo # BEGIN SECTION: colcon test-result
 colcon test-result --all

--- a/jenkins-scripts/local_build.py
+++ b/jenkins-scripts/local_build.py
@@ -87,7 +87,7 @@ def main():
             del os.environ["REUSE_PIXI_INSTALLATION"]
 
     # Run the script
-    result = subprocess.run([script_path], shell=True, check=False)
+    result = subprocess.run([script_path], shell=True, check=False, cwd=workspace)
 
     print("\n\033[1;34m Local build finished \033[0m\n")
 


### PR DESCRIPTION
This also removes desktop notification from colcon commands, which are unnecessary in CI environments.