### PR TITLE
Use RELEASE_VERSION param in _releasepy

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
@@ -76,6 +76,7 @@ class OSRFReleasepy
             echo "releasing \${n} (from branch \${src_branch})"
               python3 ./scripts/release.py \${dry_run_str} "\${PACKAGE}" "\${VERSION}" \${extra_osrf_repo} \
                       --auth "\${OSRFBUILD_JENKINS_USER}:\${OSRFBUILD_JENKINS_TOKEN}" \
+                      --release-version \${RELEASE_VERSION} \
                       --source-tarball-uri \${SOURCE_TARBALL_URI} \
                       --source-tarball-sha256 \${SOURCE_TARBALL_SHA256} \
                       --release-repo-branch \${RELEASE_REPO_BRANCH} \


### PR DESCRIPTION
Pass the `RELEASE_VERSION` param with `--release-version` since it is currently unused in the [_releasepy](https://build.osrfoundation.org/job/_releasepy) job.

I noticed this while trying to trigger gz-math 9.2.0-2 debbuilds:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_releasepy&build=364)](https://build.osrfoundation.org/job/_releasepy/364/) https://build.osrfoundation.org/job/_releasepy/364/

Repeating the failure with the same parameters in [_test_releasepy](https://build.osrfoundation.org/job/_test_releasepy):

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_releasepy&build=66)](https://build.osrfoundation.org/job/_test_releasepy/66/) https://build.osrfoundation.org/job/_test_releasepy/66/

~~~
17:15:23  !! Error in package release version. Expected 1 in line (9.2.0-2~noble)
~~~

Deploying from this branch and then testing again with [_test_releasepy](https://build.osrfoundation.org/job/_test_releasepy):

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_test&build=336)](https://build.osrfoundation.org/job/_dsl_test/336/) https://build.osrfoundation.org/job/_dsl_test/336/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_releasepy&build=67)](https://build.osrfoundation.org/job/_test_releasepy/67/) https://build.osrfoundation.org/job/_test_releasepy/67/