### PR TITLE
OSRFSourceCreation: fix PACKAGE_ALIAS

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFSourceCreation.groovy
@@ -175,7 +175,7 @@ class OSRFSourceCreation
                               'hudson.plugins.parameterizedtrigger.PredefinedBuildParameters' {
                                 properties("""
                                   PROJECT_NAME_TO_COPY_ARTIFACTS=\${JOB_NAME}
-                                  PACKAGE_ALIAS=\${PACKAGE_ALIAS}
+                                  PACKAGE_ALIAS=\${PACKAGE}
                                   S3_UPLOAD_PATH=${Globals.s3_releases_dir(package_name)}
                                   """.stripIndent())
                                 textParamValueOnNewLine('false')


### PR DESCRIPTION
The repository_uploader_packages job expects a `PACKAGE_ALIAS` variable, but the `*-source` jobs don't define `PACKAGE_ALIAS`, so use `PACKAGE` instead.

See https://build.osrfoundation.org/job/repository_uploader_packages/67019/ for example, which has a description of `${PACKAGE_ALIAS} 10.2.0-1(ubuntu/noble::)` (it should be gz-sim or gz-sim10)