### PR TITLE
CI: enable macOS cmake warnings for several packages

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -568,16 +568,10 @@ ci_configs:
         - gz-rotary
     cmake_warnings_disabled:
       - gz-common
-      - gz-fuel-tools
       - gz-sim
-      - gz-gui
-      - gz-launch
       - gz-math
-      - gz-msgs
-      - gz-physics
       - gz-rendering
       - gz-sensors
-      - gz-tools
       - gz-transport
       - sdformat
     ci_categories_enabled:
@@ -600,16 +594,10 @@ ci_configs:
         - gz-rotary
     cmake_warnings_disabled:
       - gz-common
-      - gz-fuel-tools
       - gz-sim
-      - gz-gui
-      - gz-launch
       - gz-math
-      - gz-msgs
-      - gz-physics
       - gz-rendering
       - gz-sensors
-      - gz-tools
       - gz-transport
       - sdformat
     ci_categories_enabled:

--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -569,6 +569,7 @@ ci_configs:
     cmake_warnings_disabled:
       - gz-common
       - gz-sim
+      - gz-launch
       - gz-math
       - gz-rendering
       - gz-sensors
@@ -595,6 +596,7 @@ ci_configs:
     cmake_warnings_disabled:
       - gz-common
       - gz-sim
+      - gz-launch
       - gz-math
       - gz-rendering
       - gz-sensors

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -204,7 +204,7 @@ if brew ruby -e "exit ! '${PROJECT_FORMULA}'.f.recursive_dependencies.map(&:name
 fi
 
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.10 \
       -DCMAKE_INSTALL_PREFIX=${HOMEBREW_PREFIX}/Cellar/${PROJECT_FORMULA}/HEAD \
      ${CMAKE_ARGS} \
      ${WORKSPACE}/${PROJECT_PATH}


### PR DESCRIPTION
These packages have no cmake warnings on `main`, so enable checks.

Several of these packages have cmake warnings on Fortress due to old required minimum cmake version, so I increased `CMAKE_POLICY_VERSION_MINIMUM` in the macOS CI script to 3.10.

### Testing ign-tools1 without this branch

https://build.osrfoundation.org/job/gz_tools-ci-ign-tools1-homebrew-amd64/227/console#console-section-6

~~~
14:09:57 + cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/gz-tools1/HEAD /Users/jenkins/jenkins-agent/workspace/gz_tools-ci-ign-tools1-homebrew-amd64/gz-tools
14:09:58 CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
14:09:58   Compatibility with CMake < 3.10 will be removed from a future version of
14:09:58   CMake.
14:09:58 
14:09:58   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
14:09:58   to tell CMake that the project requires at least <min> but has been updated
14:09:58   to work with policies introduced by <max> or earlier.
14:09:58 
14:09:58 
14:09:59 -- The C compiler identification is AppleClang 16.0.0.16000026
14:10:00 -- The CXX compiler identification is AppleClang 16.0.0.16000026
~~~

### Testing ign-tools1 with this branch

https://build.osrfoundation.org/job/gz_tools-ci-ign-tools1-homebrew-amd64/228/console#console-section-6

~~~
14:26:08 + cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POLICY_VERSION_MINIMUM=3.10 -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/gz-tools1/HEAD /Users/jenkins/jenkins-agent/workspace/gz_tools-ci-ign-tools1-homebrew-amd64/gz-tools
14:26:09 -- The C compiler identification is AppleClang 16.0.0.16000026
14:26:09 -- The CXX compiler identification is AppleClang 16.0.0.16000026

~~~