### PR TITLE
Add a Mujoco debbuilder for gazebo-forks

### DIFF
--- a/jenkins-scripts/dsl/extra.dsl
+++ b/jenkins-scripts/dsl/extra.dsl
@@ -12,7 +12,8 @@ release_repo_debbuilds = [ 'opensplice' ]
 gbp_repo_debbuilds = [ 'lark-parser',
                        'ogre-2.1',
                        'ogre-2.2',
-                       'ogre-2.3']
+                       'ogre-2.3',
+                       'mujoco']
 
 release_repo_debbuilds.each { software ->
   // --------------------------------------------------------------


### PR DESCRIPTION
The Mujoco release repository https://github.com/gazebo-forks/mujoco-release is a gbp like repository similar to ogre-2.3 and others that we used before. Adding it here to the list of generated repositories in extra.dsl to have the Jenkins job in place.