### PR TITLE
Use brew trust osrf/simulation in CI scripts

### DIFF
--- a/jenkins-scripts/lib/_homebrew_github_setup.bash
+++ b/jenkins-scripts/lib/_homebrew_github_setup.bash
@@ -57,6 +57,7 @@ brew config
 # tap osrf/simulation
 brew untap osrf/simulation || true
 brew tap osrf/simulation
+brew trust osrf/simulation
 TAP_PREFIX=$(brew --repo osrf/simulation)
 GIT="git -C ${TAP_PREFIX}"
 ${GIT} remote add pr_head ${PULL_REQUEST_HEAD_REPO}

--- a/jenkins-scripts/lib/homebrew_bottle_creation.bash
+++ b/jenkins-scripts/lib/homebrew_bottle_creation.bash
@@ -76,6 +76,7 @@ echo '# BEGIN SECTION: run test-bot'
 # git to keep the slave working
 export HOMEBREW_DEVELOPER=1
 brew tap osrf/simulation
+brew trust osrf/simulation
 # replace with 'hub -C $(brew --repo osrf/simulation) pr checkout ${ghprbPullId}'
 # after the following hub issue is resolved:
 # https://github.com/github/hub/issues/2612

--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -54,6 +54,7 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: setup the osrf/simulation tap'
 brew tap osrf/simulation
+brew trust osrf/simulation
 echo '# END SECTION'
 
 if [[ -n "${ghprbSourceBranch}" ]] && \

--- a/jenkins-scripts/lib/project-install-homebrew.bash
+++ b/jenkins-scripts/lib/project-install-homebrew.bash
@@ -42,6 +42,7 @@ echo '# END SECTION'
 
 echo '# BEGIN SECTION: setup the osrf/simulation tap'
 brew tap osrf/simulation
+brew trust osrf/simulation
 echo '# END SECTION'
 
 if python3 "${SCRIPT_DIR}/tools/detect_ci_matching_branch.py" "${RTOOLS_BRANCH}"


### PR DESCRIPTION
Homebrew's package descriptions (formulae) are implemented as executable ruby code, which can lead to security issues when using 3rd-party taps, so they have recently added a `brew trust` command to help mitigate security issues, [documented here](https://docs.brew.sh/Tap-Trust). It will soon be required to use `brew trust osrf/simulation` after `brew tap osrf/simulation` in order to run additional commands like `brew install gz-jetty`. I have added these commands to our CI scripts to fix `brew doctor` complaints in CI:

### Using release-tools `master` branch

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rotary_cmake-install_formula-homebrew-amd64&build=82)](https://build.osrfoundation.org/job/gz_rotary_cmake-install_formula-homebrew-amd64/82/) https://build.osrfoundation.org/job/gz_rotary_cmake-install_formula-homebrew-amd64/82/

~~~
11:12:34 + brew doctor
11:12:35 Please note that these warnings are just used to help the Homebrew maintainers
11:12:35 with debugging if you file an issue. If everything you use Homebrew for is
11:12:35 working fine: please don't worry or file an issue; just ignore this. Thanks!
11:12:35 
11:12:35 Warning: The following taps are not trusted:
11:12:35   osrf/simulation
11:12:35 
11:12:35 Homebrew will ignore formulae, casks and commands from these taps when `HOMEBREW_REQUIRE_TAP_TRUST` is set.
11:12:35 This will become the default in Homebrew 6.0.0 or 5.2.0, whichever comes first.
11:12:35 Enable trust checks now with:
11:12:35   export HOMEBREW_REQUIRE_TAP_TRUST=1
11:12:35 Trust specific formulae, casks or commands with:
11:12:35   brew trust --formula <user>/<tap>/<formula>
11:12:35   brew trust --cask <user>/<tap>/<cask>
11:12:35   brew trust --command <user>/<tap>/<command>
11:12:35 or trust installed formulae from these taps with:
11:12:35   brew trust --formula osrf/simulation/gz-rotary-cmake
11:12:35 You can trust all formulae, casks and commands from these taps with:
11:12:35   brew trust osrf/simulation
11:12:35 Prefer trusting only the specific formulae, casks or commands you need.
11:12:35 Untap them with:
11:12:35   brew untap osrf/simulation
11:12:35 To keep allowing them by default during the transition:
11:12:35   export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
11:12:35 This is not recommended and will be removed in a later release.
~~~

### Using this branch

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rotary_cmake-install_formula-homebrew-amd64&build=83)](https://build.osrfoundation.org/job/gz_rotary_cmake-install_formula-homebrew-amd64/83/) https://build.osrfoundation.org/job/gz_rotary_cmake-install_formula-homebrew-amd64/83/