### PR TITLE
arm: use official Ubuntu images instead of osrf custom ones

### DIFF
--- a/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
+++ b/jenkins-scripts/docker/lib/docker_generate_dockerfile.bash
@@ -118,15 +118,8 @@ case ${ARCH} in
        FROM_VALUE=${ARCH}/${LINUX_DISTRO}:${DISTRO}
      fi
      ;;
-   'armhf')
-     if [[ ${DISTRO} == 'focal' ]]; then
-      FROM_VALUE=osrf/${LINUX_DISTRO}_${ARCH}:${DISTRO}
-     else
-      FROM_VALUE=${LINUX_DISTRO}:${DISTRO}
-     fi
-     ;;
-  'arm64')
-     FROM_VALUE=osrf/${LINUX_DISTRO}_${ARCH}:${DISTRO}
+  'armhf' | 'arm64')
+     FROM_VALUE=${LINUX_DISTRO}:${DISTRO}
      ;;
   *)
      echo "Arch unknown"

--- a/jenkins-scripts/docker/lib/docker_run.bash
+++ b/jenkins-scripts/docker/lib/docker_run.bash
@@ -26,9 +26,8 @@ USER=$(whoami)
 # platform support starts on versions greater than 17.07
 PLAFTORM_PARAM=
 if [[ ${LINUX_DISTRO} == 'ubuntu' && \
-      ${DISTRO} != 'focal' && \
-      ${ARCH} == 'armhf' ]]; then
-  PLAFTORM_PARAM="--platform=linux/armhf"
+      ( ${ARCH} == 'armhf' || ${ARCH} == 'arm64' ) ]]; then
+  PLAFTORM_PARAM="--platform=linux/${ARCH}"
 fi
 
 sudo docker build ${PLAFTORM_PARAM} ${_DOCKER_BUILD_EXTRA_ARGS} \


### PR DESCRIPTION
The arm64 debbuilder was pinned to the manually-maintained osrf/ubuntu_arm64:${DISTRO} base images, built and pushed to Docker Hub by hand. The custom images were a 2016 workaround from before Docker offered native multi-arch base images and cross-arch emulation. armhf was already migrated off them (#647, #1135) using the official ubuntu:${DISTRO} image plus --platform.

Since Focal is EOL and no longer built, so its remaining osrf/ special case for armhf is dead code. Drop it and handle both arm arches with a single check.

Nowadays we are building images on native platforms so we can probably drop the platform argument for arm but I think that it does no hurt and it is robust if we decide to change to emulation at some point.

Assisted-By: Opus 4.8