### PR TITLE
Add a default timeout for all jobs

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFBase.groovy
@@ -45,6 +45,11 @@ class OSRFBase
 
         wrappers {
           timestamps()
+
+          // Default timeout for all jobs
+          timeout {
+            absolute(360)
+          }
         }
 
         // Create the naginator retry tags

--- a/jenkins-scripts/dsl/gazebo_libs.dsl
+++ b/jenkins-scripts/dsl/gazebo_libs.dsl
@@ -160,10 +160,8 @@ void add_brew_shell_build_step(gz_brew_ci_job, lib_name, ws_checkout_dir)
   lib_name = lib_name.replaceAll(/^ign-/, 'ignition-')
   gz_brew_ci_job.with
   {
-    wrappers {
-      timeout {
-        absolute(120)
-      }
+    configure { project ->
+      project / 'buildWrappers' / 'hudson.plugins.build__timeout.BuildTimeoutWrapper' / 'strategy' / 'timeoutMinutes' (120)
     }
 
     steps {
@@ -294,10 +292,8 @@ String generate_brew_install(src_name, lib_name, arch, gzdev_project = '')
 
   install_default_job.with
   {
-    wrappers {
-      timeout {
-        absolute(120)
-      }
+    configure { project ->
+      project / 'buildWrappers' / 'hudson.plugins.build__timeout.BuildTimeoutWrapper' / 'strategy' / 'timeoutMinutes' (120)
     }
 
     triggers {


### PR DESCRIPTION
I've seen different kind of jobs hung in the buildfarm for a long time

This PR sets a default timeout for all jobs