### PR TITLE
brew CI: check RTOOLS_BRANCH for ci_matching_branch

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -56,13 +56,24 @@ echo '# BEGIN SECTION: setup the osrf/simulation tap'
 brew tap osrf/simulation
 echo '# END SECTION'
 
+# check if github pull request source branch starts with ci_matching_branch/
 if [[ -n "${ghprbSourceBranch}" ]] && \
    python3 ${SCRIPT_DIR}/tools/detect_ci_matching_branch.py "${ghprbSourceBranch}"
 then
-  echo "# BEGIN SECTION: trying to checkout branch ${ghprbSourceBranch} from osrf/simulation"
+  export CI_MATCHING_BRANCH=${ghprbSourceBranch}
+# otherwise check if release-tools branch starts with ci_matching_branch/
+elif [[ -n "${RTOOLS_BRANCH}" ]] && \
+   python3 ${SCRIPT_DIR}/tools/detect_ci_matching_branch.py "${RTOOLS_BRANCH}"
+then
+  export CI_MATCHING_BRANCH=${RTOOLS_BRANCH}
+fi
+
+if [[ -n "${CI_MATCHING_BRANCH}" ]]
+then
+  echo "# BEGIN SECTION: trying to checkout branch ${CI_MATCHING_BRANCH} from osrf/simulation"
   pushd $(brew --repo osrf/simulation)
-  git fetch origin ${ghprbSourceBranch} || true
-  git checkout ${ghprbSourceBranch} || true
+  git fetch origin ${CI_MATCHING_BRANCH} || true
+  git checkout ${CI_MATCHING_BRANCH} || true
   popd
   echo '# END SECTION'
 fi


### PR DESCRIPTION
We currently allow different branches of metadata repositories to be used in some cases when branches start with `ci_matching_branch/`, as documented in the [Gazebo CI docs page](https://gazebosim.org/docs/latest/ci/#testing-pull-requests-with-custom-tooling-branches). Currently macOS CI jobs only check the `ghprbSourceBranch` variable, which is to the source branch of a GitHub pull request. It is inconvenient to open an entire pull request just to trigger a CI build with custom metadata, so I've updated the logic to also check the `RTOOLS_BRANCH` for the `ci_matching_branch/` prefix, which can be set when starting stable branch CI jobs.

### example build results here

In order to test the effect of https://github.com/gazebosim/gz-sensors/pull/623 on gz-sim, I updated the gz-rotary-sensors formula to use the PR branch in https://github.com/osrf/homebrew-simulation/commit/856ded171fa2e1498a9a615931ed08fc6cf33e67 and created a gz-sim branch from `main` with matching name, made a dummy change to the readme, opened a draft PR https://github.com/gazebosim/gz-sim/pull/3664, and the homebrew CI job triggered for that PR used the specified branch of gz-sensors

With the approach in this branch, it is much simpler, as I was able to trigger a [gz_sim-ci-main-homebrew-arm64](https://build.osrfoundation.org/job/gz_sim-ci-main-homebrew-arm64) branch using the release-tools branch from this PR, without pushing a dummy change to gz-sim or opening a dummy PR:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_sim-ci-main-homebrew-arm64&build=113)](https://build.osrfoundation.org/job/gz_sim-ci-main-homebrew-arm64/113/) https://build.osrfoundation.org/job/gz_sim-ci-main-homebrew-arm64/113/

~~~
18:29:49 + [[ -n '' ]]
18:29:49 + [[ -n ci_matching_branch/brew_rtools_ci_matching_branch ]]
18:29:49 + python3 ./scripts/jenkins-scripts/tools/detect_ci_matching_branch.py ci_matching_branch/brew_rtools_ci_matching_branch
18:29:49 ci_matching_branch/brew_rtools_ci_matching_branch matches ci_matching_branch/
18:29:49 + export CI_MATCHING_BRANCH=ci_matching_branch/brew_rtools_ci_matching_branch
18:29:49 + CI_MATCHING_BRANCH=ci_matching_branch/brew_rtools_ci_matching_branch
18:29:49 + [[ -n ci_matching_branch/brew_rtools_ci_matching_branch ]]
18:29:49 + echo '# BEGIN SECTION: trying to checkout branch ci_matching_branch/brew_rtools_ci_matching_branch from osrf/simulation'
 trying to checkout branch ci_matching_branch/brew_rtools_ci_matching_branch from osrf/simulation
18:29:49 # BEGIN SECTION: trying to checkout branch ci_matching_branch/brew_rtools_ci_matching_branch from osrf/simulation
18:29:49 ++ brew --repo osrf/simulation
18:29:49 + pushd /opt/homebrew/Library/Taps/osrf/homebrew-simulation
18:29:49 /opt/homebrew/Library/Taps/osrf/homebrew-simulation ~/jenkins-agent/workspace/gz_sim-ci-main-homebrew-arm64
18:29:49 + git fetch origin ci_matching_branch/brew_rtools_ci_matching_branch
18:29:50 From https://github.com/osrf/homebrew-simulation
18:29:50  * branch              ci_matching_branch/brew_rtools_ci_matching_branch -> FETCH_HEAD
18:29:50 + git checkout ci_matching_branch/brew_rtools_ci_matching_branch
18:29:50 Switched to a new branch 'ci_matching_branch/brew_rtools_ci_matching_branch'
18:29:50 branch 'ci_matching_branch/brew_rtools_ci_matching_branch' set up to track 'origin/ci_matching_branch/brew_rtools_ci_matching_branch'.
18:29:50 + popd
~~~

### TODO link to gazebosim/docs update PR