### PR TITLE
Move pixi paths to %PROGRAMDATA% to prevent cleanup issues

### DIFF
--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -2,11 +2,13 @@
 set "PIXI_VERSION=0.44.0"
 set "PIXI_URL=https://github.com/prefix-dev/pixi/releases/download/v%PIXI_VERSION%/pixi-x86_64-pc-windows-msvc.exe"
 if NOT DEFINED PIXI_PROJECT_PATH (
-  set "PIXI_PROJECT_PATH=%TMP%\pixi\project"
+  set "PIXI_PROJECT_PATH=%LOCALAPPDATA%\pixi\project"
 )
-set "PIXI_BOOTSTRAP_PROJECT_PATH=%TMP%\pixi\bootstrap_project"
+if NOT DEFINED PIXI_BOOTSTRAP_PROJECT_PATH (
+  set "PIXI_BOOTSTRAP_PROJECT_PATH=%LOCALAPPDATA%\pixi\bootstrap_project"
+)
 
-set "PIXI_TMPDIR=%TMP%\pixi"
+set "PIXI_TMPDIR=%LOCALAPPDATA%\pixi"
 set "PIXI_TMP=%PIXI_TMPDIR%\pixi.exe"
 set "CONDA_ROOT_DIR=%LIB_DIR%\..\..\conda\"
 set "CONDA_ENVS_DIR=%CONDA_ROOT_DIR%\envs\"

--- a/jenkins-scripts/lib/windows_env_vars.bat
+++ b/jenkins-scripts/lib/windows_env_vars.bat
@@ -2,13 +2,13 @@
 set "PIXI_VERSION=0.44.0"
 set "PIXI_URL=https://github.com/prefix-dev/pixi/releases/download/v%PIXI_VERSION%/pixi-x86_64-pc-windows-msvc.exe"
 if NOT DEFINED PIXI_PROJECT_PATH (
-  set "PIXI_PROJECT_PATH=%LOCALAPPDATA%\pixi\project"
+  set "PIXI_PROJECT_PATH=%PROGRAMDATA%\pixi\project"
 )
 if NOT DEFINED PIXI_BOOTSTRAP_PROJECT_PATH (
-  set "PIXI_BOOTSTRAP_PROJECT_PATH=%LOCALAPPDATA%\pixi\bootstrap_project"
+  set "PIXI_BOOTSTRAP_PROJECT_PATH=%PROGRAMDATA%\pixi\bootstrap_project"
 )
 
-set "PIXI_TMPDIR=%LOCALAPPDATA%\pixi"
+set "PIXI_TMPDIR=%PROGRAMDATA%\pixi"
 set "PIXI_TMP=%PIXI_TMPDIR%\pixi.exe"
 set "CONDA_ROOT_DIR=%LIB_DIR%\..\..\conda\"
 set "CONDA_ENVS_DIR=%CONDA_ROOT_DIR%\envs\"

--- a/jenkins-scripts/local_build.py
+++ b/jenkins-scripts/local_build.py
@@ -53,7 +53,7 @@ def main():
     # Set environment variables
     os.environ["WORKSPACE"] = str(workspace)
     os.environ["MAKE_JOBS"] = str(make_jobs)  # Customize the number of building threads
-    pixi_project_path = Path(os.environ["LOCALAPPDATA"]) / "pixi" / "project"
+    pixi_project_path = Path(os.environ["PROGRAMDATA"]) / "pixi" / "project"
     os.environ["PIXI_PROJECT_PATH"] = str(pixi_project_path)
 
     # Check if script exists

--- a/jenkins-scripts/local_build.py
+++ b/jenkins-scripts/local_build.py
@@ -53,7 +53,7 @@ def main():
     # Set environment variables
     os.environ["WORKSPACE"] = str(workspace)
     os.environ["MAKE_JOBS"] = str(make_jobs)  # Customize the number of building threads
-    pixi_project_path = Path(os.environ["TMP"]) / "pixi" / "project"
+    pixi_project_path = Path(os.environ["LOCALAPPDATA"]) / "pixi" / "project"
     os.environ["PIXI_PROJECT_PATH"] = str(pixi_project_path)
 
     # Check if script exists


### PR DESCRIPTION
A possible fix for https://github.com/gazebo-tooling/release-tools/issues/1442

As described in  , the main hypothesis is that "Storage Sense" and/or "SilentCleanup" Windows mechanisms could be trimming files from C:\Windows\Temp\pixi\project\.pixi\envs\default\ during long builds so the pull request updates the handling of temporary and project paths for the Pixi environment in both the Windows batch script and the Python build script. The main change is to move Pixi-related directories from the user-specific `%TMP%` directory to the system-wide `%PROGRAMDATA%` directory, ensuring greater consistency and potentially avoiding issues with user-specific temp directories.

**Environment variable and path changes:**

* Updated `PIXI_PROJECT_PATH`, `PIXI_BOOTSTRAP_PROJECT_PATH`, and `PIXI_TMPDIR` in `windows_env_vars.bat` to use `%PROGRAMDATA%\pixi` instead of `%TMP%\pixi` for system-wide consistency.
* Modified the `local_build.py` script to set `PIXI_PROJECT_PATH` using the `PROGRAMDATA` environment variable instead of `TMP`, aligning with the batch script changes.

Testing run: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-pr-cnlwin&build=210)](https://build.osrfoundation.org/job/gz_common-pr-cnlwin/210/) 
