### PR TITLE
disable brew bundle to mitigate zenoh issue

### DIFF
--- a/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
+++ b/jenkins-scripts/lib/project-default-devel-homebrew-amd64.bash
@@ -141,9 +141,12 @@ if [[ -n "${SOURCE_DEFINED_BREWFILES}" ]]; then
       echo "Error validating ${brewfile}"
       exit 1
     fi
-    # Validation passed, run brew bundle
-    echo "Running 'brew bundle --file ${brewfile} --verbose'"
-    brew bundle --file ${brewfile} --verbose
+    # Disable brew bundle until zenoh dependencies are fixed
+    # https://github.com/gazebosim/gz-transport/issues/927
+    # uncomment the following lines when this issue is resolved
+    # # Validation passed, run brew bundle
+    # echo "Running 'brew bundle --file ${brewfile} --verbose'"
+    # brew bundle --file ${brewfile} --verbose
   done
 else
   echo "No brewfiles found. Skipping brew bundle install"


### PR DESCRIPTION
Mitigation for https://github.com/gazebosim/gz-transport/issues/927. Merge if upstream https://github.com/eclipse-zenoh/homebrew-zenoh/issues/21 is not resolved soon and we want to fix gz-transport CI.

## without this branch:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-gz-transport15-homebrew-arm64&build=100)](https://build.osrfoundation.org/job/gz_transport-ci-gz-transport15-homebrew-arm64/100/) https://build.osrfoundation.org/job/gz_transport-ci-gz-transport15-homebrew-arm64/100/

## with this branch:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-gz-transport15-homebrew-arm64&build=101)](https://build.osrfoundation.org/job/gz_transport-ci-gz-transport15-homebrew-arm64/101/) https://build.osrfoundation.org/job/gz_transport-ci-gz-transport15-homebrew-arm64/101/