### PR TITLE
abi-checker: install packages.apt from each branch

### DIFF
--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -53,7 +53,7 @@ cd /tmp/${ABI_JOB_SOFTWARE_NAME}
 git fetch origin
 git checkout origin/${DEST_BRANCH}
 # Install dependencies again in case packages.apt files are changed
-sudo apt install -y "$(sort -u $(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
+sudo apt install -y "\$(sort -u \$(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
 rm -rf $WORKSPACE/build
 mkdir -p $WORKSPACE/build
@@ -76,7 +76,7 @@ git remote add source_repo ${SRC_REPO}
 git fetch source_repo
 git checkout source_repo/${SRC_BRANCH}
 # Install dependencies again in case packages.apt files are changed
-sudo apt install -y "$(sort -u $(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
+sudo apt install -y "\$(sort -u \$(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
 rm -rf $WORKSPACE/build
 mkdir -p $WORKSPACE/build

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -52,6 +52,8 @@ cp -a $WORKSPACE/${ABI_JOB_SOFTWARE_NAME} /tmp/${ABI_JOB_SOFTWARE_NAME}
 cd /tmp/${ABI_JOB_SOFTWARE_NAME}
 git fetch origin
 git checkout origin/${DEST_BRANCH}
+# Install dependencies again in case packages.apt files are changed
+sudo apt install -y "$(sort -u $(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
 rm -rf $WORKSPACE/build
 mkdir -p $WORKSPACE/build
@@ -73,6 +75,8 @@ cd /tmp/${ABI_JOB_SOFTWARE_NAME}
 git remote add source_repo ${SRC_REPO}
 git fetch source_repo
 git checkout source_repo/${SRC_BRANCH}
+# Install dependencies again in case packages.apt files are changed
+sudo apt install -y "$(sort -u $(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
 rm -rf $WORKSPACE/build
 mkdir -p $WORKSPACE/build

--- a/jenkins-scripts/docker/lib/generic-abi-base.bash
+++ b/jenkins-scripts/docker/lib/generic-abi-base.bash
@@ -53,7 +53,7 @@ cd /tmp/${ABI_JOB_SOFTWARE_NAME}
 git fetch origin
 git checkout origin/${DEST_BRANCH}
 # Install dependencies again in case packages.apt files are changed
-sudo apt install -y "\$(sort -u \$(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
+sudo apt install -y \$(sort -u \$(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
 rm -rf $WORKSPACE/build
 mkdir -p $WORKSPACE/build
@@ -76,7 +76,7 @@ git remote add source_repo ${SRC_REPO}
 git fetch source_repo
 git checkout source_repo/${SRC_BRANCH}
 # Install dependencies again in case packages.apt files are changed
-sudo apt install -y "\$(sort -u \$(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')"
+sudo apt install -y \$(sort -u \$(find .github/ci -iname 'packages-'$DISTRO'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
 # Normal cmake routine for ${ABI_JOB_SOFTWARE_NAME}
 rm -rf $WORKSPACE/build
 mkdir -p $WORKSPACE/build


### PR DESCRIPTION
The abi-checking job builds from two different branches, but currently only installs the required packages from one branch. If a PR changes the required packages, the abi checker now installs again for each branch.

For example, https://github.com/gazebosim/gz-common/pull/803 removes a dependency on freeimage, but the abi checker fails since the target branch still needs freeimage, but it is not installed.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-abichecker-any_to_any-ubuntu-noble-amd64&build=152)](https://build.osrfoundation.org/job/gz_common-abichecker-any_to_any-ubuntu-noble-amd64/152/) https://build.osrfoundation.org/job/gz_common-abichecker-any_to_any-ubuntu-noble-amd64/152/

### Testing

Tested https://github.com/gazebosim/gz-common/pull/803 with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_common-abichecker-any_to_any-ubuntu-noble-amd64&build=156)](https://build.osrfoundation.org/job/gz_common-abichecker-any_to_any-ubuntu-noble-amd64/156/) https://build.osrfoundation.org/job/gz_common-abichecker-any_to_any-ubuntu-noble-amd64/156/
