### PR TITLE
Use brew main branch until unbottled is fixed

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -45,8 +45,8 @@ else
 fi
 # Use stable version of brew
 export HOMEBREW_UPDATE_TO_TAG=1
-if [[ $(date +%Y%m%d) -le 20260310 ]]; then
-  # until https://github.com/Homebrew/brew/pull/21552 is released
+if [[ $(date +%Y%m%d) -le 20260510 ]]; then
+  # until https://github.com/Homebrew/brew/pull/22050 is released
   unset HOMEBREW_UPDATE_TO_TAG
 fi
 brew update-reset


### PR DESCRIPTION
The `brew unbottled` command is broken in 5.1.7 and was recently fixed in https://github.com/Homebrew/brew/pull/22050, so use `main` for a few weeks until the fix is released.

Needed since https://github.com/osrf/homebrew-simulation/pull/3416 was not properly generated

Properly generated https://github.com/osrf/homebrew-simulation/pull/3417 with this branch