### PR TITLE
dsl: remove unused PULL_REQUEST_URL brew param

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBrewCompilation.groovy
@@ -20,12 +20,6 @@ class OSRFBrewCompilation extends OSRFOsXBase
 
     job.with
     {
-      parameters
-      {
-        stringParam("PULL_REQUEST_URL", '',
-                    'Pull request URL (osrf/homebrew-simulation) pointing to a pull request.')
-      }
-
       publishers
       {
         configure { project ->


### PR DESCRIPTION
This parameter is added to all brew compilation jobs but is unused. It has not been used since https://github.com/gazebo-tooling/release-tools/pull/575, and we discussed removing the param in https://github.com/gazebo-tooling/release-tools/pull/575#discussion_r758599949. I was against removing it at the time, though I can't remember why since the `PULL_REQUEST_URL` parameter is [independently defined](https://github.com/gazebo-tooling/release-tools/blob/a0d35164439648791330664658ff1bbf0335441e/jenkins-scripts/dsl/brew_release.dsl#L270) in the other job where it is used. Steve today thinks it's safe to remove.