### PR TITLE
Support trusted param in validate_brewfile

### DIFF
--- a/jenkins-scripts/lib/_homebrew_brewfiles.bash
+++ b/jenkins-scripts/lib/_homebrew_brewfiles.bash
@@ -19,7 +19,8 @@ validate_brew_bundle_repo() {
 
   if [[ ! -f ${whitelist_file} ]]; then
     # Not found whitelist file
-    echo ""
+    echo "ERROR: homebrew whitelist file not found: ${whitelist_file}" >&2
+    return 1
   fi
 
   IFS=$'\n' repos=($(cat ${whitelist_file}))
@@ -48,7 +49,7 @@ validate_brewfile() {
     # Check to make sure the brew command is allowed
     local brew_cmd=$(validate_brew_bundle_cmd ${tokens[0]})
     if [[ ${brew_cmd} == "" ]]; then
-      echo "brew bundle command not allowed: ${brew_cmd}"
+      echo "brew bundle command not allowed: ${tokens[0]}"
       return 1
     fi
     # The token that follows the brew command may contain the repo name
@@ -69,7 +70,7 @@ validate_brewfile() {
     if [[ ${brew_cmd} == "tap" ]]; then
       validated_repo=$(validate_brew_bundle_repo ${repo})
     else
-      if [[ ${repo} == "*/*" ]]; then
+      if [[ ${repo} == */* ]]; then
         repo="${repo%/*}"
         validated_repo=$(validate_brew_bundle_repo ${repo})
       else

--- a/jenkins-scripts/lib/_homebrew_brewfiles.bash
+++ b/jenkins-scripts/lib/_homebrew_brewfiles.bash
@@ -65,16 +65,16 @@ validate_brewfile() {
     #   brew "org/repo/package", trusted: true
     # Remove `"` and `,` from the second token and check to make sure the
     # homebrew repo is allowed if specified
-    repo=$(echo "${tokens[1]}" | tr -d '",')
+    resource=$(echo "${tokens[1]}" | tr -d '",')
     validated_repo=""
     if [[ ${brew_cmd} == "tap" ]]; then
-      validated_repo=$(validate_brew_bundle_repo ${repo})
+      validated_repo=$(validate_brew_bundle_repo ${resource})
     else
-      if [[ ${repo} == */* ]]; then
-        repo="${repo%/*}"
+      if [[ ${resource} == */*/* ]]; then
+        repo="${resource%/*}"
         validated_repo=$(validate_brew_bundle_repo ${repo})
       else
-        validated_repo=${repo}
+        validated_repo=${resource}
       fi
     fi
     if [[ ${validated_repo} == "" ]]; then

--- a/jenkins-scripts/lib/_homebrew_brewfiles.bash
+++ b/jenkins-scripts/lib/_homebrew_brewfiles.bash
@@ -40,50 +40,47 @@ validate_brewfile() {
   for i in $(seq ${#lines[*]}); do
     line=${lines[$i-1]}
     IFS=$' ' tokens=($line)
-    checked_cmd=false
-    for j in "${tokens[@]}"; do
-       token=${j}
-       # A token that starts with # is a comment. Ignore the rest of the line.
-       if [[ "${token}" == \#* ]]; then
-         break
-       fi
-       # The first token in a line should be a brew command
-       # Check to make sure the brew command is allowed
-       if [[ $checked_cmd == false ]]; then
-         local brew_cmd=$(validate_brew_bundle_cmd ${token})
-         if [[ ${brew_cmd} == "" ]]; then
-           echo "brew bundle command not allowed: ${brew_cmd}"
-           return 1
-         fi
-         checked_cmd=true
-       else
-         # The token that follows the brew command may contain the repo name
-         # e.g.
-         #   tap org/repo
-         #   brew org/repo/package
-         # homebrew-core packages do not have repo name in them
-         # e.g.
-         #   brew package
-         # Remove quotes and check to make sure the homebrew repo is allowed
-         # if specified
-         repo=`echo "${token}" | cut -d'"' -f 2`
-         validated_repo=""
-         if [[ ${brew_cmd} == "tap" ]]; then
-           validated_repo=$(validate_brew_bundle_repo ${repo})
-         else
-           if [[ ${repo} == "*/*" ]]; then
-             repo="${token%/*}"
-             validated_repo=$(validate_brew_bundle_repo ${repo})
-           else
-             validated_repo=${repo}
-           fi
-         fi
-         if [[ ${validated_repo} == "" ]]; then
-           echo "homebrew repo not allowed: ${repo}"
-           return 1
-         fi
-       fi
-    done
+    # A first token that starts with # is a comment. Ignore the rest of the line.
+    if [[ "${tokens[0]}" == \#* ]]; then
+      break
+    fi
+    # The first token in a line should be a brew command
+    # Check to make sure the brew command is allowed
+    local brew_cmd=$(validate_brew_bundle_cmd ${tokens[0]})
+    if [[ ${brew_cmd} == "" ]]; then
+      echo "brew bundle command not allowed: ${brew_cmd}"
+      return 1
+    fi
+    # The token that follows the brew command may contain the repo name
+    # e.g.
+    #   tap "org/repo"
+    #   brew "org/repo/package"
+    # homebrew-core packages do not have repo name in them
+    # e.g.
+    #   brew "package"
+    # 3rd-party taps and formulae may also specified as trusted
+    # e.g.
+    #   tap "org/repo", trusted: true
+    #   brew "org/repo/package", trusted: true
+    # Remove `"` and `,` from the second token and check to make sure the
+    # homebrew repo is allowed if specified
+    repo=$(echo "${tokens[1]}" | tr -d '",')
+    validated_repo=""
+    if [[ ${brew_cmd} == "tap" ]]; then
+      validated_repo=$(validate_brew_bundle_repo ${repo})
+    else
+      if [[ ${repo} == "*/*" ]]; then
+        repo="${token%/*}"
+        validated_repo=$(validate_brew_bundle_repo ${repo})
+      else
+        validated_repo=${repo}
+      fi
+    fi
+    if [[ ${validated_repo} == "" ]]; then
+      echo "homebrew repo not allowed: ${repo}"
+      return 1
+    fi
+    # ignore any additional tokens
   done
 
   return 0

--- a/jenkins-scripts/lib/_homebrew_brewfiles.bash
+++ b/jenkins-scripts/lib/_homebrew_brewfiles.bash
@@ -42,7 +42,7 @@ validate_brewfile() {
     IFS=$' ' tokens=($line)
     # A first token that starts with # is a comment. Ignore the rest of the line.
     if [[ "${tokens[0]}" == \#* ]]; then
-      break
+      continue
     fi
     # The first token in a line should be a brew command
     # Check to make sure the brew command is allowed
@@ -70,7 +70,7 @@ validate_brewfile() {
       validated_repo=$(validate_brew_bundle_repo ${repo})
     else
       if [[ ${repo} == "*/*" ]]; then
-        repo="${token%/*}"
+        repo="${repo%/*}"
         validated_repo=$(validate_brew_bundle_repo ${repo})
       else
         validated_repo=${repo}

--- a/jenkins-scripts/lib/_homebrew_brewfiles.bash
+++ b/jenkins-scripts/lib/_homebrew_brewfiles.bash
@@ -58,7 +58,7 @@ validate_brewfile() {
     # homebrew-core packages do not have repo name in them
     # e.g.
     #   brew "package"
-    # 3rd-party taps and formulae may also specified as trusted
+    # 3rd-party taps and formulae may also be specified as trusted
     # e.g.
     #   tap "org/repo", trusted: true
     #   brew "org/repo/package", trusted: true


### PR DESCRIPTION
This refactors `validate_brewfile` to support the `trusted` parameter:

* Check the first token as the command and the contents of the second token for its presence in the repo whitelist. Ignore remaining tokens on the line
* Strip `,` characters in addition to `"` from second token.

Please visualize the [diff without whitespace](https://github.com/gazebo-tooling/release-tools/pull/1511/changes?w=1) for easier review.

gz-transport brew CI is currently broken

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-main-homebrew-arm64&build=82)](https://build.osrfoundation.org/job/gz_transport-ci-main-homebrew-arm64/82/) https://build.osrfoundation.org/job/gz_transport-ci-main-homebrew-arm64/82/

This change is needed in conjunction with https://github.com/gazebosim/gz-transport/pull/881

* testing both https://github.com/gazebosim/gz-transport/pull/881 and this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-pr_any-homebrew-arm64&build=309)](https://build.osrfoundation.org/job/gz_transport-ci-pr_any-homebrew-arm64/309/) https://build.osrfoundation.org/job/gz_transport-ci-pr_any-homebrew-arm64/309/