### PR TITLE
Replace ignition with gz in nightly-scheduler job

### DIFF
--- a/jenkins-scripts/dsl/ignition_collection.dsl
+++ b/jenkins-scripts/dsl/ignition_collection.dsl
@@ -150,7 +150,7 @@ gz_collections_yaml.collections.each { collection ->
 nightly_collection = gz_collections_yaml.collections
   .find { it.name == gz_nightly }
 
-def nightly_scheduler_job = job("ignition-${gz_nightly}-nightly-scheduler")
+def nightly_scheduler_job = job("gz-${gz_nightly}-nightly-scheduler")
 OSRFUNIXBase.create(nightly_scheduler_job)
 OSRFCredentials.setOSRFCrendentials(nightly_scheduler_job, ['OSRFBUILD_JENKINS_TOKEN'])
 


### PR DESCRIPTION
Current job:

* https://build.osrfoundation.org/job/ignition-rotary-nightly-scheduler/

I think it only needs to be renamed in one place.