### PR TITLE
dsl: detect the current NVIDIA driver/library mismatch message

### DIFF
--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -30,6 +30,25 @@ class Globals
    // constant will result in (osx && osx)
    static OSX_ANY_ARCHITECTURE = 'osx'
 
+   // Matches the NVML failure that appears when the nvidia userspace libraries
+   // were upgraded while the previously loaded nvidia.ko is still in memory.
+   // The wording depends on the nvidia-container-toolkit version, so match the
+   // stable part of it:
+   //   - libnvidia-container / nvidia-container-cli (legacy):
+   //       nvidia-container-cli: initialization error:
+   //       nvml error: driver/library version mismatch
+   //   - nvidia-container-toolkit >= 1.17 (CDI "auto" mode, go-nvml):
+   //       failed to initialize NVML: Driver/library version mismatch
+   //   - nvidia-smi on the agent (see jenkins-scripts/lib/check_graphic_card.bash):
+   //       Failed to initialize NVML: Driver/library version mismatch
+   // Keep 'nvml' in the expression: matching the bare 'driver/library version
+   // mismatch' would let a test log trigger a node reboot.
+   // The case-insensitive flag is scoped with (?i:...) instead of a leading
+   // (?i) because this value is appended to an alternation of other retry
+   // regexes (see HelperRetryFailures), and a bare flag would leak into any
+   // expression added after this one.
+   static NVIDIA_MISMATCH_LOG_REGEX = '(?i:nvml.*driver/library version mismatch)'
+
    static gpu_by_distro  = [ bionic  : [ 'nvidia' ]]
 
    static ros_ci = [ 'noetic'   : ['focal'] ,

--- a/jenkins-scripts/dsl/_configs_/Globals.groovy
+++ b/jenkins-scripts/dsl/_configs_/Globals.groovy
@@ -39,8 +39,8 @@ class Globals
    //       nvml error: driver/library version mismatch
    //   - nvidia-container-toolkit >= 1.17 (CDI "auto" mode, go-nvml):
    //       failed to initialize NVML: Driver/library version mismatch
-   //   - nvidia-smi on the agent (see jenkins-scripts/lib/check_graphic_card.bash):
-   //       Failed to initialize NVML: Driver/library version mismatch
+   //   - nvidia-smi on the agent
+   //       if sometime in the future is used 
    // Keep 'nvml' in the expression: matching the bare 'driver/library version
    // mismatch' would let a test log trigger a node reboot.
    // The case-insensitive flag is scoped with (?i:...) instead of a leading

--- a/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFUNIXBase.groovy
@@ -43,7 +43,7 @@ class OSRFUNIXBase extends OSRFBase
         // Add the new regex to naginator tag
         // There is no need to specify checkRegexp and maxSchedule because they are the default values
         HelperRetryFailures.create(job, [
-          regexpForRerun: "nvml error: driver/library version mismatch",
+          regexpForRerun: Globals.NVIDIA_MISMATCH_LOG_REGEX,
           delay: 70
         ])
       }
@@ -76,7 +76,7 @@ def node = build.getBuiltOn()
 def old_labels = node.getLabelString()
 
 println("Checking if nvidia mismatch error is present in log")
-if (!(build.getLog(1000) =~ "nvml error: driver/library version mismatch")) {
+if (!(build.getLog(1000) =~ "''' + Globals.NVIDIA_MISMATCH_LOG_REGEX + '''")) {
 println(" NVIDIA driver/library version mismatch not detected in the log - Not performing any automatic recovery steps")
 return 1;
 } else {


### PR DESCRIPTION
Alternative to #1522 

The recovery regex was written in 2023 against the message printed by libnvidia-container / nvidia-container-cli:

```
  nvidia-container-cli: initialization error:
  nvml error: driver/library version mismatch
```

The agents now run nvidia-container-toolkit 1.19.1, whose CDI "auto" path is Go code using go-nvml and reports instead:
```
  failed to initialize NVML: Driver/library version mismatch
```

Different prefix and different capitalization, so neither the naginator rerun nor the post-build recovery matched. A node in that state was left in the pool failing every GPU job it picked up, e.g. https://build.osrfoundation.org/job/gz_sim-ci-pr_any-noble-amd64/2521/

Match on the stable part of both wordings and keep the expression in a single Globals constant, since the value has to stay in sync between the naginator publisher and the embedded recovery script.

Assisted-By: Claude Opus 5