### PR TITLE
OSRFReleasepy: add flag for --only-bump-revision-linux

### DIFF
--- a/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
+++ b/jenkins-scripts/dsl/_configs_/OSRFReleasepy.groovy
@@ -26,6 +26,9 @@ class OSRFReleasepy
         stringParam("RELEASE_VERSION",
                     default_params.find{ it.key == "RELEASE_VERSION"}?.value,
                     "Packages release version")
+        booleanParam('ONLY_BUMP_REVISION_LINUX',
+                    default_params.find{ it.key == "ONLY_BUMP_REVISION_LINUX"}?.value,
+                    'Only trigger Linux debbuild jobs with bumped revision number. Do not upload new tarball or open homebrew pull request.')
         stringParam("SOURCE_TARBALL_URI",
                     default_params.find{ it.key == "SOURCE_TARBALL_URI"}?.value,
                     "URL to the tarball containing the package sources")
@@ -68,6 +71,11 @@ class OSRFReleasepy
               dry_run_str="--dry-run"
             fi
 
+            only_bump_revision_linux_str=""
+            if \$ONLY_BUMP_REVISION_LINUX; then
+              only_bump_revision_linux_str="--only-bump-revision-linux"
+            fi
+
             extra_osrf_repo=""
             if [[ -n \${EXTRA_OSRF_REPO} ]]; then
               extra_osrf_repo="--extra-osrf-repo \${EXTRA_OSRF_REPO}"
@@ -75,6 +83,7 @@ class OSRFReleasepy
 
             echo "releasing \${n} (from branch \${src_branch})"
               python3 ./scripts/release.py \${dry_run_str} "\${PACKAGE}" "\${VERSION}" \${extra_osrf_repo} \
+                      \${only_bump_revision_linux_str} \
                       --auth "\${OSRFBUILD_JENKINS_USER}:\${OSRFBUILD_JENKINS_TOKEN}" \
                       --source-tarball-uri \${SOURCE_TARBALL_URI} \
                       --source-tarball-sha256 \${SOURCE_TARBALL_SHA256} \

--- a/jenkins-scripts/dsl/core.dsl
+++ b/jenkins-scripts/dsl/core.dsl
@@ -117,7 +117,7 @@ outdated_job_runner.with
 
 // -------------------------------------------------------------------
 def releasepy_job = job("_releasepy")
-OSRFReleasepy.create(releasepy_job, [DRY_RUN: false])
+OSRFReleasepy.create(releasepy_job, [DRY_RUN: false, ONLY_BUMP_REVISION_LINUX: false])
 releasepy_job.with {
       blockOn("repository_uploader_packages") {
         blockLevel('GLOBAL')

--- a/jenkins-scripts/dsl/test.dsl
+++ b/jenkins-scripts/dsl/test.dsl
@@ -21,7 +21,7 @@ OSRFLinuxCompilationAnyGitHub.create(ignition_ci_pr_job,
 
 // releasing testing job
 def releasepy_job = job("_test_releasepy")
-OSRFReleasepy.create(releasepy_job, [DRY_RUN: true])
+OSRFReleasepy.create(releasepy_job, [DRY_RUN: true, ONLY_BUMP_REVISION_LINUX: false])
 releasepy_job.with {
       blockOn("_test_repository_uploader") {
         blockLevel('GLOBAL')


### PR DESCRIPTION
Follow-up to #1527.

I started https://build.osrfoundation.org/job/_releasepy/367 run debbuild jobs with an incremented `RELEASE_VERSION`, but this also executed [generic-release-homebrew_pull_request_updater](https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/1820/) and opened an undesired homebrew-simulation PR:

* https://github.com/osrf/homebrew-simulation/pull/3507

This PR adds an additional jenkins job parameter to `_releaspy` that maps to the `--only-bump-revision-linux` argument in `release.py`, which will avoid opening unneeded homebrew-simulation PRs.

## Testing

* Deploy from this branch [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_dsl_test&build=339)](https://build.osrfoundation.org/job/_dsl_test/339/) https://build.osrfoundation.org/job/_dsl_test/339/
* Invoke [_test_releasepy](https://build.osrfoundation.org/job/_test_releasepy/) with same parameters as https://build.osrfoundation.org/job/_releasepy/367:
    * `ONLY_BUMP_REVISION_LINUX` disabled causes homebrew_pull_request_updater job to be invoked: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_releasepy&build=68)](https://build.osrfoundation.org/job/_test_releasepy/68/) https://build.osrfoundation.org/job/_test_releasepy/68/

~~~
13:30:49 Simulation of jobs to be called if not dry-run:
13:30:49  + Releasing Brew in https://build.osrfoundation.org//job/generic-release-homebrew_pull_request_updater?search=gz-plugin4-4.0.0
13:30:49  + Releasing ubuntu noble/amd64 in https://build.osrfoundation.org//job/gz-plugin4-debbuilder?search=4.0.0-2
13:30:49  + Releasing ubuntu noble/armhf in https://build.osrfoundation.org//job/gz-plugin4-debbuilder?search=4.0.0-2
13:30:49  + Releasing ubuntu noble/arm64 in https://build.osrfoundation.org//job/gz-plugin4-debbuilder?search=4.0.0-2
~~~

*
    * `ONLY_BUMP_REVISION_LINUX` enabled prevents homebrew_pull_request_updater job: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=_test_releasepy&build=69)](https://build.osrfoundation.org/job/_test_releasepy/69/) https://build.osrfoundation.org/job/_test_releasepy/69/

~~~
13:31:06 Simulation of jobs to be called if not dry-run:
13:31:06  + Releasing ubuntu noble/amd64 in https://build.osrfoundation.org//job/gz-plugin4-debbuilder?search=4.0.0-2
13:31:06  + Releasing ubuntu noble/armhf in https://build.osrfoundation.org//job/gz-plugin4-debbuilder?search=4.0.0-2
13:31:06  + Releasing ubuntu noble/arm64 in https://build.osrfoundation.org//job/gz-plugin4-debbuilder?search=4.0.0-2
~~~