### PR TITLE
Drop the notation unix:0 for DISPLAY (fix Resolute)

### DIFF
--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -50,7 +50,7 @@ fi
 
 if $USE_GPU_DOCKER; then
   EXTRA_PARAMS_STR="--privileged \
-                    -e DISPLAY=unix$DISPLAY \
+                    -e DISPLAY=$DISPLAY \
                     -v /sys:/sys:ro         \
                     -v /var/run/docker.sock:/var/run/docker.sock \
                     -v /tmp/.X11-unix:/tmp/.X11-unix:rw"


### PR DESCRIPTION
Fixes: #1499

Tested for resolute: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_gui-ci-main-resolute-amd64&build=8)](https://build.osrfoundation.org/job/gz_gui-ci-main-resolute-amd64/8/)

Tested for noble: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_display_gz_gui-ci-main-noble-amd64&build=2)](https://build.osrfoundation.org/job/_test_display_gz_gui-ci-main-noble-amd64/2/)