### PR TITLE
Enable CI for gz-rotary

### DIFF
--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -238,7 +238,7 @@ String get_debbuilder_name(parsed_yaml_lib, parsed_yaml_packaging, collection_na
   if (ignore_major_version && ignore_major_version.contains(parsed_yaml_lib.name))
     major_version = ""
 
-  if (collection_name == 'rotary') {
+  if (collection_name == 'rotary' && parsed_yaml_lib.name != 'gz-rotary') {
     base_name = parsed_yaml_lib.name.startsWith('gz-') ?
       parsed_yaml_lib.name.substring(3) : parsed_yaml_lib.name
     return "gz-rotary-${base_name}-debbuilder"
@@ -285,7 +285,7 @@ String generate_brew_install(src_name, lib_name, arch, gzdev_project = '')
   // See: https://github.com/osrf/osrf_jenkins_agent/blob/latest/recipes/macos.rb#L68
   def arch_label = arch == 'amd64' ? 'x86_64' : arch
   def gz_designation = lib_name.replace('gz-','')
-  def formula_name = (gzdev_project == 'rotary') ? "gz-rotary-${gz_designation}" : "${src_name}"
+  def formula_name = (gzdev_project == 'rotary' && gz_designation != 'rotary') ? "gz-rotary-${gz_designation}" : "${src_name}"
   def script_name_prefix = cleanup_library_name(formula_name)
   def install_type = (gzdev_project == 'rotary') ? 'install_formula' : 'install_bottle'
   def job_name = "${script_name_prefix}-${install_type}-homebrew-${arch}"

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -601,6 +601,7 @@ ci_configs:
         - gz-ionic
         - gz-jetty
         - gz-kura
+        - gz-rotary
       abichecker:
         - gz-cmake
         - gz-tools
@@ -651,6 +652,7 @@ ci_configs:
         - gz-ionic
         - gz-jetty
         - gz-kura
+        - gz-rotary
     cmake_warnings_disabled:
       - gz-common
       - gz-fuel-tools
@@ -683,6 +685,7 @@ ci_configs:
         - gz-ionic
         - gz-jetty
         - gz-kura
+        - gz-rotary
     cmake_warnings_disabled:
       - gz-common
       - gz-fuel-tools
@@ -750,6 +753,7 @@ ci_configs:
       all:
         - gz-jetty
         - gz-kura
+        - gz-rotary
     cmake_warnings_disabled:
       - gz-cmake
       - gz-common

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -496,6 +496,9 @@ collections:
       - name: gz-sim
         repo:
           current_branch: main
+      - name: gz-rotary
+        repo:
+          current_branch: main
     ci:
       configs:
         - noble

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -497,6 +497,7 @@ collections:
         repo:
           current_branch: main
       - name: gz-rotary
+        major_version: 1
         repo:
           current_branch: main
     ci:
@@ -527,6 +528,7 @@ collections:
           - gz-sensors
           - gz-physics
           - gz-sim
+          - gz-rotary
 ci_configs:
   - name: focal
     system:

--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -21,7 +21,7 @@ String get_debbuilder_name(parsed_yaml_lib, parsed_yaml_packaging, collection_na
   if (ignore_major_version && ignore_major_version.contains(parsed_yaml_lib.name))
     major_version = ""
 
-  if (collection_name == 'rotary') {
+  if (collection_name == 'rotary' && parsed_yaml_lib.name != 'gz-rotary') {
     // gz-cmake → gz-rotary-cmake, sdformat → gz-rotary-sdformat
     base_name = parsed_yaml_lib.name.startsWith('gz-') ?
       parsed_yaml_lib.name.substring(3) : parsed_yaml_lib.name

--- a/jenkins-scripts/dsl/logs/generated_jobs.txt
+++ b/jenkins-scripts/dsl/logs/generated_jobs.txt
@@ -787,6 +787,9 @@ install_ci rotary gz_msgs-install-pkg-noble-amd64
 install_ci rotary gz_physics-install-pkg-noble-amd64
 install_ci rotary gz_plugin-install-pkg-noble-amd64
 install_ci rotary gz_rendering-install-pkg-noble-amd64
+install_ci rotary gz_rotary-install-pkg-noble-amd64
+install_ci rotary gz_rotary-install_formula-homebrew-amd64
+install_ci rotary gz_rotary-install_formula-homebrew-arm64
 install_ci rotary gz_rotary_cmake-install_formula-homebrew-amd64
 install_ci rotary gz_rotary_cmake-install_formula-homebrew-arm64
 install_ci rotary gz_rotary_common-install_formula-homebrew-amd64


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1446.

There is now a https://github.com/gazebosim/gz-rotary repo and homebrew formula, so we can enable CI and a debbuilder for it.