### PR TITLE
gz_physics-compilation: set SKIP_mujoco for rotary, resolute

### DIFF
--- a/jenkins-scripts/docker/gz_physics-compilation.bash
+++ b/jenkins-scripts/docker/gz_physics-compilation.bash
@@ -29,4 +29,10 @@ fi
 
 export GZDEV_PROJECT_NAME="${GZDEV_PROJECT_NAME:-gz-physics${GZ_PHYSICS_MAJOR_VERSION}}"
 
+# set SKIP_mujoco=true for Rotary on 26.04
+# see https://github.com/gazebosim/gz-physics/pull/972
+if [[ "${GZDEV_PROJECT_NAME}" == "rotary" && "${DISTRO}" == "resolute" ]]; then
+  export BUILDING_EXTRA_CMAKE_PARAMS+=" -DSKIP_mujoco=true"
+fi
+
 . ${SCRIPT_DIR}/lib/generic-building-base.bash


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1485.

Copied logic from [gz_rendering-compilation.bash](https://github.com/gazebo-tooling/release-tools/blob/master/jenkins-scripts/docker/gz_rendering-compilation.bash#L33-L37).

### Currently fails to compile mujoco

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-resolute-amd64&build=2)](https://build.osrfoundation.org/job/gz_physics-ci-main-resolute-amd64/2/) https://build.osrfoundation.org/job/gz_physics-ci-main-resolute-amd64/2/

### Testing

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-main-resolute-amd64&build=3)](https://build.osrfoundation.org/job/gz_physics-ci-main-resolute-amd64/3/) https://build.osrfoundation.org/job/gz_physics-ci-main-resolute-amd64/3/