### PR TITLE
gz-physics: ignore cmake warnings on macOS

### DIFF
--- a/jenkins-scripts/dsl/gz-collections.yaml
+++ b/jenkins-scripts/dsl/gz-collections.yaml
@@ -571,6 +571,7 @@ ci_configs:
       - gz-sim
       - gz-launch
       - gz-math
+      - gz-physics
       - gz-rendering
       - gz-sensors
       - gz-transport
@@ -598,6 +599,7 @@ ci_configs:
       - gz-sim
       - gz-launch
       - gz-math
+      - gz-physics
       - gz-rendering
       - gz-sensors
       - gz-transport


### PR DESCRIPTION
Reverting one part of https://github.com/gazebo-tooling/release-tools/pull/1500, since there are cmake warnings from building the gz-physics examples, and it will require a change in gz-physics to resolve that.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_physics-ci-gz-physics7-homebrew-amd64&build=252)](https://build.osrfoundation.org/job/gz_physics-ci-gz-physics7-homebrew-amd64/252/) https://build.osrfoundation.org/job/gz_physics-ci-gz-physics7-homebrew-amd64/252/cmake/

~~~
147: [ RUN      ] ExamplesBuild.Build
147: Build directory: /private/var/folders/hg/xlxhphbn5dg13pfl_qxv0vc00000gp/T/0mrM5l
147: CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
147:   Compatibility with CMake < 3.10 will be removed from a future version of
147:   CMake.
147: 
147:   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
147:   to tell CMake that the project requires at least <min> but has been updated
147:   to work with policies introduced by <max> or earlier.
147: 
147: 
~~~