### PR TITLE
Fix NVML mismatch recovery detection

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -43,7 +43,7 @@ class OSRFUNIXBase extends OSRFBase
         // Add the new regex to naginator tag
         // There is no need to specify checkRegexp and maxSchedule because they are the default values
         HelperRetryFailures.create(job, [
-          regexpForRerun: "nvml error: driver/library version mismatch",
+          regexpForRerun: "(?i)driver/library version mismatch",
           delay: 70
         ])
       }
@@ -76,7 +76,7 @@ def node = build.getBuiltOn()
 def old_labels = node.getLabelString()
 
 println("Checking if nvidia mismatch error is present in log")
-if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
+if (!(build.getLog(1000) =~ "(?i)driver/library version mismatch")) {
 println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any automatic recovery steps")
 return 1;
 } else {


### PR DESCRIPTION
## Summary

- Match the stable NVML `driver/library version mismatch` diagnostic
  independently of runtime prefix and capitalization.
- Keep the Naginator retry expression and post-build recovery guard aligned.

## Root cause

The recovery logic expected the older, case-sensitive message:

`nvml error: driver/library version mismatch`

The NVIDIA container runtime now reports:

`failed to initialize NVML: Driver/library version mismatch`

As a result, affected GPU jobs failed before container startup and the
post-build script incorrectly skipped automatic recovery:

- https://build.osrfoundation.org/job/gz_rendering-ci-pr_any-resolute-amd64/2/
- https://build.osrfoundation.org/job/gz_sensors-ci-pr_any-resolute-amd64/4/

## Validation

- Generated all Jenkins DSL XML with OpenJDK 17.
- Ran `jenkins-scripts/dsl/dsl_checks.bash`.
- Ran `jenkins-scripts/docker/sanity_checks.bash`.
- Confirmed the generated `_test_job_from_dsl.xml` uses the updated expression
  in both Naginator and the post-build Groovy guard.
- Confirmed with Java regular expressions that the old expression misses the
  reported runtime message while the updated expression matches both the old
  and reported forms.

The remaining integration check is to run the safe `_dsl_test` Jenkins fixture
with the reported message and verify retry, recovery relabeling, and reboot
behavior.
